### PR TITLE
Add completion for `git revert`

### DIFF
--- a/src/git.zsh
+++ b/src/git.zsh
@@ -79,7 +79,7 @@ _fzf_complete_git() {
         return
     fi
 
-    if [[ ${(Q)${(z)arguments}} =~ '^git (branch|cherry-pick|merge)' ]]; then
+    if [[ ${(Q)${(z)arguments}} =~ '^git (branch|cherry-pick|merge|revert)' ]]; then
         _fzf_complete_git-commits '--multi' $@
         return
     fi

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -267,6 +267,25 @@
     _fzf_complete_git 'git merge '
 }
 
+@test 'Testing completion: git revert **' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index --multi'
+        assert $2 same_as 'git revert '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)another-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)master         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)v1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)v2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)$hash_1        $(tput sgr0) 1st commit"
+    }
+
+    prefix=
+    _fzf_complete_git 'git revert '
+}
+
 @test 'Testing completion: git commit --fixup=**' {
     _fzf_complete() {
         assert $# equals 2


### PR DESCRIPTION
```
git revert [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>…​
git revert (--continue | --skip | --abort | --quit)
```
See: https://git-scm.com/docs/git-revert
