### PR TITLE
Improve git completions by showing branches and commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ zplug "chitoku-k/fzf-zsh-completions"
 
 - git
   - add
-    - Shows the files
+    - Shows the unstaged files
   - branch
     - Shows the commits/branches
   - checkout

--- a/README.md
+++ b/README.md
@@ -28,15 +28,21 @@ zplug "chitoku-k/fzf-zsh-completions"
   - add
     - Shows the files
   - branch
-    - Shows the branches
+    - Shows the commits/branches
   - checkout
-    - Shows the branches
+    - Shows the commits/branches
+  - cherry-pick
+    - Shows the commits/branches
   - commit
-    - Shows the commit messages, or the commits if preceded by `--fixup`
+    - Shows the commit messages, or the commits/branches if preceded by `--fixup`
+  - log
+    - Shows the commits/branches
+  - merge
+    - Shows the commits/branches
   - rebase
-    - Shows the commits
+    - Shows the commits/branches
   - reset
-    - Shows the commits
+    - Shows the commits/branches
 - npm
   - run
     - Shows the scripts

--- a/git.zsh
+++ b/git.zsh
@@ -1,47 +1,88 @@
 #!/usr/bin/env zsh
 
+_fzf_complete_awk_functions='
+    function colorize_git_status(color1, color2, reset) {
+        index_status = substr($0, 1, 1)
+        work_tree_status = substr($0, 2, 1)
+        if (index_status ~ /[MADRC]/) {
+            index_status_color = color1
+        }
+        if (index_status work_tree_status ~ /(D[DU]|A[AU])|U.|\?\?|!!/) {
+            index_status_color = color2
+        }
+        if (work_tree_status ~ /[MADRCU\?!]/) {
+            work_tree_status_color = color2
+        }
+
+        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, substr($0, 4))
+    }
+'
+
 _fzf_complete_git() {
-    if [[ "$@" = 'git branch'* ]] || [[ "$@" = 'git checkout'* ]]; then
-        _fzf_complete --ansi "$@" < <(git branch -a --format='%(refname:short) %(contents:subject)' 2> /dev/null | _fzf_complete_git_tabularize)
+    if [[ "$@" =~ '^git (branch|checkout|cherry-pick|log|merge|rebase|reset)' ]]; then
+        _fzf_complete_git-commits "$@"
         return
     fi
 
     if [[ "$@" = 'git commit'* ]]; then
         if [[ "$prefix" = '--fixup=' ]]; then
-            _fzf_complete '--ansi --tiebreak=index' "$@" < <(git log --color=always --format='%C(yellow)%h%C(reset)  %s' 2> /dev/null | awk -v prefix="$prefix" '{ print prefix $0 }')
+            _fzf_complete_git-commits "$@"
         else
-            _fzf_complete_git-commit "$@"
+            _fzf_complete_git-commit-messages "$@"
         fi
         return
     fi
 
-    if  [[ "$@" = 'git rebase'* ]] || [[ "$@" = 'git reset'* ]]; then
-        _fzf_complete '--ansi --tiebreak=index' "$@" < <(git log --color=always --format='%C(yellow)%h%C(reset)  %s' 2> /dev/null)
-        return
-    fi
-
     if [[ "$@" = 'git add'* ]]; then
-        _fzf_complete_git-add "$@"
+        _fzf_complete_git-files "$@"
         return
     fi
 
     _fzf_path_completion "$prefix" "$@"
 }
 
-_fzf_complete_git-commit() {
-    _fzf_complete '--ansi --tiebreak=index' "$@" < <(git log --color=always --format='%C(yellow)%h%C(reset)  %s' 2> /dev/null)
-}
-
 _fzf_complete_git_post() {
     awk '{ print $1 }'
 }
 
