### PR TITLE
Improve quotation of commit message

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -20,10 +20,6 @@ _fzf_complete_awk_functions='
         match(str, prefix)
         return substr(str, RSTART + RLENGTH)
     }
-    function quote_by_single_quotations(str) {
-        gsub("'\''", "'\''\\'\'''\''", str)
-        return "'\''" str "'\''"
-    }
 '
 
 _fzf_complete_preview_git_diff=$(cat <<'PREVIEW_OPTIONS'
@@ -168,15 +164,16 @@ _fzf_complete_git-commit-messages() {
 }
 
 _fzf_complete_git-commit-messages_post() {
-    awk -v prefix="$prefix_option" '
+    local message=$(awk -v prefix="$prefix_option" '
         '"$_fzf_complete_awk_functions"'
         {
             match($0, /  /)
             str = substr($0, RSTART + RLENGTH)
-            str = get_after_prefix(str)
-            print prefix enclose_in_single_quote(str)
+            print prefix get_after_prefix(str)
         }
-    '
+    ')
+
+    echo ${(qq)message}
 }
 
 _fzf_complete_git-unstaged-files() {

--- a/git.zsh
+++ b/git.zsh
@@ -169,11 +169,11 @@ _fzf_complete_git-commit-messages_post() {
         {
             match($0, /  /)
             str = substr($0, RSTART + RLENGTH)
-            print prefix get_after_prefix(str)
+            print get_after_prefix(str)
         }
     ')
 
-    echo ${(qq)message}
+    echo "$prefix_option${(qq)message}"
 }
 
 _fzf_complete_git-unstaged-files() {

--- a/git.zsh
+++ b/git.zsh
@@ -16,7 +16,7 @@ _fzf_complete_awk_functions='
 
         return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, substr($0, 4))
     }
-    function get_after_prefix(str) {
+    function trim_prefix(str, prefix) {
         match(str, prefix)
         return substr(str, RSTART + RLENGTH)
     }
@@ -169,7 +169,7 @@ _fzf_complete_git-commit-messages_post() {
         {
             match($0, /  /)
             str = substr($0, RSTART + RLENGTH)
-            print get_after_prefix(str)
+            print trim_prefix(str, prefix)
         }
     ')
 


### PR DESCRIPTION
Undefined function for quoting output was called.
Quoting output should be using parameter expansion flags of Zsh instead of user defined function in AWK.