### PR TITLE
Support `git diff **`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ zplug "chitoku-k/fzf-zsh-completions"
   - checkout
   - cherry-pick
   - commit
+  - diff
   - log
   - merge
   - pull

--- a/src/git.zsh
+++ b/src/git.zsh
@@ -66,9 +66,9 @@ _fzf_complete_git() {
     local subcommand=${${(Q)${(z)arguments}}[2]}
     local last_argument=${${(Q)${(z)arguments}}[-1]}
 
-    if [[ $subcommand =~ '(checkout|log|rebase|reset|switch)' ]]; then
+    if [[ $subcommand =~ '(checkout|diff|log|rebase|reset|switch)' ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
-            if [[ $subcommand = 'checkout' ]]; then
+            if [[ $subcommand =~ '(checkout|diff)' ]]; then
                 _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
             fi

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -143,6 +143,101 @@
     _fzf_complete_git 'git checkout -- '
 }
 
+@test 'Testing completion: git diff **' {
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 same_as '--ansi --tiebreak=index '
+        assert $2 same_as 'git diff '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch $reset_color  2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master         $reset_color 1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v1             $reset_color 1st commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v2             $reset_color  2nd commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3        $reset_color 1st commit"
+    }
+
+    prefix=
+    _fzf_complete_git 'git diff '
+}
+
+@test 'Testing completion: git diff -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git diff -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color  file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git diff -- '
+}
+
+@test 'Testing completion in subdirectory: git diff -- **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 2
+        assert $1 matches '--ansi --read0 --print0 --multi '
+        assert $2 same_as 'git diff -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git diff -- '
+}
+
 @test 'Testing completion: git log **' {
     _fzf_complete() {
         assert $# equals 2


### PR DESCRIPTION
The options is not considered.

```sh
git diff [<options>] [--] [<path>…​]
git diff [<options>] --no-index [--] <path> <path>
git diff [<options>] --cached [<commit>] [--] [<path>…​]
git diff [<options>] <commit> [--] [<path>…​]
git diff [<options>] <commit> <commit> [--] [<path>…​]
git diff [<options>] <commit>..<commit> [--] [<path>…​]
git diff [<options>] <commit>...<commit> [--] [<path>…​]
```
https://git-scm.com/docs/git-diff#_description