### PR TITLE
Fix a bug where git commit -m inserted '' when cancelled

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -172,6 +172,9 @@ _fzf_complete_git-commit-messages_post() {
             print trim_prefix(str, prefix)
         }
     ')
+    if [[ -z "$message" ]]; then
+        return
+    fi
 
     echo "$prefix_option${(qq)message}"
 }


### PR DESCRIPTION
This PR fixes `git commit` completion not to insert `''` when a user cancels the fzf prompt.