### PR TITLE
Refactor git option parser and fix wrong behaviours

### DIFF
--- a/src/git.zsh
+++ b/src/git.zsh
@@ -138,7 +138,11 @@ _fzf_complete_git() {
         done
 
         if [[ $completing_option_source = prefix ]]; then
-            prefix_option=$prefix
+            if [[ $completing_option = --* ]]; then
+                prefix_option=$completing_option=
+            else
+                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
+            fi
         fi
 
         case $completing_option in
@@ -154,7 +158,7 @@ _fzf_complete_git() {
                 ;;
 
             -F|-t|--file|--pathspec-from-file|--template)
-                _fzf_path_completion "${prefix/--*=}" $@$prefix_option
+                _fzf_path_completion "${prefix#$prefix_option}" $@$prefix_option
                 ;;
 
             --cleanup)

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -86,7 +86,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'commit' ]]; then
-        if [[ ${${(Q)${(z)arguments}}[(r)--]} != '' ]] || [[ $last_argument != -* && $prefix != -* ]]; then
+        if [[ -n ${${(Q)${(z)arguments}}[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
             _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
             return
         fi
@@ -96,10 +96,10 @@ _fzf_complete_git() {
         local git_options_argument_optional=(-u --untracked-files)
 
         current=$prefix
-        while [[ $current != '' ]]; do
+        while [[ -n $current ]]; do
             case $current in
                 -[A-Za-z]*)
-                    if [[ ${git_options_argument_required[(r)${current:0:2}]} != '' ]] || [[ ${git_options_argument_optional[(r)${current:0:2}]} != '' ]]; then
+                    if [[ -n ${git_options_argument_required[(r)${current:0:2}]} ]] || [[ -n ${git_options_argument_optional[(r)${current:0:2}]} ]]; then
                         completing_option=${current:0:2}
                         completing_option_source=prefix
                         break
@@ -107,7 +107,7 @@ _fzf_complete_git() {
                     ;;
 
                 --*)
-                    if [[ ${git_options_argument_required[(r)${current%=*}]} != '' ]] || [[ ${git_options_argument_optional[(r)${current%=*}]} != '' ]]; then
+                    if [[ -n ${git_options_argument_required[(r)${current%=*}]} ]] || [[ -n ${git_options_argument_optional[(r)${current%=*}]} ]]; then
                         completing_option=${current%=*}
                         completing_option_source=prefix
                         break
@@ -123,8 +123,8 @@ _fzf_complete_git() {
         done
 
         current=$last_argument
-        while [[ $current != '' ]]; do
-            if [[ ${git_options_argument_required[(r)$current]} != '' ]]; then
+        while [[ -n $current ]]; do
+            if [[ -n ${git_options_argument_required[(r)$current]} ]]; then
                 completing_option=$current
                 completing_option_source=last_argument
                 break

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -116,7 +116,7 @@ _fzf_complete_git() {
                 ;;
 
             -F|-t|--file|--pathspec-from-file|--template)
-                _fzf_path_completion "${prefix#$prefix_option}" $@$prefix_option
+                __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
                 ;;
 
             --cleanup)

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -837,6 +837,21 @@
     _fzf_complete_git 'git commit -F '
 }
 
+@test 'Testing completion: git commit -F**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit -F'
+    }
+
+    prefix=-F
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -qF **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
@@ -850,6 +865,21 @@
 
     prefix=
     _fzf_complete_git 'git commit -qF '
+}
+
+@test 'Testing completion: git commit -qF**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit -qF'
+    }
+
+    prefix=-qF
+    _fzf_complete_git 'git commit '
 }
 
 @test 'Testing completion: git commit -t **' {
@@ -867,6 +897,21 @@
     _fzf_complete_git 'git commit -t '
 }
 
+@test 'Testing completion: git commit -t**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit -t'
+    }
+
+    prefix=-t
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -qt **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
@@ -880,6 +925,21 @@
 
     prefix=
     _fzf_complete_git 'git commit -qt '
+}
+
+@test 'Testing completion: git commit -qt**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit -qt'
+    }
+
+    prefix=-qt
+    _fzf_complete_git 'git commit '
 }
 
 @test 'Testing completion: git commit --file **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -416,6 +416,25 @@
     _fzf_complete_git 'git commit -c '
 }
 
+@test 'Testing completion: git commit -c**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)-canother-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)-cmaster         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)-cv1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)-cv2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)-c$hash_1        $(tput sgr0) 1st commit"
+    }
+
+    prefix=-c
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -qc **' {
     _fzf_complete() {
         assert $# equals 2
@@ -433,6 +452,25 @@
 
     prefix=
     _fzf_complete_git 'git commit -qc '
+}
+
+@test 'Testing completion: git commit -qc**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)-qcanother-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)-qcmaster         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)-qcv1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)-qcv2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)-qc$hash_1        $(tput sgr0) 1st commit"
+    }
+
+    prefix=-qc
+    _fzf_complete_git 'git commit '
 }
 
 @test 'Testing completion: git commit -C **' {
@@ -454,6 +492,25 @@
     _fzf_complete_git 'git commit -C '
 }
 
