### PR TITLE
Add regex option to tests/test.zsh

### DIFF
--- a/tests/test.zsh
+++ b/tests/test.zsh
@@ -3,5 +3,40 @@
 ROOT=${0:h:h:A}
 PATH=$ROOT/bin/revolver:$ROOT/bin/zunit:$PATH
 
-cd $ROOT/bin/zunit && ./build.zsh
-cd $ROOT && zunit ${@:-tests/*.zunit}
+setup() {
+    local test_args=()
+    zparseopts -D -E r+:=regex -regex+:=regex
+
+    if [[ -n $regex ]]; then
+        for (( i = 2; i <= ${#regex}; i = i + 2 )); do
+            local argument=(${(s:@:)${regex[$i]}})
+            local test_file
+            local test_name
+            if [[ ${#argument} == 1 ]]; then
+                test_file=''
+                test_name=${argument[1]}
+            else
+                test_file=${argument[1]}
+                test_name=${argument[2]}
+            fi
+            local pattern='^ *@test  *([^ ]'$test_name')  *\{ *(.*)$'
+            IFS=$'\n' local lines=($(grep -H -E $pattern ${test_file:-tests/*.zunit}))
+            local line
+            for line in $lines; do
+                test_args+=(${test_file:-${line%%:*}}@${^${line#*\'}%\'*})
+            done
+        done
+    fi
+
+    args=($@ ${test_args})
+}
+
+run() {
+    local args=()
+    setup $@
+
+    cd $ROOT/bin/zunit && ./build.zsh
+    cd $ROOT && zunit ${args:-tests/*.zunit}
+}
+
+run $@


### PR DESCRIPTION
This adds `-r` and `--regex` options to `tests/test.zsh`. These options allow running individual test 
to use the regular expressions. 

## Motivation
When I implementing the new subcommand, I was depressed about it run all tests or related it one by one 😢.

## Usage
```
tests/test.zsh [<zunit-option>] [[-r | --regex] <test-file>@<test-name-with-regex>]
```
```sh
# Runs the tests of the all completions related `git commit`
tests/test.zsh -r tests/git.zunit@'Testing completion: git commit .+'

# If <test-file> is empty, runs the all tests related `<test-name-with-regex>`
tests/test.zsh -r @'.+post.+'

# Can run the tests with multiple regex
tests/test.zsh -r @'.+log.+' -r @'.+rebase.+'
```