-_fzf_complete_git-commit_post() {
+_fzf_complete_git-commits() {
+    _fzf_complete '--ansi --tiebreak=index' "$@" < <({
+        git branch -a --format='%(refname:short) %(contents:subject)' 2> /dev/null
+        git log --color=always --format='%h %s' 2> /dev/null | awk -v prefix="$prefix" '{ print prefix $0 }'
+    } | _fzf_complete_git_tabularize)
+}
+
+_fzf_complete_git-commits_post() {
+    awk '{ print $1 }'
+}
+
+_fzf_complete_git-commit-messages() {
+    _fzf_complete '--ansi --tiebreak=index' "$@" < <(git log --color=always --format='%C(yellow)%h%C(reset)  %s' 2> /dev/null)
+}
+
+_fzf_complete_git-commit-messages_post() {
     awk '{
         $1 = ""
         sub(/^ /, "", $0)
         print "'\''" $0 "'\''"
     }'
+}
+
+_fzf_complete_git-files() {
+    _fzf_complete '--ansi' "$@" < <(git status --porcelain=v1 2> /dev/null | awk \
+        -v green="$(tput setaf 2)" \
+        -v red="$(tput setaf 1)" \
+        -v reset="$(tput sgr0)" '
+            '"$_fzf_complete_awk_functions"'
+            /^.[^ ]/ {
+                print colorize_git_status(green, red, reset)
+            }
+        '
+    )
+}
+
+_fzf_complete_git-files_post() {
+    awk '{ print substr($0, 4) }'
 }
 
 _fzf_complete_git_tabularize() {
@@ -65,38 +106,3 @@ _fzf_complete_git_tabularize() {
         }
     '
 }
-
-_fzf_complete_git-add() {
-    _fzf_complete '--ansi' "$@" < <(git status --porcelain=v1 2> /dev/null | awk \
-        -v green="$(tput setaf 2)" \
-        -v red="$(tput setaf 1)" \
-        -v reset="$(tput sgr0)" '
-            '"$_fzf_complete_awk_functions"'
-            /^.[^ ]/ {
-                print colorize_git_status(green, red, reset)
-            }
-        '
-    )
-}
-
-_fzf_complete_git-add_post() {
-    awk '{ print substr($0, 4) }'
-}
-
-_fzf_complete_awk_functions='
-    function colorize_git_status(color1, color2, reset) {
-        index_status = substr($0, 1, 1)
-        work_tree_status = substr($0, 2, 1)
-        if (index_status ~ /[MADRC]/) {
-            index_status_color = color1
-        }
-        if (index_status work_tree_status ~ /(D[DU]|A[AU])|U.|\?\?|!!/) {
-            index_status_color = color2
-        }
-        if (work_tree_status ~ /[MADRCU\?!]/) {
-            work_tree_status_color = color2
-        }
-
-        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, substr($0, 4))
-    }
-'

--- a/git.zsh
+++ b/git.zsh
@@ -34,7 +34,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git add'* ]]; then
-        _fzf_complete_git-files "$@"
+        _fzf_complete_git-unstaged-files "$@"
         return
     fi
 
@@ -68,7 +68,7 @@ _fzf_complete_git-commit-messages_post() {
     }'
 }
 
-_fzf_complete_git-files() {
+_fzf_complete_git-unstaged-files() {
     _fzf_complete '--ansi' "$@" < <(git status --porcelain=v1 2> /dev/null | awk \
         -v green="$(tput setaf 2)" \
         -v red="$(tput setaf 1)" \
@@ -81,7 +81,7 @@ _fzf_complete_git-files() {
     )
 }
 
-_fzf_complete_git-files_post() {
+_fzf_complete_git-unstaged-files_post() {
     awk '{ print substr($0, 4) }'
 }
 


### PR DESCRIPTION
## Refactor
- Renames `_fzf_complete_git-commit` (and its post processor) to `_fzf_complete_git-commits`
- Renames `_fzf_complete_git-add` (and its post processor) to `_fzf_complete_git-files`
- Commits and branches are to be completed for the commands that accept them

Completion functions should no longer be named by its input but by its output.

## Add
- `git cherry-pick`
- `git log`
- `git merge`