### PR TITLE
Support generic resources in kubectl completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,27 @@ git rebase -i **<TAB>
   - rm
   - switch
 - kubectl
-  - describe (pods)
+  - annotate
+  - apply
+  - autoscale
+  - cordon
+  - create
+  - delete
+  - describe
+  - drain
+  - edit
   - exec
-  - get (pods)
+  - explain
+  - expose
+  - get
+  - label
   - logs
+  - patch
+  - port-forward
+  - rollout
+  - set
+  - taint
+  - uncordon
 - make
 - npm
   - run

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -164,7 +164,7 @@ _fzf_complete_git() {
         case $completing_option in
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             --gpg-sign|-S)
@@ -172,7 +172,7 @@ _fzf_complete_git() {
 
             --strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                _fzf_complete_git_constants '' "${(F)strategies}" $@
+                _fzf_complete_constants '' "${(F)strategies}" $@
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -197,7 +197,7 @@ _fzf_complete_git() {
                     subtree=
                     theirs
                 )
-                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)strategy_options}" $@
+                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" $@
                 ;;
 
             *)
@@ -282,12 +282,12 @@ _fzf_complete_git() {
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -u|--untracked-files)
                 local untracked_file_modes=(no normal all)
-                _fzf_complete_git_constants '' "${(F)untracked_file_modes}" $@
+                _fzf_complete_constants '' "${(F)untracked_file_modes}" $@
                 ;;
 
             *)
@@ -321,17 +321,17 @@ _fzf_complete_git() {
         case $completing_option in
             --recurse-submodules)
                 local recurse_submodules=(yes on-demand no)
-                _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules}" $@
                 ;;
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -s|--strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                _fzf_complete_git_constants '' "${(F)strategies}" $@
+                _fzf_complete_constants '' "${(F)strategies}" $@
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -356,12 +356,12 @@ _fzf_complete_git() {
                     subtree=
                     theirs
                 )
-                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)strategy_options}" $@
+                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" $@
                 ;;
 
             --rebase)
                 local rebases=(false interactive merges preserve true)
-                _fzf_complete_git_constants '' "${(F)rebases}" $@
+                _fzf_complete_constants '' "${(F)rebases}" $@
                 ;;
 
             --shallow-exclude)
@@ -412,7 +412,7 @@ _fzf_complete_git() {
         case $completing_option in
             --signed)
                 local signed=(false if-asked true)
-                _fzf_complete_git_constants '' "${(F)signed}" $@
+                _fzf_complete_constants '' "${(F)signed}" $@
                 ;;
 
             -o|--push-option)
@@ -431,7 +431,7 @@ _fzf_complete_git() {
 
             --recurse-submodules)
                 local recurse_submodules=(check no on-demand only)
-                _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules}" $@
                 ;;
 
             *)
@@ -622,28 +622,6 @@ _fzf_complete_git-refs_post() {
     for ref in ${(f)input}; do
         echo ${${ref#*/}%% *}
     done
-}
-
-_fzf_complete_git_constants() {
-    local fzf_options=$1
-    local values=$2
-    shift 2
-
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(echo $values)
-}
-
-_fzf_complete_git_constants_post() {
-    local input=$(cat)
-
-    if [[ -z $input ]]; then
-        return
-    fi
-
-    if [[ $input = *= ]]; then
-        echo -n $input
-    else
-        echo $input
-    fi
 }
 
 _fzf_complete_git_resolve_alias() {

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -177,6 +177,11 @@ _fzf_complete_kubectl() {
         return
     fi
 
+    if [[ ${subcommands[1]} = 'explain' ]]; then
+        _fzf_complete_kubectl-resources '' $@
+        return
+    fi
+
     if [[ ${subcommands[1]} = 'port-forward' ]]; then
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -107,7 +107,7 @@ _fzf_complete_kubectl() {
     )
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_kubectl-parse-namespace $@)
+    namespace=$(_fzf_complete_kubectl-parse-namespace $@$RBUFFER)
 
     if [[ ${subcommands[1]} =~ '^(rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -149,6 +149,32 @@ _fzf_complete_kubectl() {
         return
     fi
 
+    if [[ ${subcommands[1]} =~ '^(autoscale|create|edit|expose|patch)$' ]]; then
+        if [[ -z $resource ]]; then
+            _fzf_complete_kubectl-resources '' $@
+            return
+        fi
+
+        _fzf_complete_kubectl-resource-names '' $@
+        return
+    fi
+
+    if [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
+        resource=nodes
+        _fzf_complete_kubectl-resource-names '' $@
+        return
+    fi
+
+    if [[ ${subcommands[1]} =~ '^(delete|describe|get)$' ]]; then
+        if [[ -z $resource ]]; then
+            _fzf_complete_kubectl-resources '' $@
+            return
+        fi
+
+        _fzf_complete_kubectl-resource-names '--multi' $@
+        return
+    fi
+
     if [[ ${subcommands[1]} =~ '^(exec|logs)$' ]]; then
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
@@ -199,16 +225,6 @@ _fzf_complete_kubectl() {
         return
     fi
 
-    if [[ ${subcommands[1]} =~ '^(describe|expose|get|patch)$' ]]; then
-        if [[ -z $resource ]]; then
-            _fzf_complete_kubectl-resources '' $@
-            return
-        fi
-
-        _fzf_complete_kubectl-resource-names '--multi' $@
-        return
-    fi
-
     if [[ ${subcommands[1]} = 'rollout' ]]; then
         if [[ ${#subcommands[@]} != 2 ]]; then
             local rollout_subcommands=(history pause restart resume status undo)
@@ -246,12 +262,6 @@ _fzf_complete_kubectl() {
             _fzf_complete_kubectl-containers '' $@
             return
         fi
-        return
-    fi
-
-    if [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
-        resource=nodes
-        _fzf_complete_kubectl-resource-names '' $@
         return
     fi
 

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -267,7 +267,7 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ ${subcommands[2]} = 'image' ]]; then
-            _fzf_complete_kubectl-containers '' $@
+            _fzf_complete_kubectl-containers '--multi' $@
             return
         fi
         return
@@ -280,12 +280,11 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ -z $name ]]; then
-            resource=nodes
             _fzf_complete_kubectl-resource-names '' $@
             return
         fi
 
-        _fzf_complete_kubectl-taints '' $@
+        _fzf_complete_kubectl-taints '--multi' $@
         return
     fi
 
@@ -348,11 +347,12 @@ _fzf_complete_kubectl-containers() {
 }
 
 _fzf_complete_kubectl-containers_post() {
-    if [[ ${subcommands[@]} != 'set image' ]]; then
-        awk '{ print $1 }'
-    else
+    if [[ ${subcommands[1]} = 'set' ]] && [[ ${subcommands[2]} = 'image' ]]; then
         awk '{ printf "%s=%s", $1, $2 }'
+        return
     fi
+
+    awk '{ print $1 }'
 }
 
 _fzf_complete_kubectl-ports() {
@@ -437,7 +437,7 @@ _fzf_complete_kubectl-taints() {
 }
 
 _fzf_complete_kubectl-taints_post() {
-    awk '{ printf "%s=%s:%s", $1, $2, $3 }'
+    awk '{ printf "%s%s=%s:%s", (NR > 1 ? "\n" : ""), $1, $2, $3 }'
 }
 
 _fzf_complete_kubectl-resource-names() {

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -109,11 +109,13 @@ _fzf_complete_kubectl() {
     subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
     namespace=$(_fzf_complete_kubectl-parse-namespace $@)
 
-    if [[ ${subcommands[1]} =~ ^(rollout|set)$ ]]; then
+    if [[ ${subcommands[1]} =~ '^(rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))
         resource=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "$arguments" "${(F)kubectl_options_argument_required}" || :)
     else
         resource=$(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
     fi
 
     if [[ $resource = */* ]]; then
@@ -123,9 +125,8 @@ _fzf_complete_kubectl() {
         resource=${prefix%/*}
         prefix_option=${prefix%/*}/
         prefix=${prefix#$prefix_option}
-    else
-        name=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
     fi
+
 
     if [[ ${subcommands[1]} =~ '^(exec|logs)$' ]]; then
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -6,18 +6,42 @@ colors
 _fzf_complete_kubectl() {
     local arguments=$@
     local last_argument=${${(Q)${(z)@}}[-1]}
+    local prefix_option resource name
 
     if [[ $last_argument =~ '(-[^-]*n|--namespace)$' ]]; then
-        _fzf_complete_kubectl-namespaces '' $@
+        resource=namespaces
+        _fzf_complete_kubectl-resource-names '' $@
         return
     fi
 
-    if [[ $prefix =~ '(-[^-]*n|--namespace=)' ]]; then
+    if [[ $prefix =~ '^(-[^-]*n|--namespace=)' ]]; then
         if [[ $prefix = --* ]]; then
-            prefix_option=${prefix/=*/=} _fzf_complete_kubectl-namespaces '' $@
+            resource=namespaces \
+            prefix_option=${prefix/=*/=} \
+            prefix=${prefix#$prefix_option} \
+                _fzf_complete_kubectl-resource-names '' $@
         else
-            prefix_option=${prefix%%n*}n _fzf_complete_kubectl-namespaces '' $@
+            resource=namespaces \
+            prefix_option=${prefix%%n*}n \
+            prefix=${prefix#$prefix_option} \
+                _fzf_complete_kubectl-resource-names '' $@
         fi
+        return
+    fi
+
+    if [[ $last_argument =~ '(-[^-]*f|--filename)$' ]]; then
+        _fzf_path_completion "$prefix" $@
+        return
+    fi
+
+    if [[ $prefix =~ '^(-[^-]*f|--filename=)' ]]; then
+        if [[ $prefix = --* ]]; then
+            prefix_option=${prefix/=*/=}
+        else
+            prefix_option=${prefix%%f*}f
+        fi
+
+        __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
         return
     fi
 
@@ -82,32 +106,80 @@ _fzf_complete_kubectl() {
         --vmodule
     )
 
-    local subcommand resource
-    subcommand=$(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}")
-    resource=$(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}")
+    local subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}"))
+    local namespace=$(_fzf_complete_kubectl-parse-namespace $@)
 
-    if [[ $subcommand =~ 'exec|logs' ]]; then
+    if [[ ${subcommands[1]} =~ '^(rollout|set)$' ]]; then
+        subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}"))
+        resource=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}")
+    else
+        resource=$(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}")
+    fi
+
+    if [[ $resource = */* ]]; then
+        name=${resource#*/}
+        resource=${resource%/*}
+    elif [[ -z $resource ]] && [[ $prefix =~ / ]]; then
+        resource=${prefix%/*}
+        prefix_option=${prefix%/*}/
+        prefix=${prefix#$prefix_option}
+    else
+        name=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}")
+    fi
+
+    if [[ ${subcommands[1]} =~ '^(exec|logs|port-forward)$' ]]; then
+        if [[ -z $name ]]; then
+            name=$resource
+            resource=pods
+        fi
+
         if [[ $last_argument =~ '(-[^-]*c|--container)$' ]]; then
             _fzf_complete_kubectl-containers '' $@
             return
         fi
 
-        if [[ $prefix =~ '-[^-]*c|--container=' ]]; then
+        if [[ $prefix =~ '^(-[^-]*c|--container=)' ]]; then
             if [[ $prefix = --* ]]; then
-                prefix_option=${prefix/=*/=} _fzf_complete_kubectl-containers '' $@
+                prefix_option=${prefix/=*/=} \
+                prefix=${prefix#$prefix_option} \
+                    _fzf_complete_kubectl-containers '' $@
             else
-                prefix_option=${prefix%%n*}n _fzf_complete_kubectl-containers '' $@
+                prefix_option=${prefix%%c*}c \
+                prefix=${prefix#$prefix_option} \
+                    _fzf_complete_kubectl-containers '' $@
             fi
             return
         fi
 
-        _fzf_complete_kubectl-pods '' $@
+        _fzf_complete_kubectl-resource-names '' $@
         return
     fi
 
-    if [[ $subcommand =~ 'describe|get' ]] && [[ $resource =~ 'po|pod|pods' ]]; then
-        _fzf_complete_kubectl-pods '' $@
-        return
+    if [[ ${subcommands[1]} =~ '^(annotate|describe|expose|get|label|patch)$' ]]; then
+        if [[ -z $resource ]]; then
+            _fzf_complete_kubectl-resources '' $@
+            return
+        fi
+
+        _fzf_complete_kubectl-resource-names '--multi' $@
+    fi
+
+    if [[ ${subcommands[1]} = 'rollout' ]]; then
+        if [[ ${#subcommands[@]} != 2 ]]; then
+            return
+        fi
+
+        if [[ -z $resource ]]; then
+            _fzf_complete_kubectl-resources '' $@
+            return
+        fi
+
+        _fzf_complete_kubectl-resource-names '--multi' $@
+    fi
+
+    if [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
+        resource=nodes
+        _fzf_complete_kubectl-resource-names '' $@
     fi
 }
 
@@ -116,7 +188,7 @@ _fzf_complete_kubectl-parse-namespace() {
 
     if [[ -n ${(Q)${(z)@}[(r)-[^-]#n?##]} ]]; then
         idx=${(Q)${(z)@}[(i)-[^-]#n?##]}
-        namespace=${(Q)${(z)@}[idx]/-[^-]#n/}
+        namespace=${(Q)${(z)@}[idx]/-[^-n]#n/}
     fi
 
     if [[ -n ${(Q)${(z)@}[(r)-[^-]#n]} ]]; then
@@ -137,63 +209,79 @@ _fzf_complete_kubectl-parse-namespace() {
     echo - $namespace
 }
 
-_fzf_complete_kubectl-namespaces() {
+_fzf_complete_kubectl-resources() {
     local fzf_options=$1
     shift
 
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
-        kubectl get namespaces |
-        awk -v prefix_option=$prefix_option '{ print (NR == 1 ? "" : prefix_option) $1, $2, $3 }' |
-        _fzf_complete_tabularize $fg[yellow] $reset_color
+        kubectl api-resources --cached --verbs=get |
+        _fzf_complete_colorize $fg[yellow]
     )
 }
 
-_fzf_complete_kubectl-namespaces_post() {
+_fzf_complete_kubectl-resources_post() {
     awk '{ print $1 }'
-}
-
-_fzf_complete_kubectl-pods() {
-    local fzf_options=$1
-    shift
-
-    local arguments=()
-    local namespace=$(_fzf_complete_kubectl-parse-namespace $@)
-
-    if [[ -z $namespace ]]; then
-        arguments+=(--all-namespaces)
-    else
-        arguments+=(--namespace=$namespace)
-    fi
-
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
-        kubectl get pods -o wide ${(Q)${(z)arguments}} |
-        awk -v n=$namespace '
-            n != "" { print $1, $2, $3, $4, $5, $6, $7 }
-            n == "" { print $1, $2, $3, $4, $5, $6, $7, $8 }' |
-        if [[ -n $namespace ]]; then
-            _fzf_complete_tabularize $fg[yellow] $reset_color{,,,,,}
-        else
-            _fzf_complete_tabularize $fg[green] $fg[yellow] $reset_color{,,,,,}
-        fi
-    )
-}
-
-_fzf_complete_kubectl-pods_post() {
-    if [[ -n $namespace ]]; then
-        awk '{ print $1 }'
-    else
-        awk '{ print "--namespace=" $1, $2 }'
-    fi
 }
 
 _fzf_complete_kubectl-containers() {
     local fzf_options=$1
     shift
 
-    local namespace=$(_fzf_complete_kubectl-parse-namespace $@)
-    local pod=$(_fzf_complete_parse_argument 2 2 "$@" "${(F)kubectl_options_argument_required}")
+    local arguments=()
+    if [[ -n $namespace ]]; then
+        arguments+=(--namespace=$namespace)
+    fi
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
-        kubectl get pod $pod -n ${namespace:-default} -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}'
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+        kubectl get pod $name ${(Q)${(z)arguments}} -o jsonpath='{"NAME\tIMAGE\n"}{range .spec.containers[*]}{.name}{"\t"}{.image}{"\n"}{end}' 2> /dev/null |
+        _fzf_complete_tabularize $fg[yellow] $reset_color
     )
+}
+
+_fzf_complete_kubectl-containers_post() {
+    awk '{ print $1 }'
+}
+
+_fzf_complete_kubectl-resource-names() {
+    local fzf_options=$1
+    shift
+
+    local arguments=()
+    if [[ -z $namespace ]]; then
+        arguments+=(--all-namespaces)
+    else
+        arguments+=(--namespace=$namespace)
+    fi
+
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+        local result=$(kubectl get "$resource" -o wide ${(Q)${(z)arguments}} 2> /dev/null)
+        if [[ $result = NAMESPACE\ * ]]; then
+            _fzf_complete_colorize $fg[green] $fg[yellow] | awk '{ print SUBSEP $0 }'
+        else
+            _fzf_complete_colorize $fg[yellow]
+        fi <<< "$result"
+    )
+}
+
+_fzf_complete_kubectl-resource-names_post() {
+    awk \
+        -v prefix_option=$prefix_option '
+        NR > 1 && prefix_option ~ /\/$/ {
+            printf "%s", prefix_option
+        }
+        /^\x1c/ {
+            sub(SUBSEP, "", $1)
+            namespace = $1
+            print $2
+            next
+        }
+        {
+            print $1
+        }
+        END {
+            if (namespace != "") {
+                print "--namespace=" namespace
+            }
+        }
+    '
 }

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -385,7 +385,7 @@ _fzf_complete_kubectl-annotations() {
     fi
 
     _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
-        kubectl get "$resource" "$name" ${(Q)${(z)arguments}} -o jsonpath='{.metadata.annotations}' 2> /dev/null | jq -r 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
+        kubectl get "$resource" "$name" ${(Q)${(z)arguments}} -o jsonpath='{.metadata.annotations}' 2> /dev/null | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
     )
 }
 

--- a/src/core/completions.zsh
+++ b/src/core/completions.zsh
@@ -1,0 +1,21 @@
+_fzf_complete_constants() {
+    local fzf_options=$1
+    local values=$2
+    shift 2
+
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(echo $values)
+}
+
+_fzf_complete_constants_post() {
+    local input=$(cat)
+
+    if [[ -z $input ]]; then
+        return
+    fi
+
+    if [[ $input = *= ]]; then
+        echo -n $input
+    else
+        echo $input
+    fi
+}

--- a/src/core/formatter.zsh
+++ b/src/core/formatter.zsh
@@ -38,3 +38,36 @@ _fzf_complete_tabularize() {
         }
     '
 }
+
+_fzf_complete_colorize() {
+    if [[ $# = 0 ]]; then
+        cat
+        return
+    fi
+
+    awk \
+        -v colors_args=${(pj: :)@} \
+        -v reset=$reset_color '
+        BEGIN {
+            split(colors_args, colors, " ")
+            fields[1] = 1
+        }
+        NR == 1 {
+            for (i = 2; i <= length($0); ++i) {
+                if (substr($0, i - 1, 1) == " " && substr($0, i, 1) != " ") {
+                    fields[length(fields) + 1] = i
+                }
+            }
+        }
+        {
+            total = 0
+            for (i = 1; i<= length(colors); ++i) {
+                width = fields[i + 1] - fields[i] < 0 ? length($0) : fields[i + 1] - fields[i]
+                total += width
+                printf "%s%s%s", colors[i], substr($0, fields[i], width), reset
+            }
+
+            printf "%s\n", substr($0, total)
+        }
+    '
+}

--- a/src/core/formatter.zsh
+++ b/src/core/formatter.zsh
@@ -67,7 +67,7 @@ _fzf_complete_colorize() {
                 printf "%s%s%s", colors[i], substr($0, fields[i], width), reset
             }
 
-            printf "%s\n", substr($0, total)
+            printf "%s\n", substr($0, total + 1)
         }
     '
 }

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -76,7 +76,7 @@ _fzf_complete_parse_argument() {
     local options_argument_required=(${(z)4})
     shift 4
 
-    if [[ ${#arguments} = 0 ]]; then
+    if (( ${#arguments} < $start_index )); then
         return 1
     fi
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -4253,7 +4253,7 @@
         '--strategy-option=subtree'
     )
 
-    run _fzf_complete_git_constants_post <<< ${(F)input} \| tr '\n' ' '
+    run _fzf_complete_constants_post <<< ${(F)input} \| tr '\n' ' '
 
     assert $state equals 0
     assert ${#lines} equals 1
@@ -4266,7 +4266,7 @@
         '--strategy-option=subtree='
     )
 
-    run _fzf_complete_git_constants_post <<< ${(F)input} \| tr '\n' ' '
+    run _fzf_complete_constants_post <<< ${(F)input} \| tr '\n' ' '
 
     assert $state equals 0
     assert ${#lines} equals 1

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -617,7 +617,7 @@
     _fzf_complete_kubectl 'kubectl annotate pods/etcd-minikube '
 }
 
-@test 'Testing completion: kubectl label **' {
+@test 'Testing completion: kubectl autoscale **' {
     kubectl_mock_1() {
         assert $# equals 3
         assert $1 same_as 'api-resources'
@@ -641,7 +641,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl label '
+        assert $5 same_as 'kubectl autoscale '
 
         run cat
         assert ${#lines} equals 9
@@ -657,10 +657,10 @@
     }
 
     prefix=
-    _fzf_complete_kubectl 'kubectl label '
+    _fzf_complete_kubectl 'kubectl autoscale '
 }
 
-@test 'Testing completion: kubectl label pods **' {
+@test 'Testing completion: kubectl autoscale pods **' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -684,7 +684,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl label pods '
+        assert $5 same_as 'kubectl autoscale pods '
 
         run cat
         assert ${#lines} equals 7
@@ -698,10 +698,10 @@
     }
 
     prefix=
-    _fzf_complete_kubectl 'kubectl label pods '
+    _fzf_complete_kubectl 'kubectl autoscale pods '
 }
 
-@test 'Testing completion: kubectl label pods/**' {
+@test 'Testing completion: kubectl autoscale pods/**' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -725,7 +725,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl label pods/'
+        assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
         assert ${#lines} equals 7
@@ -739,74 +739,10 @@
     }
 
     prefix=pods/
-    _fzf_complete_kubectl 'kubectl label '
+    _fzf_complete_kubectl 'kubectl autoscale '
 }
 
-@test 'Testing completion: kubectl label pods etcd-minikube **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.metadata.labels}'
-
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-    }
-
-    _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'kubectl label pods etcd-minikube '
-
-        run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
-        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
-}
-
-@test 'Testing completion: kubectl label pods/etcd-minikube **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.metadata.labels}'
-
-        echo '{"component":"etcd","tier":"control-plane"}'
-    }
-
-    _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'kubectl label pods/etcd-minikube '
-
-        run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
-        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
-}
-
-@test 'Testing completion: kubectl label pods ** --namespace=kube-system' {
+@test 'Testing completion: kubectl autoscale pods ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -830,7 +766,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl label pods '
+        assert $5 same_as 'kubectl autoscale pods '
 
         run cat
         assert ${#lines} equals 7
@@ -845,10 +781,10 @@
 
     RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl label pods '
+    _fzf_complete_kubectl 'kubectl autoscale pods '
 }
 
-@test 'Testing completion: kubectl label pods/** --namespace=kube-system' {
+@test 'Testing completion: kubectl autoscale pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -872,7 +808,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl label pods/'
+        assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
         assert ${#lines} equals 7
@@ -887,20 +823,997 @@
 
     RBUFFER=' --namespace=kube-system'
     prefix=pods/
-    _fzf_complete_kubectl 'kubectl label '
+    _fzf_complete_kubectl 'kubectl autoscale '
 }
 
-@test 'Testing completion: kubectl label pods etcd-minikube ** --namespace=kube-system' {
+@test 'Testing completion: kubectl create **' {
     kubectl_mock_1() {
-        assert $# equals 6
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl create '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl create '
+}
+
+@test 'Testing completion: kubectl create pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '--namespace=kube-system'
-        assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.metadata.labels}'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl create pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl create pods '
+}
+
+@test 'Testing completion: kubectl create pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl create pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl create '
+}
+
+@test 'Testing completion: kubectl create pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl create pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl create pods '
+}
+
+@test 'Testing completion: kubectl create pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl create pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl create '
+}
+
+@test 'Testing completion: kubectl edit **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl edit '
+}
+
+@test 'Testing completion: kubectl edit pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl edit pods '
+}
+
+@test 'Testing completion: kubectl edit pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl edit '
+}
+
+@test 'Testing completion: kubectl edit pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl edit pods '
+}
+
+@test 'Testing completion: kubectl edit pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl edit '
+}
+
+@test 'Testing completion: kubectl expose **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl expose '
+}
+
+@test 'Testing completion: kubectl expose pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl expose pods '
+}
+
+@test 'Testing completion: kubectl expose pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl expose '
+}
+
+@test 'Testing completion: kubectl expose pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl expose pods '
+}
+
+@test 'Testing completion: kubectl expose pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl expose '
+}
+
+@test 'Testing completion: kubectl patch **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl patch '
+}
+
+@test 'Testing completion: kubectl patch pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl patch pods '
+}
+
+@test 'Testing completion: kubectl patch pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl patch '
+}
+
+@test 'Testing completion: kubectl patch pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl patch pods '
+}
+
+@test 'Testing completion: kubectl patch pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl patch '
+}
+
+@test 'Testing completion: kubectl cordon **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'nodes'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME       STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME'
+        echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl cordon '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
+        assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl cordon '
+}
+
+@test 'Testing completion: kubectl drain **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'nodes'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME       STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME'
+        echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl drain '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
+        assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl drain '
+}
+
+@test 'Testing completion: kubectl uncordon **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'nodes'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME       STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME'
+        echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl uncordon '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
+        assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl uncordon '
+}
+
+@test 'Testing completion: kubectl delete **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl delete '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl delete '
+}
+
+@test 'Testing completion: kubectl delete pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
     _fzf_complete() {
@@ -910,31 +1823,39 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl label pods etcd-minikube '
+        assert $6 same_as 'kubectl delete pods '
 
         run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
-        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
-    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+    _fzf_complete_kubectl 'kubectl delete pods '
 }
 
-@test 'Testing completion: kubectl label pods/etcd-minikube ** --namespace=kube-system' {
+@test 'Testing completion: kubectl delete pods/**' {
     kubectl_mock_1() {
-        assert $# equals 6
+        assert $# equals 5
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '--namespace=kube-system'
-        assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.metadata.labels}'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
     _fzf_complete() {
@@ -944,18 +1865,533 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl label pods/etcd-minikube '
+        assert $6 same_as 'kubectl delete pods/'
 
         run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
-        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl delete '
+}
+
+@test 'Testing completion: kubectl delete pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl delete pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
     RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+    _fzf_complete_kubectl 'kubectl delete pods '
+}
+
+@test 'Testing completion: kubectl delete pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl delete pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl delete '
+}
+
+@test 'Testing completion: kubectl describe **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl describe '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl describe '
+}
+
+@test 'Testing completion: kubectl describe pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl describe pods '
+}
+
+@test 'Testing completion: kubectl describe pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl describe '
+}
+
+@test 'Testing completion: kubectl describe pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl describe pods '
+}
+
+@test 'Testing completion: kubectl describe pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl describe '
+}
+
+@test 'Testing completion: kubectl get **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get '
+}
+
+@test 'Testing completion: kubectl get pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl get '
+}
+
+@test 'Testing completion: kubectl get pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl get '
 }
 
 @test 'Testing completion: kubectl exec **' {
@@ -2306,6 +3742,390 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
+@test 'Testing completion: kubectl explain **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl explain '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl explain '
+}
+
+@test 'Testing completion: kubectl label **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods '
+}
+
+@test 'Testing completion: kubectl label pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods/etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.labels}'
+
+        echo '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods '
+}
+
+@test 'Testing completion: kubectl label pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods/etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+}
+
 @test 'Testing completion: kubectl port-forward **' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -2953,6 +4773,711 @@
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
+@test 'Testing completion: kubectl rollout **' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'kubectl rollout '
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as history
+        assert ${lines[2]} same_as pause
+        assert ${lines[3]} same_as restart
+        assert ${lines[4]} same_as resume
+        assert ${lines[5]} same_as status
+        assert ${lines[6]} same_as undo
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl rollout '
+}
+
+@test 'Testing completion: kubectl rollout restart **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl rollout restart '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl rollout restart '
+}
+
+@test 'Testing completion: kubectl rollout restart deployments **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl rollout restart deployments '
+}
+
+@test 'Testing completion: kubectl rollout restart deployments/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=deployments/
+    _fzf_complete_kubectl 'kubectl rollout restart '
+}
+
+@test 'Testing completion: kubectl rollout restart deployments ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl rollout restart deployments '
+}
+
+@test 'Testing completion: kubectl rollout restart deployments/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=deployments/
+    _fzf_complete_kubectl 'kubectl rollout restart '
+}
+
+@test 'Testing completion: kubectl set **' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'kubectl set '
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as env
+        assert ${lines[2]} same_as image
+        assert ${lines[3]} same_as resources
+        assert ${lines[4]} same_as selector
+        assert ${lines[5]} same_as serviceaccount
+        assert ${lines[6]} same_as subject
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl set '
+}
+
+@test 'Testing completion: kubectl set image **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image '
+}
+
+@test 'Testing completion: kubectl set image pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods '
+}
+
+@test 'Testing completion: kubectl set image pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set image '
+}
+
+@test 'Testing completion: kubectl set image pods etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl set image pods/etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl set image pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods '
+}
+
+@test 'Testing completion: kubectl set image pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set image '
+}
+
+@test 'Testing completion: kubectl set image pods etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl set image pods/etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl taint **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl taint '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl taint '
+}
+
+@test 'Testing completion: kubectl taint nodes **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'nodes'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME       STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME'
+        echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl taint nodes '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
+        assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl taint nodes '
+}
+
+@test 'Testing completion: kubectl taint nodes minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'nodes'
+        assert $3 same_as 'minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={range .spec.taints[*]}{.key} {.value} {.effect}{"\\n"}{end}'
+
+        echo 'key1 value1 NoSchedule'
+        echo 'key2 value2 NoExecute'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl taint nodes minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY ${reset_color}  ${reset_color}VALUE ${reset_color}  EFFECT"
+        assert ${lines[2]} same_as "${fg[yellow]}key1${reset_color}  ${reset_color}value1${reset_color}  NoSchedule"
+        assert ${lines[3]} same_as "${fg[yellow]}key2${reset_color}  ${reset_color}value2${reset_color}  NoExecute"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl taint nodes minikube '
+}
+
 @test 'Testing post: a resource name' {
     input=(
         'test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
@@ -3085,13 +5610,26 @@
     assert ${lines[1]} same_as 'app'
 }
 
+@test 'Testing post: a container name and image' {
+    input=(
+        'app  alpine:latest'
+    )
+
+    subcommands=(set image)
+    run _fzf_complete_kubectl-containers_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'app=alpine:latest'
+}
+
 @test 'Testing post: a port number' {
     input=(
         '53    TCP       dns-tcp'
         '9153  TCP       metrics'
     )
 
-    run _fzf_complete_kubectl-containers_post <<< ${(F)input}
+    run _fzf_complete_kubectl-ports_post <<< ${(F)input}
 
     assert $state equals 0
     assert ${#lines} equals 2
@@ -3125,4 +5663,18 @@
     assert ${#lines} equals 2
     assert ${lines[1]} same_as 'component=etcd'
     assert ${lines[2]} same_as 'tier=control-plane'
+}
+
+@test 'Testing post: a taint' {
+    input=(
+        'key1  value1  NoSchedule'
+        'key2  value2  NoExecute'
+    )
+
+    run _fzf_complete_kubectl-taints_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as 'key1=value1:NoSchedule'
+    assert ${lines[2]} same_as 'key2=value2:NoExecute'
 }

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -1,0 +1,2345 @@
+#!/usr/bin/env zunit
+
+@setup {
+    load ../fzf-zsh-completions.plugin.zsh
+
+    echo 0 > kubectl_mock_times
+
+    kubectl() {
+        kubectl_mock_times=$(($(cat kubectl_mock_times) + 1))
+        echo $kubectl_mock_times > kubectl_mock_times
+
+        kubectl_mock_$kubectl_mock_times $@
+    }
+}
+
+@teardown {
+    rm -f kubectl_mock_times
+}
+
+@test 'Testing completion: kubectl **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl '
+}
+
+@test 'Testing completion: kubectl --namespace=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --namespace='
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=--namespace=
+    _fzf_complete_kubectl 'kubectl '
+}
+
+@test 'Testing completion: kubectl --namespace **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --namespace '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl --namespace '
+}
+
+@test 'Testing completion: kubectl -n **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl -n '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl -n '
+}
+
+@test 'Testing completion: kubectl -n**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl -n'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=-n
+    _fzf_complete_kubectl 'kubectl '
+}
+
+@test 'Testing completion: kubectl apply --filename=**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    __fzf_generic_path_completion() {
+        assert $# equals 6
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl apply --filename='
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
+    }
+
+    prefix=--filename=
+    _fzf_complete_kubectl 'kubectl apply '
+}
+
+@test 'Testing completion: kubectl apply --filename **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    __fzf_generic_path_completion() {
+        assert $# equals 6
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl apply --filename '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl apply --filename '
+}
+
+@test 'Testing completion: kubectl apply -f **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    __fzf_generic_path_completion() {
+        assert $# equals 6
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl apply -f '
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl apply -f '
+}
+
+@test 'Testing completion: kubectl apply -f**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    __fzf_generic_path_completion() {
+        assert $# equals 6
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl apply -f'
+        assert $3 same_as '_fzf_compgen_path'
+        assert $4 same_as ''
+        assert $5 same_as ''
+        assert $6 same_as ' '
+    }
+
+    prefix=-f
+    _fzf_complete_kubectl 'kubectl apply '
+}
+
+# TODO
+# if [[ ${subcommands[1]} =~ '^(exec|logs|port-forward)$' ]]; then
+# if [[ ${subcommands[1]} =~ '^(annotate|describe|expose|get|label|patch)$' ]]; then
+# if [[ ${subcommands[1]} = 'rollout' ]]; then
+# if [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
+
+@test 'Testing completion: kubectl exec **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec '
+}
+
+@test 'Testing completion: kubectl exec pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl exec '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system '
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system pods/'
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs '
+}
+
+@test 'Testing completion: kubectl logs pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl logs '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system '
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system pods/'
+
+        run cat
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl port-forward **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000     1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000     ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000     1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward pods/'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000     ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward services/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR'
+        echo 'default       kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP                  1d    <none>'
+        echo 'kube-system   kube-dns     ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward services/'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME         ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}kubernetes   ${reset_color}ClusterIP   10.96.0.1    <none>        443/TCP                  1d    <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-dns     ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
+    }
+
+    prefix=services/
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward --namespace=kube-system '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward --namespace=kube-system pods/'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system services/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR'
+        echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward --namespace=kube-system services/'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
+        assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
+    }
+
+    prefix=services/
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+}
+
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward services/kube-dns **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward services/kube-dns '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system coredns-000000000-00000 **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system services/kube-dns **' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system services/kube-dns '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward services/kube-dns 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward --namespace=kube-system services/kube-dns 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward --namespace=kube-system services/kube-dns 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system services/kube-dns '
+}
+
+@test 'Testing post: a resource name' {
+    input=(
+        'test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+    )
+
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+}
+
+@test 'Testing post: a prefixed resource name' {
+    input=(
+        'test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+    )
+
+    prefix_option=pods/
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+}
+
+@test 'Testing post: resource names' {
+    input=(
+        'test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        'test-0000000000-00001              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        'test-0000000000-00002              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+    )
+
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 3
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as 'test-0000000000-00001'
+    assert ${lines[3]} same_as 'test-0000000000-00002'
+}
+
+@test 'Testing post: prefixed resource names' {
+    input=(
+        'test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        'test-0000000000-00001              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        'test-0000000000-00002              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+    )
+
+    prefix_option=pods/
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 3
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as 'pods/test-0000000000-00001'
+    assert ${lines[3]} same_as 'pods/test-0000000000-00002'
+}
+
+@test 'Testing post: a resource name (with namespace)' {
+    input=(
+        "\x1cdefault       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+    )
+
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as '--namespace=default'
+}
+
+@test 'Testing post: a prefixed resource name (with namespace)' {
+    input=(
+        "\x1cdefault       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+    )
+
+    prefix_option=pods/
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as '--namespace=default'
+}
+
+@test 'Testing post: resource names (with namespace)' {
+    input=(
+        "\x1cdefault       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        "\x1cdefault       test-0000000000-00001              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        "\x1cdefault       test-0000000000-00002              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+    )
+
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 4
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as 'test-0000000000-00001'
+    assert ${lines[3]} same_as 'test-0000000000-00002'
+    assert ${lines[4]} same_as '--namespace=default'
+}
+
+@test 'Testing post: prefixed resource names (with namespace)' {
+    input=(
+        "\x1cdefault       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        "\x1cdefault       test-0000000000-00001              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        "\x1cdefault       test-0000000000-00002              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+    )
+
+    prefix_option=pods/
+    run _fzf_complete_kubectl-resource-names_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 4
+    assert ${lines[1]} same_as 'test-0000000000-00000'
+    assert ${lines[2]} same_as 'pods/test-0000000000-00001'
+    assert ${lines[3]} same_as 'pods/test-0000000000-00002'
+    assert ${lines[4]} same_as '--namespace=default'
+}
+
+@test 'Testing post: a container name' {
+    input=(
+        'app  alpine:latest'
+    )
+
+    run _fzf_complete_kubectl-containers_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'app'
+}

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -328,6 +328,254 @@
     _fzf_complete_kubectl 'kubectl exec '
 }
 
+@test 'Testing completion: kubectl exec etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
 @test 'Testing completion: kubectl exec ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -408,68 +656,6 @@
     _fzf_complete_kubectl 'kubectl exec '
 }
 
-@test 'Testing completion: kubectl exec etcd-minikube --container=**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec etcd-minikube --container='
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=--container=
-    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
-}
-
-@test 'Testing completion: kubectl exec pods/etcd-minikube --container=**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=--container=
-    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
-}
-
 @test 'Testing completion: kubectl exec etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -534,68 +720,6 @@
     RBUFFER=' --namespace=kube-system'
     prefix=--container=
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
-}
-
-@test 'Testing completion: kubectl exec etcd-minikube --container **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec etcd-minikube --container '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
-}
-
-@test 'Testing completion: kubectl exec pods/etcd-minikube --container **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube --container ** --namespace=kube-system' {
@@ -664,68 +788,6 @@
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl exec etcd-minikube -c **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec etcd-minikube -c '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
-}
-
-@test 'Testing completion: kubectl exec pods/etcd-minikube -c **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
-}
-
 @test 'Testing completion: kubectl exec etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -790,68 +852,6 @@
     RBUFFER=' --namespace=kube-system'
     prefix=
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
-}
-
-@test 'Testing completion: kubectl exec etcd-minikube -c**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec etcd-minikube -c'
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=-c
-    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
-}
-
-@test 'Testing completion: kubectl exec pods/etcd-minikube -c**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=-c
-    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube -c** --namespace=kube-system' {
@@ -1002,6 +1002,254 @@
     _fzf_complete_kubectl 'kubectl logs '
 }
 
+@test 'Testing completion: kubectl logs etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'NAME IMAGE'
+        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
 @test 'Testing completion: kubectl logs ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -1082,68 +1330,6 @@
     _fzf_complete_kubectl 'kubectl logs '
 }
 
-@test 'Testing completion: kubectl logs etcd-minikube --container=**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs etcd-minikube --container='
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=--container=
-    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
-}
-
-@test 'Testing completion: kubectl logs pods/etcd-minikube --container=**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=--container=
-    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
-}
-
 @test 'Testing completion: kubectl logs etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -1208,68 +1394,6 @@
     RBUFFER=' --namespace=kube-system'
     prefix=--container=
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
-}
-
-@test 'Testing completion: kubectl logs etcd-minikube --container **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs etcd-minikube --container '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
-}
-
-@test 'Testing completion: kubectl logs pods/etcd-minikube --container **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube --container ** --namespace=kube-system' {
@@ -1338,68 +1462,6 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl logs etcd-minikube -c **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs etcd-minikube -c '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
-}
-
-@test 'Testing completion: kubectl logs pods/etcd-minikube -c **' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
-}
-
 @test 'Testing completion: kubectl logs etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -1464,68 +1526,6 @@
     RBUFFER=' --namespace=kube-system'
     prefix=
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
-}
-
-@test 'Testing completion: kubectl logs etcd-minikube -c**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs etcd-minikube -c'
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=-c
-    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
-}
-
-@test 'Testing completion: kubectl logs pods/etcd-minikube -c**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'etcd-minikube'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
-
-        echo 'NAME IMAGE'
-        echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
-        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
-    }
-
-    prefix=-c
-    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube -c** --namespace=kube-system' {
@@ -1697,106 +1697,6 @@
     _fzf_complete_kubectl 'kubectl port-forward '
 }
 
-@test 'Testing completion: kubectl port-forward ** --namespace=kube-system' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as '-o'
-        assert $4 same_as 'wide'
-        assert $5 same_as '--namespace=kube-system'
-
-        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
-        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
-        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward '
-
-        run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
-        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
-        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
-    }
-
-    RBUFFER=' --namespace=kube-system'
-    prefix=
-    _fzf_complete_kubectl 'kubectl port-forward '
-}
-
-@test 'Testing completion: kubectl port-forward pods/** --namespace=kube-system' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as '-o'
-        assert $4 same_as 'wide'
-        assert $5 same_as '--namespace=kube-system'
-
-        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
-        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
-        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward pods/'
-
-        run cat
-        assert ${#lines} equals 3
-        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
-        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
-        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
-    }
-
-    RBUFFER=' --namespace=kube-system'
-    prefix=pods/
-    _fzf_complete_kubectl 'kubectl port-forward '
-}
-
-@test 'Testing completion: kubectl port-forward services/** --namespace=kube-system' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'services'
-        assert $3 same_as '-o'
-        assert $4 same_as 'wide'
-        assert $5 same_as '--namespace=kube-system'
-
-        echo 'NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR'
-        echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward services/'
-
-        run cat
-        assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
-        assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
-    }
-
-    RBUFFER=' --namespace=kube-system'
-    prefix=services/
-    _fzf_complete_kubectl 'kubectl port-forward '
-}
-
 @test 'Testing completion: kubectl port-forward coredns-000000000-00000 **' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -1903,6 +1803,214 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward services/kube-dns 53:**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward pods/'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward services/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR'
+        echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward services/'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
+        assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=services/
+    _fzf_complete_kubectl 'kubectl port-forward '
 }
 
 @test 'Testing completion: kubectl port-forward coredns-000000000-00000 ** --namespace=kube-system' {
@@ -2016,114 +2124,6 @@
 
     RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
-}
-
-@test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'coredns-000000000-00000'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
-
-        echo 'PORT PROTOCOL NAME'
-        echo ' 53 UDP dns'
-        echo ' 53 TCP dns-tcp'
-        echo ' 9153 TCP metrics'
-    }
-
-    _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
-
-        run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
-        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
-        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
-        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
-    }
-
-    prefix=53:
-    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
-}
-
-@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 53:**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'pods'
-        assert $3 same_as 'coredns-000000000-00000'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
-
-        echo 'PORT PROTOCOL NAME'
-        echo ' 53 UDP dns'
-        echo ' 53 TCP dns-tcp'
-        echo ' 9153 TCP metrics'
-    }
-
-    _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
-
-        run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
-        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
-        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
-        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
-    }
-
-    prefix=53:
-    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
-}
-
-@test 'Testing completion: kubectl port-forward services/kube-dns 53:**' {
-    kubectl_mock_1() {
-        assert $# equals 5
-        assert $1 same_as 'get'
-        assert $2 same_as 'services'
-        assert $3 same_as 'kube-dns'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
-
-        echo 'PORT PROTOCOL NAME'
-        echo '53  UDP dns'
-        echo '53  TCP dns-tcp'
-        echo '9153  TCP metrics'
-    }
-
-    _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
-
-        run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
-        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
-        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
-        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
-    }
-
-    prefix=53:
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -413,7 +413,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -444,7 +444,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -476,7 +476,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -508,7 +508,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -539,7 +539,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -570,7 +570,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -602,7 +602,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -634,7 +634,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -665,7 +665,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -696,7 +696,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -728,7 +728,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -760,7 +760,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -791,7 +791,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -822,7 +822,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -854,7 +854,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -886,7 +886,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1077,7 +1077,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1108,7 +1108,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1140,7 +1140,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1172,7 +1172,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1203,7 +1203,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1234,7 +1234,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1266,7 +1266,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1298,7 +1298,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1329,7 +1329,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1360,7 +1360,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1392,7 +1392,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1424,7 +1424,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1455,7 +1455,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1486,7 +1486,7 @@
         assert $2 same_as 'pods'
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $5 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1518,7 +1518,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'
@@ -1550,7 +1550,7 @@
         assert $3 same_as 'etcd-minikube'
         assert $4 same_as '--namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range .spec.containers[*]}{.name} {.image}{"\\n"}{end}'
