### PR TITLE
Add preview

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -39,6 +39,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git add'* ]]; then
+        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' --preview-window=right:70%:wrap" \
         _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi

--- a/git.zsh
+++ b/git.zsh
@@ -39,7 +39,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git add'* ]]; then
-        FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' --preview-window=right:70%:wrap" \
+        FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap $FZF_DEFAULT_OPTS --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"'" \
         _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi

--- a/git.zsh
+++ b/git.zsh
@@ -40,7 +40,7 @@ _fzf_complete_git() {
 
     if [[ "$@" = 'git add'* ]]; then
         FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap --preview 'git diff --no-ext-diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' $FZF_DEFAULT_OPTS" \
-        _fzf_complete_git-unstaged-files '--multi' "$@"
+            _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi
 

--- a/git.zsh
+++ b/git.zsh
@@ -39,7 +39,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git add'* ]]; then
-        FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' $FZF_DEFAULT_OPTS" \
+        FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap --preview 'git diff --no-ext-diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' $FZF_DEFAULT_OPTS" \
         _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi

--- a/git.zsh
+++ b/git.zsh
@@ -39,7 +39,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git add'* ]]; then
-        FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap $FZF_DEFAULT_OPTS --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"'" \
+        FZF_DEFAULT_OPTS="--preview-window=right:70%:wrap --preview 'git diff --color=always {+2} | grep -v -e \"^[^ ]*\(diff\|---\|+++\)\"' $FZF_DEFAULT_OPTS" \
         _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi


### PR DESCRIPTION
This add the preview only to `git add **` in case `_fzf_complete_git-unstaged-files` are shown without using the preview.

`--preview-window` is set with `--preview` to `FZF_DEFAULT_OPTS` because it is related to the preview.