### PR TITLE
Fix an issue where the wrong directories are shown 

### DIFF
--- a/src/git.zsh
+++ b/src/git.zsh
@@ -4,9 +4,9 @@ autoload -U colors
 colors
 
 _fzf_complete_awk_functions='
-    function colorize_git_status(status, relative_from_current, color1, color2, reset) {
-        index_status = substr(status, 1, 1)
-        work_tree_status = substr(status, 2, 1)
+    function colorize_git_status(input, relative_from_current, color1, color2, reset) {
+        index_status = substr(input, 1, 1)
+        work_tree_status = substr(input, 2, 1)
 
         if (index_status ~ /[MADRC]/) {
             index_status_color = color1
@@ -18,7 +18,7 @@ _fzf_complete_awk_functions='
             work_tree_status_color = color2
         }
 
-        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, relative_from_current substr(status, 4))
+        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, relative_from_current substr(input, 4))
     }
 
     function trim_prefix(str, prefix) {

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_awk_functions='
-    function colorize_git_status(input, relative_from_current, color1, color2, reset) {
+    function colorize_git_status(input, cdup, color1, color2, reset) {
         index_status = substr(input, 1, 1)
         work_tree_status = substr(input, 2, 1)
 
@@ -18,7 +18,7 @@ _fzf_complete_awk_functions='
             work_tree_status_color = color2
         }
 
-        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, relative_from_current substr(input, 4))
+        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, cdup substr(input, 4))
     }
 
     function trim_prefix(str, prefix) {
@@ -338,20 +338,19 @@ _fzf_complete_git-unstaged-files() {
         local previous_status
         local filename
         local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
-        local relative_from_current=$(git rev-parse --show-cdup 2> /dev/null)
+        local cdup=$(git rev-parse --show-cdup 2> /dev/null)
 
         for filename in ${(0)files}; do
             if [[ $previous_status != R ]]; then
                 awk \
                     -v RS='' \
-                    -v relative_from_top_level=$relative_from_top_level \
-                    -v relative_from_current=$relative_from_current \
+                    -v cdup=$cdup \
                     -v green=${fg[green]} \
                     -v red=${fg[red]} \
                     -v reset=$reset_color '
                             '$_fzf_complete_awk_functions'
                             /^.[^ ]/ {
-                                printf "%s%c", colorize_git_status($0, relative_from_current, green, red, reset), 0
+                                printf "%s%c", colorize_git_status($0, cdup, green, red, reset), 0
                             }
                     ' <<< $filename
             fi

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -4,9 +4,9 @@ autoload -U colors
 colors
 
 _fzf_complete_awk_functions='
-    function colorize_git_status(input, color1, color2, reset) {
-        index_status = substr(input, 1, 1)
-        work_tree_status = substr(input, 2, 1)
+    function colorize_git_status(status, relative_from_top_level, relative_from_current, color1, color2, reset) {
+        index_status = substr(status, 1, 1)
+        work_tree_status = substr(status, 2, 1)
 
         if (index_status ~ /[MADRC]/) {
             index_status_color = color1
@@ -18,7 +18,19 @@ _fzf_complete_awk_functions='
             work_tree_status_color = color2
         }
 
-        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, substr(input, 4))
+        path = substr(status, 4)
+        match(path, relative_from_top_level)
+        if (RLENGTH > 0) {
+            if (RSTART == 1) {
+                path = substr(path, RLENGTH + 1)
+            } else {
+                path = relative_from_current path
+            }
+        } else {
+            path = relative_from_current path
+        }
+
+        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, path)
     }
 
     function trim_prefix(str, prefix) {
@@ -338,17 +350,21 @@ _fzf_complete_git-unstaged-files() {
         local previous_status
         local filename
         local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
+        local relative_from_current=$(git rev-parse --show-cdup 2> /dev/null)
+        local relative_from_top_level=$(git rev-parse --show-prefix 2> /dev/null)
 
         for filename in ${(0)files}; do
             if [[ $previous_status != R ]]; then
                 awk \
                     -v RS='' \
+                    -v relative_from_top_level=$relative_from_top_level \
+                    -v relative_from_current=$relative_from_current \
                     -v green=${fg[green]} \
                     -v red=${fg[red]} \
                     -v reset=$reset_color '
                             '$_fzf_complete_awk_functions'
                             /^.[^ ]/ {
-                            printf "%s%c", colorize_git_status($0, green, red, reset), 0
+                            printf "%s%c", colorize_git_status($0, relative_from_top_level, relative_from_current, green, red, reset), 0
                         }
                     ' <<< $filename
             fi

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_awk_functions='
-    function colorize_git_status(status, relative_from_top_level, relative_from_current, color1, color2, reset) {
+    function colorize_git_status(status, relative_from_current, color1, color2, reset) {
         index_status = substr(status, 1, 1)
         work_tree_status = substr(status, 2, 1)
 
@@ -18,19 +18,7 @@ _fzf_complete_awk_functions='
             work_tree_status_color = color2
         }
 
-        path = substr(status, 4)
-        match(path, relative_from_top_level)
-        if (RLENGTH > 0) {
-            if (RSTART == 1) {
-                path = substr(path, RLENGTH + 1)
-            } else {
-                path = relative_from_current path
-            }
-        } else {
-            path = relative_from_current path
-        }
-
-        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, path)
+        return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, relative_from_current substr(status, 4))
     }
 
     function trim_prefix(str, prefix) {
@@ -351,7 +339,6 @@ _fzf_complete_git-unstaged-files() {
         local filename
         local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
         local relative_from_current=$(git rev-parse --show-cdup 2> /dev/null)
-        local relative_from_top_level=$(git rev-parse --show-prefix 2> /dev/null)
 
         for filename in ${(0)files}; do
             if [[ $previous_status != R ]]; then
@@ -364,8 +351,8 @@ _fzf_complete_git-unstaged-files() {
                     -v reset=$reset_color '
                             '$_fzf_complete_awk_functions'
                             /^.[^ ]/ {
-                            printf "%s%c", colorize_git_status($0, relative_from_top_level, relative_from_current, green, red, reset), 0
-                        }
+                                printf "%s%c", colorize_git_status($0, relative_from_current, green, red, reset), 0
+                            }
                     ' <<< $filename
             fi
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -138,6 +138,7 @@
 
     prefix=
     _fzf_complete_git 'git checkout -- '
+    cd ../../
 }
 
 @test 'Testing completion: git log **' {
@@ -1320,6 +1321,7 @@
 
     prefix=
     _fzf_complete_git 'git commit '
+    cd ../../
 }
 
 @test 'Testing completion: git commit -- **' {
@@ -1396,6 +1398,7 @@
 
     prefix=
     _fzf_complete_git 'git commit -- '
+    cd ../../
 }
 
 @test 'Testing completion: git add **' {
@@ -1503,6 +1506,7 @@
 
     prefix=
     _fzf_complete_git 'git add '
+    cd ../../
 }
 
 @test 'Testing completion: git pull --recurse-submodules=**' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1479,9 +1479,9 @@
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
         assert ${actual3[3]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../ file5 containing space "
-        assert ${actual3[4]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color directory4/file9"
-        assert ${actual3[5]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color file7"
-        assert ${actual3[6]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color file8"
+        assert ${actual3[4]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../directory2/directory3/directory4/file9"
+        assert ${actual3[5]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../directory2/directory3/file7"
+        assert ${actual3[6]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../directory2/directory3/file8"
 
         actual4=(${(0)lines[4]})
         assert ${#actual4} equals 1

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -99,6 +99,47 @@
     _fzf_complete_git 'git checkout -- '
 }
 
+@test 'Testing completion in subdirectory: git checkout -- **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git checkout -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout -- '
+}
+
 @test 'Testing completion: git log **' {
     _fzf_complete() {
         assert $# equals 2
@@ -1240,6 +1281,47 @@
     _fzf_complete_git 'git commit '
 }
 
+@test 'Testing completion in subdirectory: git commit **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git commit '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit '
+}
+
 @test 'Testing completion: git commit -- **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
@@ -1269,6 +1351,47 @@
         assert ${#actual3} equals 2
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit -- '
+}
+
+@test 'Testing completion in subdirectory: git commit -- **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git commit -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
     }
 
     prefix=
@@ -1314,6 +1437,68 @@
         actual5=(${(0)lines[5]})
         assert ${#actual5} equals 1
         assert ${actual5[1]} same_as 'newlines'
+    }
+
+    prefix=
+    _fzf_complete_git 'git add '
+}
+
+@test 'Testing completion in subdirectory: git add **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git add '
+
+        run cat
+        assert ${#lines} equals 7
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 6
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
+        assert ${actual3[3]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../ file5 containing space "
+        assert ${actual3[4]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color directory4/file9"
+        assert ${actual3[5]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color file7"
+        assert ${actual3[6]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color file8"
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'containing'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 2
+        assert ${actual5[1]} same_as 'newlines'
+        assert ${actual5[2]} same_as "${fg[red]}?$reset_color${fg[red]}?$reset_color ../../directory2/file6"
+
+        actual6=(${(0)lines[6]})
+        assert ${#actual6} equals 1
+        assert ${actual6[1]} same_as 'containing'
+
+        actual7=(${(0)lines[7]})
+        assert ${#actual7} equals 1
+        assert ${actual7[1]} same_as 'newlines'
     }
 
     prefix=

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -3,6 +3,7 @@
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
     pushd tests/_support/git
+    DIR=$PWD
 
     {
         rm -rf .git
@@ -22,6 +23,8 @@
 }
 
 @teardown {
+    pushd $DIR
+
     {
         git reset --hard master
         git clean -d -f
@@ -138,7 +141,6 @@
 
     prefix=
     _fzf_complete_git 'git checkout -- '
-    cd ../../
 }
 
 @test 'Testing completion: git log **' {
@@ -1321,7 +1323,6 @@
 
     prefix=
     _fzf_complete_git 'git commit '
-    cd ../../
 }
 
 @test 'Testing completion: git commit -- **' {
@@ -1398,7 +1399,6 @@
 
     prefix=
     _fzf_complete_git 'git commit -- '
-    cd ../../
 }
 
 @test 'Testing completion: git add **' {
@@ -1506,7 +1506,6 @@
 
     prefix=
     _fzf_complete_git 'git add '
-    cd ../../
 }
 
 @test 'Testing completion: git pull --recurse-submodules=**' {


### PR DESCRIPTION
This fixes #46.
I tried to use the result of `git status --porcelain=v2`, but the result of `git status --porcelain=v2 -z` shows the relative file path from the directory of not the current but the top-level. Using the results of `git rev-parse --show-cdup` and `git rev-parse --show-prefix` instead solves an issue.

Screenshot:
![image](https://user-images.githubusercontent.com/10758173/74367422-2c231d80-4e15-11ea-97f5-b80f29349334.png)
