### PR TITLE
Improve the preview of the completion of `git add`

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -31,9 +31,10 @@ _fzf_complete_preview_git_diff=$(cat <<'PREVIEW_OPTIONS'
     --preview='echo {} | awk '\''
         {
             if ($0 ~ /^(\?\?|!!)/) {
-                old_file_for_untracked = "/dev/null"
+                printf "%s%c%s", "/dev/null", 0, substr($0, 4)
+            } else {
+                printf "%s", substr($0, 4)
             }
-            printf "%s%c%s", old_file_for_untracked, 0, substr($0, 4)
         }
     '\'' | xargs -0 git diff --no-ext-diff --color=always --'
 PREVIEW_OPTIONS

--- a/git.zsh
+++ b/git.zsh
@@ -26,10 +26,18 @@ _fzf_complete_awk_functions='
     }
 '
 
-_fzf_complete_preview_git_diff='
+_fzf_complete_preview_git_diff=$(cat <<'PREVIEW_OPTIONS'
     --preview-window=right:70%:wrap
-    --preview="echo {} | awk \"{ printf(\\\"%s\\\", substr(\\\$0, 4)) }\" | xargs -0 git diff --no-ext-diff --color=always -- | awk \"NR == 2 || NR >= 5\""
-'
+    --preview='echo {} | awk '\''
+        {
+            if ($0 ~ /^(\?\?|!!)/) {
+                old_file_for_untracked = "/dev/null"
+            }
+            printf "%s%c%s", old_file_for_untracked, 0, substr($0, 4)
+        }
+    '\'' | xargs -0 git diff --no-ext-diff --color=always --'
+PREVIEW_OPTIONS
+)
 
 _fzf_complete_git() {
     local last_options=${${(z)LBUFFER}[-2]}


### PR DESCRIPTION
# Fix
The header part of git diff, the lines from `diff --git` to `+++ filename`, varies in the number of lines depending on its file status. This PR stops removal because it is hard to determine which part is unhelpful.

# Add
This shows the diff of the untracked file in the preview.