### PR TITLE
Use path completion when preceded by --

### DIFF
--- a/src/git.zsh
+++ b/src/git.zsh
@@ -65,7 +65,7 @@ _fzf_complete_git() {
     if [[ ${(Q)${(z)arguments}} =~ '^git (checkout|log|rebase|reset)' ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
             if [[ ${(Q)${(z)arguments}} = 'git checkout '* ]]; then
-                _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
             fi
 
@@ -86,7 +86,7 @@ _fzf_complete_git() {
 
     if [[ ${(Q)${(z)arguments}} = 'git commit'* ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
-            _fzf_complete_git-unstaged-files '--multi' $@
+            _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
             return
         fi
 
@@ -158,12 +158,12 @@ _fzf_complete_git() {
             return
         fi
 
-        _fzf_complete_git-unstaged-files '--multi' $@
+        _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
         return
     fi
 
     if [[ ${(Q)${(z)arguments}} = 'git add'* ]]; then
-        _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+        _fzf_complete_git-unstaged-files '--untracked-files=all' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
         return
     fi
 
@@ -216,13 +216,14 @@ _fzf_complete_git-commit-messages_post() {
 }
 
 _fzf_complete_git-unstaged-files() {
-    local fzf_options=$1
-    shift
+    local git_options=$1
+    local fzf_options=$2
+    shift 2
 
     _fzf_complete "--ansi --read0 --print0 $fzf_options" $@ < <({
         local previous_status
         local filename
-        local files=$(git status --untracked-files=all --porcelain=v1 -z 2> /dev/null)
+        local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
 
         for filename in ${(0)files}; do
             if [[ $previous_status != R ]]; then

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -46,12 +46,12 @@ _fzf_complete_git() {
     local resolved_commands=()
 
     while true; do
-        local resolved=$(_fzf_complete_git_resolve_alias ${(Qz)arguments})
+        local resolved=$(_fzf_complete_git_resolve_alias ${(Q)${(z)arguments}})
         if [[ -z $resolved ]]; then
             break
         fi
 
-        local subcommand=${${(Qz)resolved}[2]}
+        local subcommand=${${(Q)${(z)resolved}}[2]}
         if [[ ${resolved_commands[(r)$subcommand]} = $subcommand ]]; then
             break
         fi
@@ -60,16 +60,16 @@ _fzf_complete_git() {
         resolved_commands+=($subcommand)
     done
 
-    local last_argument=${${(Qz)arguments}[-1]}
+    local last_argument=${${(Q)${(z)arguments}}[-1]}
 
-    if [[ ${(Qz)arguments} =~ '^git (checkout|log|rebase|reset)' ]]; then
-        if [[ ${${(Qz)arguments}[(r)--]} = -- ]]; then
-            if [[ ${(Qz)arguments} = 'git checkout '* ]]; then
+    if [[ ${(Q)${(z)arguments}} =~ '^git (checkout|log|rebase|reset)' ]]; then
+        if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
+            if [[ ${(Q)${(z)arguments}} = 'git checkout '* ]]; then
                 _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
             fi
 
-            if [[ ${(Qz)arguments} =~ '^git (log|rebase)' ]]; then
+            if [[ ${(Q)${(z)arguments}} =~ '^git (log|rebase)' ]]; then
                 _fzf_path_completion "$prefix" $@
                 return
             fi
@@ -79,13 +79,13 @@ _fzf_complete_git() {
         return
     fi
 
-    if [[ ${(Qz)arguments} =~ '^git (branch|cherry-pick|merge)' ]]; then
+    if [[ ${(Q)${(z)arguments}} =~ '^git (branch|cherry-pick|merge)' ]]; then
         _fzf_complete_git-commits '--multi' $@
         return
     fi
 
-    if [[ ${(Qz)arguments} = 'git commit'* ]]; then
-        if [[ ${${(Qz)arguments}[(r)--]} = -- ]]; then
+    if [[ ${(Q)${(z)arguments}} = 'git commit'* ]]; then
+        if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
             _fzf_complete_git-unstaged-files '--multi' $@
             return
         fi
@@ -162,7 +162,7 @@ _fzf_complete_git() {
         return
     fi
 
-    if [[ ${(Qz)arguments} = 'git add'* ]]; then
+    if [[ ${(Q)${(z)arguments}} = 'git add'* ]]; then
         _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
         return
     fi

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -69,8 +69,8 @@ _fzf_complete_git() {
                 return
             fi
 
-            if [[ ${(Q)${(z)arguments}} =~ '^git (log|rebase)' ]]; then
-                _fzf_path_completion "$prefix" $@
+            if [[ ${(Q)${(z)arguments}} = 'git log '* ]]; then
+                _fzf_complete_git-ls-files '' '--multi' $@
                 return
             fi
         fi
@@ -213,6 +213,23 @@ _fzf_complete_git-commit-messages_post() {
     fi
 
     echo $prefix_option${(qq)message}
+}
+
+_fzf_complete_git-ls-files() {
+    local git_options=$1
+    local fzf_options=$2
+    shift 2
+
+    _fzf_complete "--ansi --read0 --print0 $fzf_options" $@ < <(git ls-files -z ${(Z+n+)git_options} 2> /dev/null)
+}
+
+_fzf_complete_git-ls-files_post() {
+    local filename
+    local input=$(cat)
+
+    for filename in ${(0)input}; do
+        echo ${${(q+)filename}//\\n/\\\\n}
+    done
 }
 
 _fzf_complete_git-unstaged-files() {

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -62,17 +62,34 @@ _fzf_complete_git() {
 
     local last_argument=${${(Qz)arguments}[-1]}
 
-    if [[ ${(Q)arguments} =~ '^git (checkout|log|rebase|reset)' ]]; then
+    if [[ ${(Qz)arguments} =~ '^git (checkout|log|rebase|reset)' ]]; then
+        if [[ ${${(Qz)arguments}[(r)--]} = -- ]]; then
+            if [[ ${(Qz)arguments} = 'git checkout '* ]]; then
+                _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                return
+            fi
+
+            if [[ ${(Qz)arguments} =~ '^git (log|rebase)' ]]; then
+                _fzf_path_completion "$prefix" $@
+                return
+            fi
+        fi
+
         _fzf_complete_git-commits '' $@
         return
     fi
 
-    if [[ ${(Q)arguments} =~ '^git (branch|cherry-pick|merge)' ]]; then
+    if [[ ${(Qz)arguments} =~ '^git (branch|cherry-pick|merge)' ]]; then
         _fzf_complete_git-commits '--multi' $@
         return
     fi
 
-    if [[ ${(Q)arguments} = 'git commit'* ]]; then
+    if [[ ${(Qz)arguments} = 'git commit'* ]]; then
+        if [[ ${${(Qz)arguments}[(r)--]} = -- ]]; then
+            _fzf_complete_git-unstaged-files '--multi' $@
+            return
+        fi
+
         if [[ $prefix =~ '^--(fixup|reedit-message|reuse-message|squash)=' ]]; then
             prefix_option=${prefix/=*/=} _fzf_complete_git-commits '' $@
             return
@@ -145,7 +162,7 @@ _fzf_complete_git() {
         return
     fi
 
-    if [[ ${(Q)arguments} = 'git add'* ]]; then
+    if [[ ${(Qz)arguments} = 'git add'* ]]; then
         _fzf_complete_git-unstaged-files "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
         return
     fi

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -49,6 +49,18 @@
     rm -rf $TEMP
 }
 
+@test 'Debug 1' {
+    v1='git  checkout  '
+    [[ ${(Qz)v1} = 'git checkout ' ]]
+    assert $? equals 0
+}
+
+@test 'Debug 2' {
+    v1='git  checkout  '
+    [[ ${(Qz)v1} = 'git checkout' ]]
+    assert $? equals 0
+}
+
 @test 'Testing completion: git **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1057,7 +1057,7 @@
     _fzf_complete() {
         assert $# equals 2
         assert $1 same_as '--ansi --tiebreak=index '
-        assert $2 same_as '"git" "squash" '
+        assert $2 same_as '"git"  "squash" '
 
         run cat
         assert ${#lines} equals 5
@@ -1069,7 +1069,7 @@
     }
 
     prefix=
-    _fzf_complete_git '"git" "squash" '
+    _fzf_complete_git '"git"  "squash" '
 }
 
 @test 'Testing preview: git add **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -61,6 +61,12 @@
     assert $? equals 0
 }
 
+@test 'Debug 3' {
+    v1='git  checkout  '
+    echo :${(Qz)v1}:
+    assert $? equals 0
+}
+
 @test 'Testing completion: git **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -51,19 +51,19 @@
 
 @test 'Debug 1' {
     v1='git  checkout  '
-    [[ ${(Qz)v1} = 'git checkout ' ]]
+    [[ ${(Q)${(z)v1}} = 'git checkout ' ]]
     assert $? equals 0
 }
 
 @test 'Debug 2' {
     v1='git  checkout  '
-    [[ ${(Qz)v1} = 'git checkout' ]]
+    [[ ${(Q)${(z)v1}} = 'git checkout' ]]
     assert $? equals 0
 }
 
 @test 'Debug 3' {
     v1='git  checkout  '
-    echo :${(Qz)v1}: >&2
+    echo :${(Q)${(z)v1}}: >&2
     assert $? equals 1
 }
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -49,24 +49,6 @@
     rm -rf $TEMP
 }
 
-@test 'Debug 1' {
-    v1='git  checkout  '
-    [[ ${(Q)${(z)v1}} = 'git checkout ' ]]
-    assert $? equals 0
-}
-
-@test 'Debug 2' {
-    v1='git  checkout  '
-    [[ ${(Q)${(z)v1}} = 'git checkout' ]]
-    assert $? equals 0
-}
-
-@test 'Debug 3' {
-    v1='git  checkout  '
-    echo :${(Q)${(z)v1}}: >&2
-    assert $? equals 1
-}
-
 @test 'Testing completion: git **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -83,6 +83,41 @@
     _fzf_complete_git 'git checkout '
 }
 
+@test 'Testing completion: git checkout -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git checkout -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0)  file3 containing space "
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[3]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout -- '
+}
+
 @test 'Testing completion: git log **' {
     _fzf_complete() {
         assert $# equals 2
@@ -772,11 +807,11 @@
 
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as '--ansi --read0 --print0 --multi'
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit '
 
         run cat
-        assert ${#lines} equals 5
+        assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
         assert ${#actual1} equals 3
@@ -789,23 +824,48 @@
         assert ${actual2[1]} same_as 'containing'
 
         actual3=(${(0)lines[3]})
-        assert ${#actual3} equals 4
+        assert ${#actual3} equals 2
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
-        assert ${actual3[3]} same_as "$(tput setaf 1)?$(tput sgr0)$(tput setaf 1)?$(tput sgr0)  file5 containing space "
-        assert ${actual3[4]} same_as "$(tput setaf 1)?$(tput sgr0)$(tput setaf 1)?$(tput sgr0) directory2/file6"
-
-        actual4=(${(0)lines[4]})
-        assert ${#actual4} equals 1
-        assert ${actual4[1]} same_as 'containing'
-
-        actual5=(${(0)lines[5]})
-        assert ${#actual5} equals 1
-        assert ${actual5[1]} same_as 'newlines'
     }
 
     prefix=
     _fzf_complete_git 'git commit '
+}
+
+@test 'Testing completion: git commit -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git commit -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0)  file3 containing space "
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[3]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit -- '
 }
 
 @test 'Testing completion: git add **' {
@@ -974,11 +1034,11 @@
 
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as '--ansi --read0 --print0 --multi'
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit-all '
 
         run cat
-        assert ${#lines} equals 5
+        assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
         assert ${#actual1} equals 3
@@ -991,19 +1051,9 @@
         assert ${actual2[1]} same_as 'containing'
 
         actual3=(${(0)lines[3]})
-        assert ${#actual3} equals 4
+        assert ${#actual3} equals 2
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
-        assert ${actual3[3]} same_as "$(tput setaf 1)?$(tput sgr0)$(tput setaf 1)?$(tput sgr0)  file5 containing space "
-        assert ${actual3[4]} same_as "$(tput setaf 1)?$(tput sgr0)$(tput setaf 1)?$(tput sgr0) directory2/file6"
-
-        actual4=(${(0)lines[4]})
-        assert ${#actual4} equals 1
-        assert ${actual4[1]} same_as 'containing'
-
-        actual5=(${(0)lines[5]})
-        assert ${#actual5} equals 1
-        assert ${actual5[1]} same_as 'newlines'
     }
 
     prefix=
@@ -1070,6 +1120,56 @@
 
     prefix=
     _fzf_complete_git '"git"  "squash" '
+}
+
+@test 'Testing preview: git checkout -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        fzf_options=$1 run preview ' M  file3 containing space '
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview ' M directory1/file2'
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview $' M directory2/file4\ncontaining\nnewlines'
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview ' M file1'
+        assert $output is_not_empty
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout -- '
+}
+
+@test 'Testing preview: git commit -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        fzf_options=$1 run preview ' M  file3 containing space '
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview ' M directory1/file2'
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview $' M directory2/file4\ncontaining\nnewlines'
+        assert $output is_not_empty
+
+        fzf_options=$1 run preview ' M file1'
+        assert $output is_not_empty
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit -- '
 }
 
 @test 'Testing preview: git add **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -137,6 +137,41 @@
     _fzf_complete_git 'git log '
 }
 
+@test 'Testing completion: git log -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --read0 --print0 --multi'
+        assert $2 same_as 'git log -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git log -- '
+}
+
 @test 'Testing completion: git rebase **' {
     _fzf_complete() {
         assert $# equals 2

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -63,8 +63,8 @@
 
 @test 'Debug 3' {
     v1='git  checkout  '
-    echo :${(Qz)v1}:
-    assert $? equals 0
+    echo :${(Qz)v1}: >&2
+    assert $? equals 1
 }
 
 @test 'Testing completion: git **' {


### PR DESCRIPTION
This PR adds support for path completion when the arguments are preceded by `--`, which means any arguments come after that should be pathspec(s).

ToDo:
- [x] Do not show untracked files when `git checkout -- **<TAB>`
- [x] Tests