### PR TITLE
Improve `git restore` completions

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -403,9 +403,7 @@ _fzf_complete_git-ls-files_post() {
 }
 
 _fzf_complete_git-status-files() {
-    local -A regexes
-    regexes=(staged '^[^ ]' unstaged '^.[^ ]')
-    local files_kind=$1
+    local state=$1
     local git_options=$2
     local fzf_options=$3
     shift 3
@@ -420,12 +418,13 @@ _fzf_complete_git-status-files() {
             if [[ $previous_status != 'R' ]]; then
                 awk \
                     -v RS='' \
+                    -v state=$state \
                     -v cdup=$cdup \
                     -v green=${fg[green]} \
                     -v red=${fg[red]} \
                     -v reset=$reset_color '
                         '$_fzf_complete_awk_functions'
-                        /'${regexes[$files_kind]}'/ {
+                        state == "staged" ? /^[^ ]/ : /^.[^ ]/ {
                             printf "%s%c", colorize_git_status($0, cdup, green, red, reset), 0
                         }
                     ' <<< $filename

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -169,12 +169,12 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ -n ${${(Q)${(z)arguments}}[(r)--source]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s]} ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s[[:alpha:]]#]} ]]; then
                     _fzf_complete_git-ls-files '' '--multi' $@
                     return
                 fi
 
-                if [[ -n ${${(Q)${(z)arguments}}[(r)--staged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#S]} ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--staged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#S[[:alpha:]]#]} ]]; then
                     _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" $@
                     return
                 fi

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -169,12 +169,12 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ ${${(Q)${(z)arguments}}[(r)--source]} = '--source' ]] || [[ ${${(Q)${(z)arguments}}[(r)-s]} = '-s' ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--source]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s]} ]]; then
                     _fzf_complete_git-ls-files '' '--multi' $@
                     return
                 fi
 
-                if [[ ${${(Q)${(z)arguments}}[(r)--staged]} = '--staged' ]] || [[ ${${(Q)${(z)arguments}}[(r)-S]} = '-S' ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--staged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#S]} ]]; then
                     _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" $@
                     return
                 fi

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -169,7 +169,7 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s[[:alpha:]]#]} ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s*]} ]]; then
                     _fzf_complete_git-ls-files '' '--multi' $@
                     return
                 fi

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -848,6 +848,45 @@
     _fzf_complete_git 'git restore -s HEAD '
 }
 
+@test 'Testing completion: git restore -qs HEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git restore -qs HEAD '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -qs HEAD '
+}
+
 @test 'Testing completion: git restore --staged **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
@@ -930,6 +969,48 @@
 
     prefix=
     _fzf_complete_git 'git restore -S '
+}
+
+@test 'Testing completion: git restore -qS **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git restore -qS '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as "${fg[green]}M$reset_color $reset_color  file3 containing space "
+        assert ${actual1[2]} same_as "${fg[green]}M$reset_color $reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as "${fg[green]}M$reset_color $reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -qS '
 }
 
 @test 'Testing completion: git restore --source=**' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -3319,7 +3319,7 @@
     assert ${lines[1]} same_as "' 2nd commit'"
 }
 
-@test 'Testing post: git unstaged files' {
+@test 'Testing post: git status files' {
     input=(
         'M  file1'
         'M  directory1/file2'
@@ -3329,7 +3329,7 @@
         $'?? directory2/file6\ncontaining\nnewlines'
     )
 
-    run _fzf_complete_git-unstaged-files_post <<< ${(pj:\0:)input}
+    run _fzf_complete_git-status-files_post <<< ${(pj:\0:)input}
 
     assert $state equals 0
     assert ${#lines} equals 6

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -736,13 +736,55 @@
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
     _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git restore '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as " $reset_color${fg[red]}M$reset_color  file3 containing space "
+        assert ${actual1[2]} same_as " $reset_color${fg[red]}M$reset_color directory1/file2"
+        assert ${actual1[3]} same_as " $reset_color${fg[red]}M$reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as " $reset_color${fg[red]}M$reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore '
+}
+
+@test 'Testing completion: git restore --source HEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
         assert $2 same_as '--read0'
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore '
+        assert $6 same_as 'git restore --source HEAD '
 
         run cat
         assert ${#lines} equals 3
@@ -764,7 +806,130 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore '
+    _fzf_complete_git 'git restore --source HEAD '
+}
+
+@test 'Testing completion: git restore -s HEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git restore -s HEAD '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -s HEAD '
+}
+
+@test 'Testing completion: git restore --staged **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git restore --staged '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as "${fg[green]}M$reset_color $reset_color  file3 containing space "
+        assert ${actual1[2]} same_as "${fg[green]}M$reset_color $reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as "${fg[green]}M$reset_color $reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore --staged '
+}
+
+@test 'Testing completion: git restore -S **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+    run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git restore -S '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as "${fg[green]}M$reset_color $reset_color  file3 containing space "
+        assert ${actual1[2]} same_as "${fg[green]}M$reset_color $reset_color directory2/file4"
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as "${fg[green]}M$reset_color $reset_color file1"
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -S '
 }
 
 @test 'Testing completion: git restore --source=**' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -770,6 +770,45 @@
     _fzf_complete_git 'git restore '
 }
 
+@test 'Testing completion: git restore --source=HEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git restore --source=HEAD '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore --source=HEAD '
+}
+
 @test 'Testing completion: git restore --source HEAD **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
@@ -848,6 +887,45 @@
     _fzf_complete_git 'git restore -s HEAD '
 }
 
+@test 'Testing completion: git restore -sHEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git restore -sHEAD '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -sHEAD '
+}
+
 @test 'Testing completion: git restore -qs HEAD **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
@@ -885,6 +963,45 @@
 
     prefix=
     _fzf_complete_git 'git restore -qs HEAD '
+}
+
+@test 'Testing completion: git restore -qsHEAD **' {
+    run git checkout another-branch
+    echo >> ' file3 containing space '
+    echo >> directory2/$'file4\ncontaining\nnewlines'
+    echo >> ' file5 containing space '
+    echo >> directory2/$'file6\ncontaining\nnewlines'
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git restore -qsHEAD '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 2
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git restore -qsHEAD '
 }
 
 @test 'Testing completion: git restore --staged **' {
@@ -971,7 +1088,7 @@
     _fzf_complete_git 'git restore -S '
 }
 
-@test 'Testing completion: git restore -qS **' {
+@test 'Testing completion: git restore -qSq **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
     echo >> directory2/$'file4\ncontaining\nnewlines'
@@ -989,7 +1106,7 @@
         assert $6 matches '--preview=*'
         assert $7 same_as '--reverse'
         assert $8 same_as '--'
-        assert $9 same_as 'git restore -qS '
+        assert $9 same_as 'git restore -qSq '
 
         run cat
         assert ${#lines} equals 3
@@ -1010,7 +1127,7 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -qS '
+    _fzf_complete_git 'git restore -qSq '
 }
 
 @test 'Testing completion: git restore --source=**' {


### PR DESCRIPTION
The completions of `git restore` that are shown are changed by the options.

- `--source` or `-s`
  The result of `git ls-files` is shown.
- `--staged` or `-S`
  The staged files are shown.
- other
  The unstaged files are shown.

https://git-scm.com/docs/git-restore