+@test 'Testing completion: git commit -C**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)-Canother-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)-Cmaster         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)-Cv1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)-Cv2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)-C$hash_1        $(tput sgr0) 1st commit"
+    }
+
+    prefix=-C
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -qC **' {
     _fzf_complete() {
         assert $# equals 2
@@ -471,6 +528,25 @@
 
     prefix=
     _fzf_complete_git 'git commit -qC '
+}
+
+@test 'Testing completion: git commit -qC**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)-qCanother-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)-qCmaster         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)-qCv1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)-qCv2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)-qC$hash_1        $(tput sgr0) 1st commit"
+    }
+
+    prefix=-qC
+    _fzf_complete_git 'git commit '
 }
 
 @test 'Testing completion: git commit --fixup **' {
@@ -585,6 +661,24 @@
     _fzf_complete_git 'git commit -m '
 }
 
+@test 'Testing completion: git commit -m**' {
+    run git checkout another-branch
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "$(tput setaf 3)$hash_2 $(tput sgr0) -m 2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)$hash_1 $(tput sgr0) -m1st commit"
+    }
+
+    prefix=-m
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -qm **' {
     run git checkout another-branch
 
@@ -601,6 +695,24 @@
 
     prefix=
     _fzf_complete_git 'git commit -qm '
+}
+
+@test 'Testing completion: git commit -qm**' {
+    run git checkout another-branch
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "$(tput setaf 3)$hash_2 $(tput sgr0) -qm 2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)$hash_1 $(tput sgr0) -qm1st commit"
+    }
+
+    prefix=-qm
+    _fzf_complete_git 'git commit '
 }
 
 @test 'Testing completion: git commit --message **' {
@@ -853,6 +965,40 @@
     _fzf_complete_git 'git commit --cleanup '
 }
 
+@test 'Testing completion: git commit -u**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as -uno
+        assert ${lines[2]} same_as -unormal
+        assert ${lines[3]} same_as -uall
+    }
+
+    prefix=-u
+    _fzf_complete_git 'git commit '
+}
+
+@test 'Testing completion: git commit -qu**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as -quno
+        assert ${lines[2]} same_as -qunormal
+        assert ${lines[3]} same_as -quall
+    }
+
+    prefix=-qu
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit --untracked-files=**' {
     _fzf_complete() {
         assert $# equals 2
@@ -871,16 +1017,34 @@
 }
 
 @test 'Testing completion: git commit --untracked-files **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as ''
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit --untracked-files '
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as no
-        assert ${lines[2]} same_as normal
-        assert ${lines[3]} same_as all
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0)  file3 containing space "
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[3]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
     }
 
     prefix=
@@ -1094,18 +1258,36 @@
 }
 
 @test 'Testing completion (alias): git commit --untracked-files **' {
+    run git checkout another-branch
     run git config alias.commit-untracked 'commit --untracked-files'
+
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
 
     _fzf_complete() {
         assert $# equals 2
-        assert $1 same_as ''
+        assert $1 matches '--ansi --read0 --print0 --multi '
         assert $2 same_as 'git commit-untracked '
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as no
-        assert ${lines[2]} same_as normal
-        assert ${lines[3]} same_as all
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0)  file3 containing space "
+        assert ${actual1[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory1/file2"
+        assert ${actual1[3]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $(tput sgr0)$(tput setaf 1)M$(tput sgr0) file1"
     }
 
     prefix=

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -782,10 +782,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --file='
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=--file=
@@ -797,10 +801,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --template='
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=--template=
@@ -812,10 +820,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --pathspec-from-file='
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=--pathspec-from-file=
@@ -827,10 +839,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -F '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -842,10 +858,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -F'
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=-F
@@ -857,10 +877,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -qF '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -872,10 +896,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -qF'
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=-qF
@@ -887,10 +915,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -t '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -902,10 +934,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -t'
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=-t
@@ -917,10 +953,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -qt '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -932,10 +972,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit -qt'
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=-qt
@@ -947,10 +991,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --file '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -962,10 +1010,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --template '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -977,10 +1029,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit --pathspec-from-file '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=
@@ -1286,10 +1342,14 @@
         fail '_fzf_complete should not be invoked'
     }
 
-    _fzf_path_completion() {
-        assert $# equals 2
+    __fzf_generic_path_completion() {
+        assert $# equals 6
         assert $1 same_as ''
         assert $2 same_as 'git commit-spec '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
     }
 
     prefix=


### PR DESCRIPTION
The current option parser looks like it has reached its limitation because it did some tricky regular expressions to handle short and long options. I have entirely rewritten the core parser to properly handle the cases described in #40 and #41 and I added the tests that cover them.