### PR TITLE
Support untracked files whose name contains LF

### DIFF
--- a/git.zsh
+++ b/git.zsh
@@ -26,17 +26,10 @@ _fzf_complete_awk_functions='
 
 _fzf_complete_preview_git_diff=$(cat <<'PREVIEW_OPTIONS'
     --preview-window=right:70%:wrap
-    --preview='echo {} | awk '\''
-        NR == 1 {
+    --preview='echo {} | awk -v RS="" '\''
+        {
             status = substr($0, 1, 2)
             input = substr($0, 4)
-            next
-        }
-        {
-            input = input "\n" $0
-        }
-        END {
-            sub(/^\n/, "", input)
 
             if (status ~ /^(\?\?|!!)/) {
                 printf "%s%c%s", "/dev/null", 0, input
@@ -198,16 +191,13 @@ _fzf_complete_git-unstaged-files() {
         local files=$(git status --untracked-files=all --porcelain=v1 -z 2> /dev/null)
         for filename in ${(0)files}; do
             awk \
+                -v RS='' \
                 -v green="$(tput setaf 2)" \
                 -v red="$(tput setaf 1)" \
                 -v reset="$(tput sgr0)" '
                     '"$_fzf_complete_awk_functions"'
                     /^.[^ ]/ {
-                        input = input "\n" $0
-                    }
-                    END {
-                        sub(/^\n/, "", input)
-                        printf "%s%c", colorize_git_status(input, green, red, reset), 0
+                        printf "%s%c", colorize_git_status($0, green, red, reset), 0
                     }
                 ' <<< $filename
         done

--- a/git.zsh
+++ b/git.zsh
@@ -186,9 +186,10 @@ _fzf_complete_git-unstaged-files() {
     local fzf_options="$1"
     shift
 
-    _fzf_complete "--ansi --read0 $fzf_options" "$@" < <({
+    _fzf_complete "--ansi --read0 --print0 $fzf_options" "$@" < <({
         local filename
         local files=$(git status --untracked-files=all --porcelain=v1 -z 2> /dev/null)
+
         for filename in ${(0)files}; do
             awk \
                 -v RS='' \
@@ -205,12 +206,12 @@ _fzf_complete_git-unstaged-files() {
 }
 
 _fzf_complete_git-unstaged-files_post() {
-    local filename=$(awk '{ print substr($0, 4) }')
-    if [[ -z "$filename" ]]; then
-        return
-    fi
+    local filename
+    local input=$(cat)
 
-    echo ${(q)${(f)filename}}
+    for filename in ${(0)input}; do
+        echo ${${(q)filename:3}//\\n/\\\\n}
+    done
 }
 
 _fzf_complete_git_tabularize() {


### PR DESCRIPTION
Zsh is a wand!

This PR refactors `_fzf_complete_git-unstaged-files` to accept `LF (0x0A)` as a filename. In order to support that, it utilizes Zsh parameter expansion `0`, which splits input by null character.

http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags