### PR TITLE
Move git option parser to core/parser

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -110,7 +110,7 @@ _fzf_complete_git() {
         local git_options_argument_required=(-b -B --orphan --conflict --pathspec-from-file)
         local git_options_argument_optional=()
 
-        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
+        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
             else
@@ -132,7 +132,7 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if _fzf_complete_git_parse_argument "${arguments%% -- *}" 1 "${(F)git_options_argument_required}" > /dev/null; then
+                if _fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}" > /dev/null; then
                     _fzf_complete_git-ls-files '' '--multi' $@
                     return
                 fi
@@ -155,7 +155,7 @@ _fzf_complete_git() {
         local git_options_argument_required=(--source -s)
         local git_options_argument_optional=()
 
-        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
+        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
             else
@@ -196,7 +196,7 @@ _fzf_complete_git() {
         local git_options_argument_required=(-c -C --fixup --reedit-message --reuse-message --squash -m --message --author --date -F -t --file --pathspec-from-file --template --cleanup)
         local git_options_argument_optional=(-u --untracked-files)
 
-        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" ${(F)git_options_argument_required} ${(F)git_options_argument_optional}); then
+        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)git_options_argument_required}" "${(F)git_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
             else
@@ -249,7 +249,7 @@ _fzf_complete_git() {
         local git_options_argument_required=(--cleanup --date --depth --deepen --negotiation-tip -o -s --server-option --shallow-exclude --shallow-since --strategy --strategy-option --strategy-option=diff-algorithm --upload-pack -X)
         local git_options_argument_optional=(--gpg-sign --log --rebase --recurse-submodules -S)
 
-        if completing_option=$(_fzf_complete_git_parse_completing_option "$prefix" "$last_argument" ${(F)git_options_argument_required} ${(F)git_options_argument_optional}); then
+        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" ${(F)git_options_argument_required} ${(F)git_options_argument_optional}); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
             else
@@ -319,7 +319,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_git_parse_argument "$arguments" 1 "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-remotes '' $@
                     return
                 fi
@@ -520,100 +520,12 @@ _fzf_complete_git_resolve_alias() {
     echo $git_alias_resolved
 }
 
-_fzf_complete_git_parse_completing_option() {
-    local prefix=$1
-    local last_argument=$2
-    local options_argument_required=(${(z)3})
-    local options_argument_optional=(${(z)4})
-    shift 4
-
-    local current=$prefix
-    local completing_option
-    local completing_option_source
-
-    while [[ -n $current ]]; do
-        case $current in
-            -[A-Za-z]*)
-                if [[ -n ${options_argument_required[(r)${current:0:2}]} ]] || [[ -n ${options_argument_optional[(r)${current:0:2}]} ]]; then
-                    completing_option=${current:0:2}
-                    completing_option_source=prefix
-                    break
-                fi
-                ;;
-
-            --*)
-                if [[ -n ${options_argument_required[(r)${current%=*}]} ]] || [[ -n ${options_argument_optional[(r)${current%=*}]} ]]; then
-                    completing_option=${current%=*}
-                    completing_option_source=prefix
-                    break
-                fi
-                ;;
-        esac
-
-        if [[ $current != -[A-Za-z][A-Za-z]* ]]; then
-            break
-        fi
-
-        current=${current/-[A-Za-z]/-}
-    done
-
-    current=$last_argument
-
-    while [[ -n $current ]]; do
-        if [[ -n ${options_argument_required[(r)$current]} ]]; then
-            completing_option=$current
-            completing_option_source=last_argument
-            break
-        fi
-
-        if [[ $current != -[A-Za-z][A-Za-z]* ]]; then
-            break
-        fi
-
-        current=${current/-[A-Za-z]/-}
-    done
-
-    echo $completing_option
-    case $completing_option_source in
-        prefix)
-            return 0
-            ;;
-
-        last_argument)
-            return 1
-            ;;
-
-        *)
-            return 2
-            ;;
-    esac
-}
-
 _fzf_complete_git_parse_argument() {
-    local arguments=(${(z)1})
-    local index=$2
-    local options_argument_required=(${(z)3})
-    shift 3
+    local arguments=(${(z)2})
 
     if (( ${#arguments} <= 2 )); then
         return 1
     fi
 
-    local i
-    local command_arguments=()
-    for i in {3..${#arguments}}; do
-        if [[ ${(Q)arguments[$i]} = -(#c1,2)* ]]; then
-            continue
-        fi
-
-        local previous_argument=$(_fzf_complete_git_parse_completing_option '' ${(Q)arguments[(( i - 1 ))]} $options_argument_required '' )
-        if [[ -n $previous_argument ]] && [[ ${options_argument_required[(r)$previous_argument]} = $previous_argument ]]; then
-            continue
-        fi
-
-        command_arguments+=${arguments[$i]}
-    done
-
-    echo ${command_arguments[$index]}
-    return $(( index > #command_arguments ))
+    _fzf_complete_parse_argument 3 $@
 }

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,0 +1,100 @@
+#!/usr/bin/env zsh
+
+_fzf_complete_parse_completing_option() {
+    local prefix=$1
+    local last_argument=$2
+    local options_argument_required=(${(z)3})
+    local options_argument_optional=(${(z)4})
+    shift 4
+
+    local current=$prefix
+    local completing_option
+    local completing_option_source
+
+    while [[ -n $current ]]; do
+        case $current in
+            -[A-Za-z]*)
+                if [[ -n ${options_argument_required[(r)${current:0:2}]} ]] || [[ -n ${options_argument_optional[(r)${current:0:2}]} ]]; then
+                    completing_option=${current:0:2}
+                    completing_option_source=prefix
+                    break
+                fi
+                ;;
+
+            --*)
+                if [[ -n ${options_argument_required[(r)${current%=*}]} ]] || [[ -n ${options_argument_optional[(r)${current%=*}]} ]]; then
+                    completing_option=${current%=*}
+                    completing_option_source=prefix
+                    break
+                fi
+                ;;
+        esac
+
+        if [[ $current != -[A-Za-z][A-Za-z]* ]]; then
+            break
+        fi
+
+        current=${current/-[A-Za-z]/-}
+    done
+
+    current=$last_argument
+
+    while [[ -n $current ]]; do
+        if [[ -n ${options_argument_required[(r)$current]} ]]; then
+            completing_option=$current
+            completing_option_source=last_argument
+            break
+        fi
+
+        if [[ $current != -[A-Za-z][A-Za-z]* ]]; then
+            break
+        fi
+
+        current=${current/-[A-Za-z]/-}
+    done
+
+    echo - $completing_option
+    case $completing_option_source in
+        prefix)
+            return 0
+            ;;
+
+        last_argument)
+            return 1
+            ;;
+
+        *)
+            return 2
+            ;;
+    esac
+}
+
+_fzf_complete_parse_argument() {
+    local start_index=$1
+    local index=$2
+    local arguments=(${(z)3})
+    local options_argument_required=(${(z)4})
+    shift 4
+
+    if [[ ${#arguments} = 0 ]]; then
+        return 1
+    fi
+
+    local i
+    local command_arguments=()
+    for i in {$start_index..${#arguments}}; do
+        if [[ ${(Q)arguments[$i]} = -(#c1,2)* ]]; then
+            continue
+        fi
+
+        local previous_argument=$(_fzf_complete_parse_completing_option '' ${(Q)arguments[i - 1]} ${(F)options_argument_required} '')
+        if [[ -n $previous_argument ]] && [[ ${options_argument_required[(r)$previous_argument]} = $previous_argument ]]; then
+            continue
+        fi
+
+        command_arguments+=${arguments[$i]}
+    done
+
+    echo - ${command_arguments[$index]}
+    return $(( index > #command_arguments ))
+}


### PR DESCRIPTION
Refactors the functions originally designed to parse git options so it can be generally used in other completions by changing their signature and names to `_fzf_complete_parse_completing_option` and `_fzf_complete_parse_completing_option`. Furthermore, a bugfix for `echo $var` producing none where `$var` is `-n` has been involved 🤯 .