### PR TITLE
Make `revolver stop` call

### DIFF
--- a/.zunit.yml
+++ b/.zunit.yml
@@ -1,6 +1,7 @@
 directories:
   tests: tests
   support: tests/_support
+  output: $(echo ${__zunit_output_temp_dir})
 tap: false
 time_limit: 10
 fail_fast: false

--- a/tests/test.zsh
+++ b/tests/test.zsh
@@ -3,5 +3,10 @@
 ROOT=${0:h:h:A}
 PATH=$ROOT/bin/revolver:$ROOT/bin/zunit:$PATH
 
+__zunit_output_temp_dir=$(mktemp -d)
+
 cd $ROOT/bin/zunit && ./build.zsh
-cd $ROOT && zunit ${@:-tests/*.zunit}
+cd $ROOT && __zunit_output_temp_dir=$__zunit_output_temp_dir zunit --output-html ${@:-tests/*.zunit}
+
+rm -rf $__zunit_output_temp_dir
+unset __zunit_output_temp_dir


### PR DESCRIPTION
`revolver stop` was not called and a temporary file for `revolver` was not deleted when run tests.

There is a trivial problem with display as below:
https://travis-ci.com/chitoku-k/fzf-zsh-completions/jobs/281088522#L262