### PR TITLE
Add completions for `git restore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ zplug "chitoku-k/fzf-zsh-completions"
   - merge
   - rebase
   - reset
+  - restore
   - revert
 - make
 - npm

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -85,6 +85,32 @@ _fzf_complete_git() {
         return
     fi
 
+    if [[ $subcommand = 'restore' ]]; then
+        local prefix_option completing_option
+        local git_options_argument_required=(--source)
+        local git_options_argument_optional=()
+
+        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
+            if [[ $completing_option = --* ]]; then
+                prefix_option=$completing_option=
+            else
+                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
+            fi
+        fi
+
+        case $completing_option in
+            --source)
+                _fzf_complete_git-commits '' $@
+                ;;
+
+            *)
+                _fzf_complete_git-ls-files '' '--multi' $@
+                ;;
+        esac
+
+        return
+    fi
+
     if [[ $subcommand = 'commit' ]]; then
         if [[ -n ${${(Q)${(z)arguments}}[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
             _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -302,6 +302,79 @@
     _fzf_complete_git 'git revert '
 }
 
+@test 'Testing completion: git restore **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --read0 --print0 --multi'
+        assert $2 same_as 'git restore '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore '
+}
+
+@test 'Testing completion: git restore --source=**' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git restore '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)${prefix}another-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)${prefix}master         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)${prefix}v1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)${prefix}v2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)${prefix}3e209a3        $(tput sgr0) 1st commit"
+    }
+
+    prefix=--source=
+    _fzf_complete_git 'git restore '
+}
+
+@test 'Testing completion: git restore --source **' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git restore --source '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)${prefix}another-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)${prefix}master         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)${prefix}v1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)${prefix}v2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)${prefix}3e209a3        $(tput sgr0) 1st commit"
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore --source '
+}
+
 @test 'Testing completion: git commit --fixup=**' {
     _fzf_complete() {
         assert $# equals 2


### PR DESCRIPTION
```
git restore [<options>] [--source=<tree>] [--staged] [--worktree] [--] <pathspec>…​
git restore [<options>] [--source=<tree>] [--staged] [--worktree] --pathspec-from-file=<file> [--pathspec-file-nul]
git restore (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [--] [<pathspec>…​]
```

See: https://git-scm.com/docs/git-restore