### PR TITLE
Improve `git checkout **` behaviour

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -115,13 +115,13 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ -z ${${(Q)${(z)arguments}}[(r)--]} ]]; then
-                    _fzf_complete_git-commits '' $@
+                if _fzf_complete_git_parse_argument "${arguments%% -- *}" 1 "${(F)git_options_argument_required}" > /dev/null; then
+                    _fzf_complete_git-ls-files '' '--multi' $@
                     return
                 fi
 
-                if _fzf_complete_git_parse_argument "${arguments%% -- *}" 1 "${(F)git_options_argument_required}" > /dev/null; then
-                    _fzf_complete_git-ls-files '' '--multi' $@
+                if [[ -z ${${(Q)${(z)arguments}}[(r)--]} ]]; then
+                    _fzf_complete_git-commits '' $@
                     return
                 fi
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -66,9 +66,9 @@ _fzf_complete_git() {
     local subcommand=${${(Q)${(z)arguments}}[2]}
     local last_argument=${${(Q)${(z)arguments}}[-1]}
 
-    if [[ $subcommand =~ '(checkout|diff|log|rebase|reset|switch)' ]]; then
+    if [[ $subcommand =~ '(diff|log|rebase|reset|switch)' ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
-            if [[ $subcommand =~ '(checkout|diff)' ]]; then
+            if [[ $subcommand =~ 'diff' ]]; then
                 _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
             fi
@@ -85,6 +85,51 @@ _fzf_complete_git() {
 
     if [[ $subcommand =~ '(branch|cherry-pick|merge|revert)' ]]; then
         _fzf_complete_git-commits '--multi' $@
+        return
+    fi
+
+    if [[ $subcommand = checkout ]]; then
+        local prefix_option completing_option
+        local git_options_argument_required=(-b -B --orphan --conflict --pathspec-from-file)
+        local git_options_argument_optional=()
+
+        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
+            if [[ $completing_option = --* ]]; then
+                prefix_option=$completing_option=
+            else
+                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
+            fi
+        fi
+
+        case $completing_option in
+            -b|-B)
+                return
+                ;;
+
+            --conflict)
+                return
+                ;;
+
+            --pathspec-from-file)
+                return
+                ;;
+
+            *)
+                if [[ -z ${${(Q)${(z)arguments}}[(r)--]} ]]; then
+                    _fzf_complete_git-commits '' $@
+                    return
+                fi
+
+                if _fzf_complete_git_parse_argument "${arguments%% -- *}" 1 "${(F)git_options_argument_required}" > /dev/null; then
+                    _fzf_complete_git-ls-files '' '--multi' $@
+                    return
+                fi
+
+                _fzf_complete_git-unstaged-files '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                return
+                ;;
+        esac
+
         return
     fi
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -88,7 +88,7 @@ _fzf_complete_git() {
         return
     fi
 
-    if [[ $subcommand = checkout ]]; then
+    if [[ $subcommand = 'checkout' ]]; then
         local prefix_option completing_option
         local git_options_argument_required=(-b -B --orphan --conflict --pathspec-from-file)
         local git_options_argument_optional=()
@@ -386,7 +386,7 @@ _fzf_complete_git-unstaged-files() {
         local cdup=$(git rev-parse --show-cdup 2> /dev/null)
 
         for filename in ${(0)files}; do
-            if [[ $previous_status != R ]]; then
+            if [[ $previous_status != 'R' ]]; then
                 awk \
                     -v RS='' \
                     -v cdup=$cdup \

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -250,6 +250,45 @@
     _fzf_complete_git 'git checkout -- file '
 }
 
+@test 'Testing completion: git checkout branch **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git checkout branch '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout branch '
+}
+
 @test 'Testing completion: git checkout branch -- **' {
     run git checkout another-branch
     echo >> ' file3 containing space '

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -112,6 +112,48 @@
     _fzf_complete_git 'git checkout -- '
 }
 
+@test 'Testing completion: git checkout -- file **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git checkout -- file '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color  file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout -- file '
+}
+
 @test 'Testing completion in subdirectory: git checkout -- **' {
     run git checkout another-branch
     mkdir -p directory2/directory3/directory4
@@ -158,6 +200,132 @@
 
     prefix=
     _fzf_complete_git 'git checkout -- '
+}
+
+@test 'Testing completion in subdirectory: git checkout -- file **' {
+    run git checkout another-branch
+    mkdir -p directory2/directory3/directory4
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    echo >> directory2/directory3/file7
+    echo >> directory2/directory3/$'file8\ncontaining\nnewlines'
+    echo >> directory2/directory3/directory4/file9
+
+    cd directory2/directory3
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git checkout -- file '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color ../../ file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color ../../directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color ../../directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color ../../file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout -- file '
+}
+
+@test 'Testing completion: git checkout branch -- **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git checkout branch -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout branch -- '
+}
+
+@test 'Testing completion: git checkout branch -- file **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git checkout branch -- file '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git checkout branch -- file '
 }
 
 @test 'Testing completion: git diff **' {


### PR DESCRIPTION
This PR improves `git checkout **` behaviour as below:

```sh
# Show the unstaged files
git checkout -- **
 > 
  1/1
 >  M modified-file

# Show the result of `git ls-files`
git checkout <tree-ish> [--] **
 > 
  3/3
 > ls-files1
   ls-files2
   ls-files3
```

The completion of the options is not implemented.