### PR TITLE
Fix the optional argument of the option

### DIFF
--- a/src/git.zsh
+++ b/src/git.zsh
@@ -153,23 +153,20 @@ _fzf_complete_git_has_options() {
     shift 2
 
     for option in ${(z)@}; do
-        local option_last_character=${option[-1]}
-        local option_without_last_question_mark=${option%\?}
-
-        if [[ ${#option_without_last_question_mark} = 1 ]]; then
-            if [[ $option_last_character != '?' ]] && [[ $last_argument =~ "^-[^-]*$option_without_last_question_mark" ]]; then
+        if [[ ${#option%\?} = 1 ]]; then
+            if [[ ${option[-1]} != '?' ]] && [[ $last_argument =~ "^-[^-]*${option%\?}" ]]; then
                 return 0
             fi
 
-            if [[ $option_last_character == '?' ]] && [[ $prefix =~ "^-[^-]*$option_without_last_question_mark" ]]; then
+            if [[ $prefix =~ "^-[^-]*${option%\?}" ]]; then
                 return 0
             fi
         else
-            if [[ $option_last_character != '?' ]] && [[ $last_argument = "--$option_without_last_question_mark" ]]; then
+            if [[ ${option[-1]} != '?' ]] && [[ $last_argument = "--${option%\?}" ]]; then
                 return 0
             fi
 
-            if [[ $prefix =~ "^--$option_without_last_question_mark=" ]]; then
+            if [[ $prefix =~ "^--${option%\?}=" ]]; then
                 return 0
             fi
         fi

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -853,6 +853,42 @@
     _fzf_complete_git 'git commit --cleanup '
 }
 
+@test 'Testing completion: git commit -u**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as -uno
+        assert ${lines[2]} same_as -unormal
+        assert ${lines[3]} same_as -uall
+    }
+
+    prefix=-u
+    _fzf_complete_git 'git commit '
+}
+
+@test 'Testing completion: git commit -u **' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git commit -u '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit -u '
+}
+
 @test 'Testing completion: git commit --untracked-files=**' {
     _fzf_complete() {
         assert $# equals 2
@@ -873,14 +909,16 @@
 @test 'Testing completion: git commit --untracked-files **' {
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as ''
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit --untracked-files '
 
         run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as no
-        assert ${lines[2]} same_as normal
-        assert ${lines[3]} same_as all
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
     }
 
     prefix=
@@ -1093,8 +1131,8 @@
     _fzf_complete_git 'git commit-cleanup '
 }
 
-@test 'Testing completion (alias): git commit --untracked-files **' {
-    run git config alias.commit-untracked 'commit --untracked-files'
+@test 'Testing completion (alias): git commit --untracked-files=**' {
+    run git config alias.commit-untracked 'commit --untracked-files='
 
     _fzf_complete() {
         assert $# equals 2
@@ -1103,12 +1141,12 @@
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as no
-        assert ${lines[2]} same_as normal
-        assert ${lines[3]} same_as all
+        assert ${lines[1]} same_as --untracked-files=no
+        assert ${lines[2]} same_as --untracked-files=normal
+        assert ${lines[3]} same_as --untracked-files=all
     }
 
-    prefix=
+    prefix=--untracked-files=
     _fzf_complete_git 'git commit-untracked '
 }
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1131,22 +1131,24 @@
     _fzf_complete_git 'git commit-cleanup '
 }
 
-@test 'Testing completion (alias): git commit --untracked-files=**' {
-    run git config alias.commit-untracked 'commit --untracked-files='
+@test 'Testing completion (alias): git commit --untracked-files **' {
+    run git config alias.commit-untracked 'commit --untracked-files'
 
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as ''
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit-untracked '
 
         run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as --untracked-files=no
-        assert ${lines[2]} same_as --untracked-files=normal
-        assert ${lines[3]} same_as --untracked-files=all
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
     }
 
-    prefix=--untracked-files=
+    prefix=
     _fzf_complete_git 'git commit-untracked '
 }
 


### PR DESCRIPTION
This fixed a behaviour when the argument of the option is optional.
The optional argument of the option is suffixed `?` to the item in `$git_options_*_completion`.