### PR TITLE
Fix tests/_support/git

### DIFF
--- a/tests/_support/git/directory1/file2
+++ b/tests/_support/git/directory1/file2
@@ -1,2 +1,1 @@
 file2
-file2

--- a/tests/_support/git/file1
+++ b/tests/_support/git/file1
@@ -1,2 +1,1 @@
 file1
-file1


### PR DESCRIPTION
I'm sorry.
The incorrect line was added to `tests/_support/git/file1` and `tests/_support/git/directory1/file2`.
https://github.com/chitoku-k/fzf-zsh-completions/pull/56/files?file-filters%5B%5D=No+extension#diff-9ded6c4709c79021b5c5e2a22f3901e6R2