### PR TITLE
Include tags for git commits completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,21 @@ zplug "chitoku-k/fzf-zsh-completions"
   - add
     - Shows the unstaged files
   - branch
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - checkout
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - cherry-pick
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - commit
-    - Shows the commit messages, or the commits/branches if preceded by `--fixup`
+    - Shows the commit messages, or the commits/branches/tags if preceded by `--fixup`
   - log
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - merge
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - rebase
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
   - reset
-    - Shows the commits/branches
+    - Shows the commits/branches/tags
 - npm
   - run
     - Shows the scripts

--- a/git.zsh
+++ b/git.zsh
@@ -60,9 +60,9 @@ _fzf_complete_git-commits() {
     local fzf_options="$1"
     shift
     _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <({
-        git branch -a --format='%(refname:short) %(contents:subject)' 2> /dev/null
-        git log --color=always --format='%h %s' 2> /dev/null | awk -v prefix="$prefix" '{ print prefix $0 }'
-    } | grep -v -e '^(HEAD detached' | _fzf_complete_git_tabularize)
+        git for-each-ref refs/heads refs/remotes refs/tags --format='%(refname:short) %(contents:subject)' 2> /dev/null
+        git log --format='%h %s' 2> /dev/null
+    } | awk -v prefix="$prefix" '{ print prefix $0 }' | _fzf_complete_git_tabularize)
 }
 
 _fzf_complete_git-commits_post() {


### PR DESCRIPTION
Updates completion to include git tags when any of the following is typed:
- git branch **\<TAB\>
- git checkout **\<TAB\>
- git cherry-pick **\<TAB\>
- git commit --fixup=**\<TAB\>
- git log **\<TAB\>
- git merge **\<TAB\>
- git rebase **\<TAB\>
- git reset **\<TAB\>
