### PR TITLE
Add completion for `git switch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ zplug "chitoku-k/fzf-zsh-completions"
   - rebase
   - reset
   - revert
+  - switch
 - make
 - npm
   - run

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -63,7 +63,7 @@ _fzf_complete_git() {
     local subcommand=${${(Q)${(z)arguments}}[2]}
     local last_argument=${${(Q)${(z)arguments}}[-1]}
 
-    if [[ $subcommand =~ '(checkout|log|rebase|reset)' ]]; then
+    if [[ $subcommand =~ '(checkout|log|rebase|reset|switch)' ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
             if [[ $subcommand = 'checkout' ]]; then
                 _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -226,6 +226,25 @@
     _fzf_complete_git 'git reset -- '
 }
 
+@test 'Testing completion: git switch **' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git switch '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "$(tput setaf 3)another-branch $(tput sgr0)  2nd commit"
+        assert ${lines[2]} same_as "$(tput setaf 3)master         $(tput sgr0) 1st commit"
+        assert ${lines[3]} same_as "$(tput setaf 3)v1             $(tput sgr0) 1st commit"
+        assert ${lines[4]} same_as "$(tput setaf 3)v2             $(tput sgr0)  2nd commit"
+        assert ${lines[5]} same_as "$(tput setaf 3)3e209a3        $(tput sgr0) 1st commit"
+    }
+
+    prefix=
+    _fzf_complete_git 'git switch '
+}
+
 @test 'Testing completion: git branch **' {
     _fzf_complete() {
         assert $# equals 2


### PR DESCRIPTION
```
git switch [<options>] [--no-guess] <branch>
git switch [<options>] --detach [<start-point>]
git switch [<options>] (-c|-C) <new-branch> [<start-point>]
git switch [<options>] --orphan <new-branch>
```

See: https://git-scm.com/docs/git-switch