### PR TITLE
Add completions for all options that take values of `git commit`

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -80,25 +80,25 @@ _fzf_complete_git() {
             return
         fi
 
-        local cleanup_mode="strip whitespace verbatim scissors default"
+        local cleanup_mode=(strip whitespace verbatim scissors default)
         if [[ "$prefix" =~ '^--cleanup=' ]]; then
-            _fzf_complete '' "$@" < <(echo $cleanup_mode | awk -v RS=' ' -v prefix="${prefix/=*/=}" '{ print prefix $0 }')
+            _fzf_complete '' "$@" < <(awk -v prefix="${prefix/=*/=}" '{ print prefix $0 }' <<< ${(F)cleanup_mode})
             return
         fi
 
         if [[ "$last_options" = '--cleanup' ]]; then
-            _fzf_complete '' "$@" < <(echo $cleanup_mode | tr ' ' '\n')
+            _fzf_complete '' "$@" <<< ${(F)cleanp_mode}
             return
         fi
 
-        local untracked_file_mode="no normal all"
+        local untracked_file_mode=(no normal all)
         if [[ "$prefix" =~ '^--untracked-files=' ]]; then
-            _fzf_complete '' "$@" < <(echo $untracked_file_mode | awk -v RS=' ' -v prefix="${prefix/=*/=}" '{ print prefix $0 }')
+            _fzf_complete '' "$@" < <(awk -v prefix="${prefix/=*/=}" '{ print prefix $0 }' <<< ${(F)untracked_file_mode})
             return
         fi
 
         if [[ "$last_options" =~ '^(-[^-]*u|--untracked-files)' ]]; then
-            _fzf_complete '' "$@" < <(echo $untracked_file_mode | tr ' ' '\n')
+            _fzf_complete '' "$@" <<< ${(F)untracked_file_mode}
             return
         fi
 

--- a/git.zsh
+++ b/git.zsh
@@ -37,7 +37,7 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git commit'* ]]; then
-        if [[ "$prefix" =~ '^--(reuse-message|reedit-message|fixup|squash)=' ]]; then
+        if [[ "$prefix" =~ '^--(fixup|reedit-message|reuse-message|squash)=' ]]; then
             prefix_option="${prefix/=*/=}"
             _fzf_complete_git-commits '' "$@"
             unset prefix_option

--- a/git.zsh
+++ b/git.zsh
@@ -35,8 +35,10 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git commit'* ]]; then
-        if [[ "$prefix" = '--fixup=' ]]; then
+        if [[ "$prefix" =~ '^--fixup=' ]]; then
+            prefix_option="${prefix/=*/=}"
             _fzf_complete_git-commits '' "$@"
+            unset prefix_option
         else
             _fzf_complete_git-commit-messages '' "$@"
         fi
@@ -62,7 +64,7 @@ _fzf_complete_git-commits() {
     _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <({
         git for-each-ref refs/heads refs/remotes refs/tags --format='%(refname:short) %(contents:subject)' 2> /dev/null
         git log --format='%h %s' 2> /dev/null
-    } | awk -v prefix="$prefix" '{ print prefix $0 }' | _fzf_complete_git_tabularize)
+    } | awk -v prefix="$prefix_option" '{ print prefix $0 }' | _fzf_complete_git_tabularize)
 }
 
 _fzf_complete_git-commits_post() {

--- a/git.zsh
+++ b/git.zsh
@@ -72,7 +72,7 @@ _fzf_complete_git-commits_post() {
 _fzf_complete_git-commit-messages() {
     local fzf_options="$1"
     shift
-    _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <(git log --color=always --format='%C(yellow)%h%C(reset)  %s' 2> /dev/null)
+    _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <(git log --format='%h  %s' 2> /dev/null)
 }
 
 _fzf_complete_git-commit-messages_post() {

--- a/git.zsh
+++ b/git.zsh
@@ -24,6 +24,8 @@ _fzf_complete_preview_git_diff='
 '
 
 _fzf_complete_git() {
+    local last_options=${${(z)LBUFFER}[-2]}
+
     if [[ "$@" =~ '^git (checkout|log|rebase|reset)' ]]; then
         _fzf_complete_git-commits '' "$@"
         return
@@ -35,13 +37,85 @@ _fzf_complete_git() {
     fi
 
     if [[ "$@" = 'git commit'* ]]; then
-        if [[ "$prefix" =~ '^--fixup=' ]]; then
+        if [[ "$prefix" =~ '^--(reuse-message|reedit-message|fixup|squash)=' ]]; then
             prefix_option="${prefix/=*/=}"
             _fzf_complete_git-commits '' "$@"
             unset prefix_option
-        else
-            _fzf_complete_git-commit-messages '' "$@"
+            return
         fi
+
+        if [[ "$last_options" =~ '^(-[^-]*[cC]|--(reuse-message|reedit-message|fixup|squash))$' ]]; then
+            _fzf_complete_git-commits '' "$@"
+            return
+        else
+        fi
+
+        if [[ "$prefix" =~ '^--message=' ]]; then
+            prefix_option="${prefix/=*/=}"
+            _fzf_complete_git-commit-messages '' "$@"
+            unset prefix_option
+            return
+        fi
+
+        if [[ "$last_options" =~ '^(-[^-]*m|--message)$' ]]; then
+            _fzf_complete_git-commit-messages '' "$@"
+            return
+        fi
+
+        if [[ "$prefix" =~ '^--author=' ]]; then
+            return
+        fi
+
+        if [[ "$prefix" =~ '^--date=' ]]; then
+            return
+        fi
+
+        if [[ "$prefix" =~ '^--(file|template)=$' ]]; then
+            _fzf_path_completion '' "$@$prefix"
+            return
+        fi
+
+        if [[ "$last_options" =~ '^(-[^-]*[Ft]|--(file|template))' ]]; then
+            _fzf_path_completion '' "$@"
+            return
+        fi
+
+        local cleanup_mode="strip whitespace verbatim scissors default"
+        if [[ "$prefix" =~ '^--cleanup=' ]]; then
+            _fzf_complete '' "$@" < <(echo $cleanup_mode | awk -v RS=' ' -v prefix="${prefix/=*/=}" '{ print prefix $0 }')
+            return
+        fi
+
+        if [[ "$last_options" = '--cleanup' ]]; then
+            _fzf_complete '' "$@" < <(echo $cleanup_mode | tr ' ' '\n')
+            return
+        fi
+
+        local untracked_file_mode="no normal all"
+        if [[ "$prefix" =~ '^--untracked-files=' ]]; then
+            _fzf_complete '' "$@" < <(echo $untracked_file_mode | awk -v RS=' ' -v prefix="${prefix/=*/=}" '{ print prefix $0 }')
+            return
+        fi
+
+        if [[ "$last_options" =~ '^(-[^-]*u|--untracked-files)' ]]; then
+            _fzf_complete '' "$@" < <(echo $untracked_file_mode | tr ' ' '\n')
+            return
+        fi
+
+        local gpg_command=$(git config --global gpg.program || (which gpg > /dev/null && echo gpg))
+        if [[ "$prefix" =~ '^--gpg-sign=' ]]; then
+            prefix_option="${prefix/=*/=}"
+            _fzf_complete_git-gpg-key '' "$@"
+            unset prefix_option
+            return
+        fi
+
+        if [[ "$last_options" =~ '^(-[^-]*S|--gpg-sign)' ]]; then
+            _fzf_complete_git-gpg-key '' "$@"
+            return
+        fi
+
+        _fzf_complete_git-unstaged-files '--multi' "$@"
         return
     fi
 
@@ -74,14 +148,26 @@ _fzf_complete_git-commits_post() {
 _fzf_complete_git-commit-messages() {
     local fzf_options="$1"
     shift
-    _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <(git log --format='%h  %s' 2> /dev/null)
+    _fzf_complete "--ansi --tiebreak=index $fzf_options" "$@" < <(
+        git log --format='%h %s' 2> /dev/null |
+        awk -v prefix="$prefix_option" '
+            {
+                match($0, / /)
+                print $1, prefix substr($0, RSTART + RLENGTH)
+            }
+        ' |
+        _fzf_complete_git_tabularize
+    )
 }
 
 _fzf_complete_git-commit-messages_post() {
-    awk '{
-        $1 = ""
-        sub(/^ /, "", $0)
-        print "'\''" $0 "'\''"
+    awk -v prefix="$prefix_option" '{
+        match($0, /  /)
+        str = substr($0, RSTART + RLENGTH)
+        match(str, prefix)
+        str = substr(str, RSTART + RLENGTH)
+        gsub("'\''", "'\''\\'\'''\''", str)
+        print prefix "'\''" str "'\''"
     }'
 }
 
@@ -107,6 +193,50 @@ _fzf_complete_git-unstaged-files_post() {
 
     local filename=$(awk '{ print substr($0, 4) }')
     echo "${(q)filename}"
+}
+
+_fzf_complete_git-gpg-key() {
+    local fzf_options="$1"
+    shift
+    local global_key=$(git config --global user.signingkey)
+    local local_key=$(git config --local user.signingkey)
+    _fzf_complete "--ansi $fzf_options" "$@" < <(
+        [[ -n "$gpg_command" ]] && LANG=C "$gpg_command" --list-secret-keys --keyid-format LONG 2> /dev/null |
+        awk -v global_key="$global_key" -v local_key=$local_key -v prefix="$prefix_option" '
+            /^sec/ {
+                for (i = 1; ;) {
+                    if ($0 == "") {
+                        break
+                    }
+                    if ($1 == "uid") {
+                        uid = $3 " " $4
+                    }
+                    if ($1 == "sec" || $1 == "ssb") {
+                        sub(/.*\//, "", $2)
+                        keys[i] = $2
+                        types[i++] = $4
+                    }
+                    getline
+                }
+                for (j = 1; j < i; ++j) {
+                    message = ""
+                    if (keys[j] == global_key) {
+                        message = message " " "[Git Global]"
+                    }
+                    if (keys[j] == local_key) {
+                        message = message " " "[Git Local]"
+                    }
+                    print prefix keys[j], types[j], uid message
+                }
+                delete keys
+                delete types
+            }
+        ' | _fzf_complete_git_tabularize
+    )
+}
+
+_fzf_complete_git-gpg-key_post() {
+    awk '{ print $1 }'
 }
 
 _fzf_complete_git_tabularize() {

--- a/git.zsh
+++ b/git.zsh
@@ -20,7 +20,7 @@ _fzf_complete_awk_functions='
         match(str, prefix)
         return substr(str, RSTART + RLENGTH)
     }
-    function enclose_in_single_quote(str) {
+    function quote_by_single_quotations(str) {
         gsub("'\''", "'\''\\'\'''\''", str)
         return "'\''" str "'\''"
     }

--- a/git.zsh
+++ b/git.zsh
@@ -212,37 +212,54 @@ _fzf_complete_git-gpg-key() {
     local local_key=$(git config --local user.signingkey)
     _fzf_complete "--ansi $fzf_options" "$@" < <(
         if [[ -n "$gpg_command" ]]; then
-            LANG=C "$gpg_command" --list-secret-keys --keyid-format LONG 2> /dev/null | awk \
+            LANG=C "$gpg_command" --with-colons --list-secret-keys --keyid-format LONG 2> /dev/null | awk \
+                -v FS=':' \
                 -v global_key="$global_key" \
                 -v local_key="$local_key" \
                 -v prefix="$prefix_option" '
-                    /^sec/ {
-                        for (i = 1; ;) {
-                            if ($0 == "") {
-                                break
-                            }
-                            if ($1 == "uid") {
-                                uid = $3 " " $4
-                            }
-                            if ($1 == "sec" || $1 == "ssb") {
-                                sub(/.*\//, "", $2)
-                                keys[i] = $2
-                                types[i++] = $4
-                            }
-                            getline
+                    function get_message(keyid) {
+                        if (keyid == global_key) {
+                            message = message " " "[Git Global]"
                         }
-                        for (j = 1; j < i; ++j) {
+                        if (keyid == local_key) {
+                            message = message " " "[Git Local]"
+                        }
+
+                        return message
+                    }
+                    /^(sec|ssb|uid)/ {
+                        if ($1 == "sec") {
+                            info[++id, "sec", "keyid"] = $5
+                            info[id, "sec", "capabilities"] = $12
+                            subid = 0
+                        }
+                        if ($1 == "ssb") {
+                            info[id, "ssb", ++subid, "keyid"] = $5
+                            info[id, "ssb", subid, "capabilities"] = $12
+                            ++subids[id]
+                        }
+                        if ($1 == "uid") {
+                            uids[id] = $10
+                        }
+                    }
+                    END {
+                        for (i = 1; i <= id; ++i) {
                             message = ""
-                            if (keys[j] == global_key) {
-                                message = message " " "[Git Global]"
+                            uid = uids[i]
+                            sub_keyid = info[i, "sec", "keyid"]
+                            sub_capabilities = info[i, "sec", "capabilities"]
+                            gsub(/[A-Z]/, "", sub_capabilities)
+
+                            print sub_keyid, "[" toupper(sub_capabilities) "]", uid get_message(sub_keyid)
+
+                            for (j = 1; j <= subids[i]; ++j) {
+                                message = ""
+                                ssb_keyid = info[i, "ssb", j, "keyid"]
+                                ssb_capabilities = info[i, "ssb", j, "capabilities"]
+
+                                print ssb_keyid, "[" toupper(ssb_capabilities) "]", uid get_message(ssb_keyid)
                             }
-                            if (keys[j] == local_key) {
-                                message = message " " "[Git Local]"
-                            }
-                            print prefix keys[j], types[j], uid message
                         }
-                        delete keys
-                        delete types
                     }
                 ' | _fzf_complete_git_tabularize
         fi


### PR DESCRIPTION
# Fix
The completion was not correctly shown when there was a query between `--fixup=` and `**`.
This fixed completion to be shown as below.
```sh
$ git commit --fixup=master**
> --fixup=master
  2/100
> --fixup=master         Add foo bar
  --fixup=origin/master  Add foo bar
```

# Add
- Taking a commit hash
    - --reuse-message/-C
    - --reedit-message/-c
    - --fixup
    - --squash
- Taking a commit message
    - --message/-m
- Taking a file
    - --file/-F
    - --template/-t
- Taking an own value
    - --cleanup
    - --untracked-file/-u
- ~~Taking a GPG key~~
    - ~~--gpg-sign/-S~~

Two options below don't show completions, because it is very difficult deciding the candidate for these value.
- --author
- --date