+        assert $6 same_as 'jsonpath=NAME IMAGE{"\\n"}{range ..containers[*]}{.name} {.image}{"\\n"}{end}'
 
         echo 'NAME IMAGE'
         echo 'etcd-minikube k8s.gcr.io/etcd:3.4.13-0'

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -328,7 +328,7 @@
     _fzf_complete_kubectl 'kubectl exec '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system **' {
+@test 'Testing completion: kubectl exec ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -351,7 +351,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system '
+        assert $5 same_as 'kubectl exec '
 
         run cat
         assert ${#lines} equals 6
@@ -363,11 +363,12 @@
         assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl exec '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system pods/**' {
+@test 'Testing completion: kubectl exec pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -390,7 +391,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system pods/'
+        assert $5 same_as 'kubectl exec pods/'
 
         run cat
         assert ${#lines} equals 6
@@ -402,8 +403,9 @@
         assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=pods/
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl exec '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube --container=**' {
@@ -468,7 +470,7 @@
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube --container=**' {
+@test 'Testing completion: kubectl exec etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -488,7 +490,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube --container='
+        assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
         assert ${#lines} equals 2
@@ -496,11 +498,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=--container=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube '
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube --container=**' {
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -520,7 +523,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube --container='
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
         assert ${#lines} equals 2
@@ -528,8 +531,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=--container=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube '
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube --container **' {
@@ -594,7 +598,7 @@
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube --container **' {
+@test 'Testing completion: kubectl exec etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -614,7 +618,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube --container '
+        assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
         assert ${#lines} equals 2
@@ -622,11 +626,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube --container '
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube --container **' {
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -646,7 +651,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube --container '
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
         assert ${#lines} equals 2
@@ -654,8 +659,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube --container '
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube -c **' {
@@ -720,7 +726,7 @@
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube -c **' {
+@test 'Testing completion: kubectl exec etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -740,7 +746,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube -c '
+        assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
         assert ${#lines} equals 2
@@ -748,11 +754,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube -c '
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube -c **' {
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -772,7 +779,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube -c '
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
         assert ${#lines} equals 2
@@ -780,8 +787,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube -c '
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
 }
 
 @test 'Testing completion: kubectl exec etcd-minikube -c**' {
@@ -846,7 +854,7 @@
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system etcd-minikube -c**' {
+@test 'Testing completion: kubectl exec etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -866,7 +874,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system etcd-minikube -c'
+        assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
         assert ${#lines} equals 2
@@ -874,11 +882,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=-c
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system etcd-minikube '
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
 }
 
-@test 'Testing completion: kubectl exec --namespace=kube-system pods/etcd-minikube -c**' {
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -898,7 +907,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl exec --namespace=kube-system pods/etcd-minikube -c'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
         assert ${#lines} equals 2
@@ -906,8 +915,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=-c
-    _fzf_complete_kubectl 'kubectl exec --namespace=kube-system pods/etcd-minikube '
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl logs **' {
@@ -992,7 +1002,7 @@
     _fzf_complete_kubectl 'kubectl logs '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system **' {
+@test 'Testing completion: kubectl logs ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -1015,7 +1025,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system '
+        assert $5 same_as 'kubectl logs '
 
         run cat
         assert ${#lines} equals 6
@@ -1027,11 +1037,12 @@
         assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl logs '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system pods/**' {
+@test 'Testing completion: kubectl logs pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -1054,7 +1065,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system pods/'
+        assert $5 same_as 'kubectl logs pods/'
 
         run cat
         assert ${#lines} equals 6
@@ -1066,8 +1077,9 @@
         assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=pods/
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl logs '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube --container=**' {
@@ -1132,7 +1144,7 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube --container=**' {
+@test 'Testing completion: kubectl logs etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1152,7 +1164,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube --container='
+        assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
         assert ${#lines} equals 2
@@ -1160,11 +1172,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=--container=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube '
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube --container=**' {
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1184,7 +1197,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube --container='
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
         assert ${#lines} equals 2
@@ -1192,8 +1205,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=--container=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube '
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube --container **' {
@@ -1258,7 +1272,7 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube --container **' {
+@test 'Testing completion: kubectl logs etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1278,7 +1292,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube --container '
+        assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
         assert ${#lines} equals 2
@@ -1286,11 +1300,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube --container '
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube --container **' {
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1310,7 +1325,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube --container '
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
         assert ${#lines} equals 2
@@ -1318,8 +1333,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube --container '
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube -c **' {
@@ -1384,7 +1400,7 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube -c **' {
+@test 'Testing completion: kubectl logs etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1404,7 +1420,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube -c '
+        assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
         assert ${#lines} equals 2
@@ -1412,11 +1428,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube -c '
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube -c **' {
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1436,7 +1453,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube -c '
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
         assert ${#lines} equals 2
@@ -1444,8 +1461,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube -c '
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
 }
 
 @test 'Testing completion: kubectl logs etcd-minikube -c**' {
@@ -1510,7 +1528,7 @@
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system etcd-minikube -c**' {
+@test 'Testing completion: kubectl logs etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1530,7 +1548,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system etcd-minikube -c'
+        assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
         assert ${#lines} equals 2
@@ -1538,11 +1556,12 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=-c
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system etcd-minikube '
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
 }
 
-@test 'Testing completion: kubectl logs --namespace=kube-system pods/etcd-minikube -c**' {
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1562,7 +1581,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl logs --namespace=kube-system pods/etcd-minikube -c'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
         assert ${#lines} equals 2
@@ -1570,8 +1589,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=-c
-    _fzf_complete_kubectl 'kubectl logs --namespace=kube-system pods/etcd-minikube '
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
 
 @test 'Testing completion: kubectl port-forward **' {
@@ -1677,7 +1697,7 @@
     _fzf_complete_kubectl 'kubectl port-forward '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system **' {
+@test 'Testing completion: kubectl port-forward ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -1697,7 +1717,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward --namespace=kube-system '
+        assert $5 same_as 'kubectl port-forward '
 
         run cat
         assert ${#lines} equals 3
@@ -1706,11 +1726,12 @@
         assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl port-forward '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/**' {
+@test 'Testing completion: kubectl port-forward pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -1730,7 +1751,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward --namespace=kube-system pods/'
+        assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
         assert ${#lines} equals 3
@@ -1739,11 +1760,12 @@
         assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=pods/
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl port-forward '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system services/**' {
+@test 'Testing completion: kubectl port-forward services/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'get'
@@ -1762,7 +1784,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'kubectl port-forward --namespace=kube-system services/'
+        assert $5 same_as 'kubectl port-forward services/'
 
         run cat
         assert ${#lines} equals 2
@@ -1770,8 +1792,9 @@
         assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=services/
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system '
+    _fzf_complete_kubectl 'kubectl port-forward '
 }
 
 @test 'Testing completion: kubectl port-forward coredns-000000000-00000 **' {
@@ -1882,7 +1905,7 @@
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system coredns-000000000-00000 **' {
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1905,7 +1928,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
         assert ${#lines} equals 4
@@ -1915,11 +1938,12 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 **' {
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1942,7 +1966,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
         assert ${#lines} equals 4
@@ -1952,11 +1976,12 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system services/kube-dns **' {
+@test 'Testing completion: kubectl port-forward services/kube-dns ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -1979,7 +2004,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system services/kube-dns '
+        assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
         assert ${#lines} equals 4
@@ -1989,8 +2014,9 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system services/kube-dns '
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
 @test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:**' {
@@ -2101,7 +2127,7 @@
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system coredns-000000000-00000 53:**' {
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -2124,7 +2150,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 53:'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
         assert ${#lines} equals 4
@@ -2134,11 +2160,12 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=53:
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system coredns-000000000-00000 '
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 53:**' {
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 53:** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -2161,7 +2188,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 53:'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
         assert ${#lines} equals 4
@@ -2171,11 +2198,12 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=53:
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system pods/coredns-000000000-00000 '
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
 }
 
-@test 'Testing completion: kubectl port-forward --namespace=kube-system services/kube-dns 53:**' {
+@test 'Testing completion: kubectl port-forward services/kube-dns 53:** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
         assert $1 same_as 'get'
@@ -2198,7 +2226,7 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl port-forward --namespace=kube-system services/kube-dns 53:'
+        assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
         assert ${#lines} equals 4
@@ -2208,8 +2236,9 @@
         assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
     }
 
+    RBUFFER=' --namespace=kube-system'
     prefix=53:
-    _fzf_complete_kubectl 'kubectl port-forward --namespace=kube-system services/kube-dns '
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
 @test 'Testing post: a resource name' {

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -240,11 +240,723 @@
     _fzf_complete_kubectl 'kubectl apply '
 }
 
-# TODO
-# if [[ ${subcommands[1]} =~ '^(exec|logs|port-forward)$' ]]; then
-# if [[ ${subcommands[1]} =~ '^(annotate|describe|expose|get|label|patch)$' ]]; then
-# if [[ ${subcommands[1]} = 'rollout' ]]; then
-# if [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
+@test 'Testing completion: kubectl annotate **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate '
+}
+
+@test 'Testing completion: kubectl annotate pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods '
+}
+
+@test 'Testing completion: kubectl annotate pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl annotate '
+}
+
+@test 'Testing completion: kubectl annotate pods etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl annotate pods/etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl annotate pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods '
+}
+
+@test 'Testing completion: kubectl annotate pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl annotate '
+}
+
+@test 'Testing completion: kubectl annotate pods etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl annotate pods/etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label '
+
+        run cat
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods '
+}
+
+@test 'Testing completion: kubectl label pods/**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods/etcd-minikube **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '-o'
+        assert $5 same_as 'jsonpath={.metadata.labels}'
+
+        echo '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods '
+}
+
+@test 'Testing completion: kubectl label pods/** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace=kube-system'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods/'
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl label '
+}
+
+@test 'Testing completion: kubectl label pods etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods/etcd-minikube ** --namespace=kube-system' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace=kube-system'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods/etcd-minikube '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+}
 
 @test 'Testing completion: kubectl exec **' {
     kubectl_mock_1() {
@@ -2371,4 +3083,46 @@
     assert $state equals 0
     assert ${#lines} equals 1
     assert ${lines[1]} same_as 'app'
+}
+
+@test 'Testing post: a port number' {
+    input=(
+        '53    TCP       dns-tcp'
+        '9153  TCP       metrics'
+    )
+
+    run _fzf_complete_kubectl-containers_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as '53'
+    assert ${lines[2]} same_as '9153'
+}
+
+@test 'Testing post: an annotation name' {
+    input=(
+        'cni.projectcalico.org/podIP=10.0.0.1/32'
+        $'note=line\nbreaks'
+    )
+
+    run _fzf_complete_kubectl-annotations_post <<< ${(pj:\0:)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as "cni.projectcalico.org/podIP=10.0.0.1/32"
+    assert ${lines[2]} same_as "note=\$'line\\nbreaks'"
+}
+
+@test 'Testing post: a label name' {
+    input=(
+        'component  etcd'
+        'tier       control-plane'
+    )
+
+    run _fzf_complete_kubectl-labels_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 2
+    assert ${lines[1]} same_as 'component=etcd'
+    assert ${lines[2]} same_as 'tier=control-plane'
 }


### PR DESCRIPTION
- Introduces `_fzf_complete_colorize` that colorizes formatted output
- Adds support for completions of generic resources so script does not need to support every API resource kind respectively