### PR TITLE
Don't show the prefix with options in the completions list

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -363,13 +363,7 @@ _fzf_complete_git-commit-messages() {
     shift
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
-        git log --format='%h %s' 2> /dev/null |
-        awk '
-            {
-                match($0, / /)
-                print $1, substr($0, RSTART + RLENGTH)
-            }
-        ' | _fzf_complete_tabularize ${fg[yellow]}
+        git log --format='%h %s' 2> /dev/null | _fzf_complete_tabularize ${fg[yellow]}
     )
 }
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -116,6 +116,7 @@ _fzf_complete_git() {
             else
                 prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
             fi
+            prefix=${prefix#$prefix_option}
         fi
 
         case $completing_option in
@@ -161,11 +162,12 @@ _fzf_complete_git() {
             else
                 prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
             fi
+            prefix=${prefix#$prefix_option}
         fi
 
         case $completing_option in
             -s|--source)
-                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' $@
                 ;;
 
             *)
@@ -202,15 +204,16 @@ _fzf_complete_git() {
             else
                 prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
             fi
+            prefix=${prefix#$prefix_option}
         fi
 
         case $completing_option in
             -c|-C|--fixup|--reedit-message|--reuse-message|--squash)
-                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' $@
                 ;;
 
             -m|--message)
-                prefix=${prefix#$prefix_option} _fzf_complete_git-commit-messages '' $@
+                _fzf_complete_git-commit-messages '' $@
                 ;;
 
             --author|--date)
@@ -222,12 +225,12 @@ _fzf_complete_git() {
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -u|--untracked-files)
                 local untracked_file_modes=(no normal all)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)untracked_file_modes}" $@
+                _fzf_complete_git_constants '' "${(F)untracked_file_modes}" $@
                 ;;
 
             *)
@@ -255,22 +258,23 @@ _fzf_complete_git() {
             else
                 prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
             fi
+            prefix=${prefix#$prefix_option}
         fi
 
         case $completing_option in
             --recurse-submodules)
                 local recurse_submodules=(yes on-demand no)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
                 ;;
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -s|--strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)strategies}" $@
+                _fzf_complete_git_constants '' "${(F)strategies}" $@
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -300,15 +304,15 @@ _fzf_complete_git() {
 
             --rebase)
                 local rebases=(false interactive merges preserve true)
-                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)rebases}" $@
+                _fzf_complete_git_constants '' "${(F)rebases}" $@
                 ;;
 
             --shallow-exclude)
-                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' $@
                 ;;
 
             --negotiation-tip)
-                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' $@
                 ;;
 
             --gpg-sign|-S)

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -20,11 +20,6 @@ _fzf_complete_awk_functions='
 
         return sprintf("%s%s%s%s%s%s %s", index_status_color, index_status, reset, work_tree_status_color, work_tree_status, reset, cdup substr(input, 4))
     }
-
-    function trim_prefix(str, prefix) {
-        match(str, prefix)
-        return substr(str, RSTART + RLENGTH)
-    }
 '
 
 _fzf_complete_preview_git_diff=$(cat <<'PREVIEW_OPTIONS'
@@ -362,7 +357,7 @@ _fzf_complete_git-commit-messages() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         git log --format='%h %s' 2> /dev/null | _fzf_complete_tabularize ${fg[yellow]}
     )
 }
@@ -372,15 +367,14 @@ _fzf_complete_git-commit-messages_post() {
         '$_fzf_complete_awk_functions'
         {
             match($0, /  /)
-            str = substr($0, RSTART + RLENGTH)
-            print trim_prefix(str, prefix)
+            print substr($0, RSTART + RLENGTH)
         }
     ')
     if [[ -z $message ]]; then
         return
     fi
 
-    echo $prefix_option${(qq)message}
+    echo ${(qq)message}
 }
 
 _fzf_complete_git-ls-files() {

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -363,11 +363,10 @@ _fzf_complete_git-commit-messages() {
 }
 
 _fzf_complete_git-commit-messages_post() {
-    local message=$(awk -v prefix=$prefix_option '
-        '$_fzf_complete_awk_functions'
+    local message=$(awk '
         {
-            match($0, /  /)
-            print substr($0, RSTART + RLENGTH)
+            sub(/[^ ]*  /, "")
+            print
         }
     ')
     if [[ -z $message ]]; then
@@ -460,7 +459,7 @@ _fzf_complete_git-refs() {
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
         git for-each-ref "$ref" --format='%(refname:short) %(contents:subject)' 2> /dev/null |
-        awk -v prefix=$prefix_option '{ print prefix $0 }' | _fzf_complete_tabularize ${fg[yellow]}
+            _fzf_complete_tabularize ${fg[yellow]}
     )
 }
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -165,7 +165,7 @@ _fzf_complete_git() {
 
         case $completing_option in
             -s|--source)
-                _fzf_complete_git-commits '' $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
                 ;;
 
             *)
@@ -206,11 +206,11 @@ _fzf_complete_git() {
 
         case $completing_option in
             -c|-C|--fixup|--reedit-message|--reuse-message|--squash)
-                _fzf_complete_git-commits '' $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
                 ;;
 
             -m|--message)
-                _fzf_complete_git-commit-messages '' $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git-commit-messages '' $@
                 ;;
 
             --author|--date)
@@ -222,12 +222,12 @@ _fzf_complete_git() {
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -u|--untracked-files)
                 local untracked_file_modes=(no normal all)
-                _fzf_complete_git_constants '' "${(F)untracked_file_modes}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)untracked_file_modes}" $@
                 ;;
 
             *)
@@ -260,17 +260,17 @@ _fzf_complete_git() {
         case $completing_option in
             --recurse-submodules)
                 local recurse_submodules=(yes on-demand no)
-                _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
                 ;;
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)cleanup_modes}" $@
                 ;;
 
             -s|--strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                _fzf_complete_git_constants '' "${(F)strategies}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)strategies}" $@
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -295,20 +295,20 @@ _fzf_complete_git() {
                     subtree=
                     theirs
                 )
-                prefix_option=${prefix_option/=*/=} _fzf_complete_git_constants '' "${(F)strategy_options}" $@
+                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)strategy_options}" $@
                 ;;
 
             --rebase)
                 local rebases=(false interactive merges preserve true)
-                _fzf_complete_git_constants '' "${(F)rebases}" $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git_constants '' "${(F)rebases}" $@
                 ;;
 
             --shallow-exclude)
-                _fzf_complete_git-commits '' $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
                 ;;
 
             --negotiation-tip)
-                _fzf_complete_git-commits '' $@
+                prefix=${prefix#$prefix_option} _fzf_complete_git-commits '' $@
                 ;;
 
             --gpg-sign|-S)
@@ -343,11 +343,11 @@ _fzf_complete_git-commits() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
         git for-each-ref refs/heads refs/remotes --format='%(refname:short) branch %(contents:subject)' 2> /dev/null
         git for-each-ref refs/tags --format='%(refname:short) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
-    } | awk -v prefix=$prefix_option '{ print prefix $0 }' | _fzf_complete_tabularize ${fg[yellow]} ${fg[green]})
+    } | _fzf_complete_tabularize ${fg[yellow]} ${fg[green]})
 }
 
 _fzf_complete_git-commits_post() {
@@ -360,10 +360,10 @@ _fzf_complete_git-commit-messages() {
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
         git log --format='%h %s' 2> /dev/null |
-        awk -v prefix=$prefix_option '
+        awk '
             {
                 match($0, / /)
-                print $1, prefix substr($0, RSTART + RLENGTH)
+                print $1, substr($0, RSTART + RLENGTH)
             }
         ' | _fzf_complete_tabularize ${fg[yellow]}
     )
@@ -490,7 +490,7 @@ _fzf_complete_git_constants() {
     local values=$2
     shift 2
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(awk -v prefix=$prefix_option '{ print prefix $0 }' <<< $values)
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(echo $values)
 }
 
 _fzf_complete_git_constants_post() {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1140,11 +1140,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--source=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--source=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--source=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--source=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--source=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--source=
@@ -1203,11 +1203,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}-sanother-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}-smaster        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}-sv2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}-sv1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}-s3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=-s
@@ -1224,11 +1224,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--fixup=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--fixup=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--fixup=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--fixup=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--fixup=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--fixup=
@@ -1245,11 +1245,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--reedit-message=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--reedit-message=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--reedit-message=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--reedit-message=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--reedit-message=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--reedit-message=
@@ -1266,11 +1266,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--reuse-message=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--reuse-message=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--reuse-message=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--reuse-message=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--reuse-message=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--reuse-message=
@@ -1287,11 +1287,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--squash=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--squash=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--squash=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--squash=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--squash=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--squash=
@@ -1329,11 +1329,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}-canother-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}-cmaster        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}-cv2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}-cv1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}-c3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=-c
@@ -1371,11 +1371,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}-qcanother-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}-qcmaster        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}-qcv2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}-qcv1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}-qc3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=-qc
@@ -1413,11 +1413,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}-Canother-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}-Cmaster        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}-Cv2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}-Cv1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}-C3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=-C
@@ -1455,11 +1455,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}-qCanother-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}-qCmaster        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}-qCv2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}-qCv1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}-qC3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=-qC
@@ -1562,8 +1562,8 @@
 
         run cat
         assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color  --message= 2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  --message=1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
     }
 
     prefix=--message=
@@ -1602,8 +1602,8 @@
 
         run cat
         assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color  -m 2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  -m1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
     }
 
     prefix=-m
@@ -1642,8 +1642,8 @@
 
         run cat
         assert ${#lines} equals 2
-        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color  -qm 2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  -qm1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
     }
 
     prefix=-qm
@@ -1990,11 +1990,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as --cleanup=strip
-        assert ${lines[2]} same_as --cleanup=whitespace
-        assert ${lines[3]} same_as --cleanup=verbatim
-        assert ${lines[4]} same_as --cleanup=scissors
-        assert ${lines[5]} same_as --cleanup=default
+        assert ${lines[1]} same_as strip
+        assert ${lines[2]} same_as whitespace
+        assert ${lines[3]} same_as verbatim
+        assert ${lines[4]} same_as scissors
+        assert ${lines[5]} same_as default
     }
 
     prefix=--cleanup=
@@ -2032,9 +2032,9 @@
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as -uno
-        assert ${lines[2]} same_as -unormal
-        assert ${lines[3]} same_as -uall
+        assert ${lines[1]} same_as no
+        assert ${lines[2]} same_as normal
+        assert ${lines[3]} same_as all
     }
 
     prefix=-u
@@ -2051,9 +2051,9 @@
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as -quno
-        assert ${lines[2]} same_as -qunormal
-        assert ${lines[3]} same_as -quall
+        assert ${lines[1]} same_as no
+        assert ${lines[2]} same_as normal
+        assert ${lines[3]} same_as all
     }
 
     prefix=-qu
@@ -2070,9 +2070,9 @@
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as --untracked-files=no
-        assert ${lines[2]} same_as --untracked-files=normal
-        assert ${lines[3]} same_as --untracked-files=all
+        assert ${lines[1]} same_as no
+        assert ${lines[2]} same_as normal
+        assert ${lines[3]} same_as all
     }
 
     prefix=--untracked-files=
@@ -2390,9 +2390,9 @@
 
         run cat
         assert ${#lines} equals 3
-        assert ${lines[1]} same_as --recurse-submodules=yes
-        assert ${lines[2]} same_as --recurse-submodules=on-demand
-        assert ${lines[3]} same_as --recurse-submodules=no
+        assert ${lines[1]} same_as yes
+        assert ${lines[2]} same_as on-demand
+        assert ${lines[3]} same_as no
     }
 
     prefix=--recurse-submodules=
@@ -2409,11 +2409,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as --cleanup=strip
-        assert ${lines[2]} same_as --cleanup=whitespace
-        assert ${lines[3]} same_as --cleanup=verbatim
-        assert ${lines[4]} same_as --cleanup=scissors
-        assert ${lines[5]} same_as --cleanup=default
+        assert ${lines[1]} same_as strip
+        assert ${lines[2]} same_as whitespace
+        assert ${lines[3]} same_as verbatim
+        assert ${lines[4]} same_as scissors
+        assert ${lines[5]} same_as default
     }
 
     prefix=--cleanup=
@@ -2472,11 +2472,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as -soctopus
-        assert ${lines[2]} same_as -sours
-        assert ${lines[3]} same_as -ssubtree
-        assert ${lines[4]} same_as -srecursive
-        assert ${lines[5]} same_as -sresolve
+        assert ${lines[1]} same_as octopus
+        assert ${lines[2]} same_as ours
+        assert ${lines[3]} same_as subtree
+        assert ${lines[4]} same_as recursive
+        assert ${lines[5]} same_as resolve
     }
 
     prefix=-s
@@ -2514,11 +2514,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as -qsoctopus
-        assert ${lines[2]} same_as -qsours
-        assert ${lines[3]} same_as -qssubtree
-        assert ${lines[4]} same_as -qsrecursive
-        assert ${lines[5]} same_as -qsresolve
+        assert ${lines[1]} same_as octopus
+        assert ${lines[2]} same_as ours
+        assert ${lines[3]} same_as subtree
+        assert ${lines[4]} same_as recursive
+        assert ${lines[5]} same_as resolve
     }
 
     prefix=-qs
@@ -2535,11 +2535,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as --strategy=octopus
-        assert ${lines[2]} same_as --strategy=ours
-        assert ${lines[3]} same_as --strategy=subtree
-        assert ${lines[4]} same_as --strategy=recursive
-        assert ${lines[5]} same_as --strategy=resolve
+        assert ${lines[1]} same_as octopus
+        assert ${lines[2]} same_as ours
+        assert ${lines[3]} same_as subtree
+        assert ${lines[4]} same_as recursive
+        assert ${lines[5]} same_as resolve
     }
 
     prefix=--strategy=
@@ -2612,25 +2612,25 @@
 
         run cat
         assert ${#lines} equals 19
-        assert ${lines[1]} same_as -Xdiff-algorithm=histogram
-        assert ${lines[2]} same_as -Xdiff-algorithm=minimal
-        assert ${lines[3]} same_as -Xdiff-algorithm=myers
-        assert ${lines[4]} same_as -Xdiff-algorithm=patience
-        assert ${lines[5]} same_as -Xfind-renames
-        assert ${lines[6]} same_as -Xfind-renames=
-        assert ${lines[7]} same_as -Xignore-all-space
-        assert ${lines[8]} same_as -Xignore-cr-at-eol
-        assert ${lines[9]} same_as -Xignore-space-at-eol
-        assert ${lines[10]} same_as -Xignore-space-change
-        assert ${lines[11]} same_as -Xno-renames
-        assert ${lines[12]} same_as -Xno-renormalize
-        assert ${lines[13]} same_as -Xours
-        assert ${lines[14]} same_as -Xpatience
-        assert ${lines[15]} same_as -Xrename-threshold=
-        assert ${lines[16]} same_as -Xrenormalize
-        assert ${lines[17]} same_as -Xsubtree
-        assert ${lines[18]} same_as -Xsubtree=
-        assert ${lines[19]} same_as -Xtheirs
+        assert ${lines[1]} same_as diff-algorithm=histogram
+        assert ${lines[2]} same_as diff-algorithm=minimal
+        assert ${lines[3]} same_as diff-algorithm=myers
+        assert ${lines[4]} same_as diff-algorithm=patience
+        assert ${lines[5]} same_as find-renames
+        assert ${lines[6]} same_as find-renames=
+        assert ${lines[7]} same_as ignore-all-space
+        assert ${lines[8]} same_as ignore-cr-at-eol
+        assert ${lines[9]} same_as ignore-space-at-eol
+        assert ${lines[10]} same_as ignore-space-change
+        assert ${lines[11]} same_as no-renames
+        assert ${lines[12]} same_as no-renormalize
+        assert ${lines[13]} same_as ours
+        assert ${lines[14]} same_as patience
+        assert ${lines[15]} same_as rename-threshold=
+        assert ${lines[16]} same_as renormalize
+        assert ${lines[17]} same_as subtree
+        assert ${lines[18]} same_as subtree=
+        assert ${lines[19]} same_as theirs
     }
 
     prefix=-X
@@ -2682,25 +2682,25 @@
 
         run cat
         assert ${#lines} equals 19
-        assert ${lines[1]} same_as -qXdiff-algorithm=histogram
-        assert ${lines[2]} same_as -qXdiff-algorithm=minimal
-        assert ${lines[3]} same_as -qXdiff-algorithm=myers
-        assert ${lines[4]} same_as -qXdiff-algorithm=patience
-        assert ${lines[5]} same_as -qXfind-renames
-        assert ${lines[6]} same_as -qXfind-renames=
-        assert ${lines[7]} same_as -qXignore-all-space
-        assert ${lines[8]} same_as -qXignore-cr-at-eol
-        assert ${lines[9]} same_as -qXignore-space-at-eol
-        assert ${lines[10]} same_as -qXignore-space-change
-        assert ${lines[11]} same_as -qXno-renames
-        assert ${lines[12]} same_as -qXno-renormalize
-        assert ${lines[13]} same_as -qXours
-        assert ${lines[14]} same_as -qXpatience
-        assert ${lines[15]} same_as -qXrename-threshold=
-        assert ${lines[16]} same_as -qXrenormalize
-        assert ${lines[17]} same_as -qXsubtree
-        assert ${lines[18]} same_as -qXsubtree=
-        assert ${lines[19]} same_as -qXtheirs
+        assert ${lines[1]} same_as diff-algorithm=histogram
+        assert ${lines[2]} same_as diff-algorithm=minimal
+        assert ${lines[3]} same_as diff-algorithm=myers
+        assert ${lines[4]} same_as diff-algorithm=patience
+        assert ${lines[5]} same_as find-renames
+        assert ${lines[6]} same_as find-renames=
+        assert ${lines[7]} same_as ignore-all-space
+        assert ${lines[8]} same_as ignore-cr-at-eol
+        assert ${lines[9]} same_as ignore-space-at-eol
+        assert ${lines[10]} same_as ignore-space-change
+        assert ${lines[11]} same_as no-renames
+        assert ${lines[12]} same_as no-renormalize
+        assert ${lines[13]} same_as ours
+        assert ${lines[14]} same_as patience
+        assert ${lines[15]} same_as rename-threshold=
+        assert ${lines[16]} same_as renormalize
+        assert ${lines[17]} same_as subtree
+        assert ${lines[18]} same_as subtree=
+        assert ${lines[19]} same_as theirs
     }
 
     prefix=-qX
@@ -2717,24 +2717,24 @@
 
         run cat
         assert ${#lines} equals 19
-        assert ${lines[1]} same_as --strategy-option=diff-algorithm=histogram
-        assert ${lines[2]} same_as --strategy-option=diff-algorithm=minimal
-        assert ${lines[3]} same_as --strategy-option=diff-algorithm=myers
-        assert ${lines[5]} same_as --strategy-option=find-renames
-        assert ${lines[6]} same_as --strategy-option=find-renames=
-        assert ${lines[7]} same_as --strategy-option=ignore-all-space
-        assert ${lines[8]} same_as --strategy-option=ignore-cr-at-eol
-        assert ${lines[9]} same_as --strategy-option=ignore-space-at-eol
-        assert ${lines[10]} same_as --strategy-option=ignore-space-change
-        assert ${lines[11]} same_as --strategy-option=no-renames
-        assert ${lines[12]} same_as --strategy-option=no-renormalize
-        assert ${lines[13]} same_as --strategy-option=ours
-        assert ${lines[14]} same_as --strategy-option=patience
-        assert ${lines[15]} same_as --strategy-option=rename-threshold=
-        assert ${lines[16]} same_as --strategy-option=renormalize
-        assert ${lines[17]} same_as --strategy-option=subtree
-        assert ${lines[18]} same_as --strategy-option=subtree=
-        assert ${lines[19]} same_as --strategy-option=theirs
+        assert ${lines[1]} same_as diff-algorithm=histogram
+        assert ${lines[2]} same_as diff-algorithm=minimal
+        assert ${lines[3]} same_as diff-algorithm=myers
+        assert ${lines[5]} same_as find-renames
+        assert ${lines[6]} same_as find-renames=
+        assert ${lines[7]} same_as ignore-all-space
+        assert ${lines[8]} same_as ignore-cr-at-eol
+        assert ${lines[9]} same_as ignore-space-at-eol
+        assert ${lines[10]} same_as ignore-space-change
+        assert ${lines[11]} same_as no-renames
+        assert ${lines[12]} same_as no-renormalize
+        assert ${lines[13]} same_as ours
+        assert ${lines[14]} same_as patience
+        assert ${lines[15]} same_as rename-threshold=
+        assert ${lines[16]} same_as renormalize
+        assert ${lines[17]} same_as subtree
+        assert ${lines[18]} same_as subtree=
+        assert ${lines[19]} same_as theirs
     }
 
     prefix=--strategy-option=
@@ -2786,11 +2786,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as --rebase=false
-        assert ${lines[2]} same_as --rebase=interactive
-        assert ${lines[3]} same_as --rebase=merges
-        assert ${lines[4]} same_as --rebase=preserve
-        assert ${lines[5]} same_as --rebase=true
+        assert ${lines[1]} same_as false
+        assert ${lines[2]} same_as interactive
+        assert ${lines[3]} same_as merges
+        assert ${lines[4]} same_as preserve
+        assert ${lines[5]} same_as true
     }
 
     prefix=--rebase=
@@ -2807,11 +2807,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--shallow-exclude=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--shallow-exclude=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--shallow-exclude=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--shallow-exclude=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--shallow-exclude=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--shallow-exclude=
@@ -2849,11 +2849,11 @@
 
         run cat
         assert ${#lines} equals 5
-        assert ${lines[1]} same_as "${fg[yellow]}--negotiation-tip=another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
-        assert ${lines[2]} same_as "${fg[yellow]}--negotiation-tip=master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
-        assert ${lines[3]} same_as "${fg[yellow]}--negotiation-tip=v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
-        assert ${lines[4]} same_as "${fg[yellow]}--negotiation-tip=v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
-        assert ${lines[5]} same_as "${fg[yellow]}--negotiation-tip=3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
     }
 
     prefix=--negotiation-tip=

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1558,7 +1558,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --message='
 
         run cat
         assert ${#lines} equals 2
@@ -1598,7 +1598,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -m'
 
         run cat
         assert ${#lines} equals 2
@@ -1638,7 +1638,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -qm'
 
         run cat
         assert ${#lines} equals 2

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1136,7 +1136,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git restore '
+        assert $4 same_as 'git restore --source='
 
         run cat
         assert ${#lines} equals 5
@@ -1199,7 +1199,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git restore '
+        assert $4 same_as 'git restore -s'
 
         run cat
         assert ${#lines} equals 5
@@ -1220,7 +1220,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --fixup='
 
         run cat
         assert ${#lines} equals 5
@@ -1241,7 +1241,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --reedit-message='
 
         run cat
         assert ${#lines} equals 5
@@ -1262,7 +1262,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --reuse-message='
 
         run cat
         assert ${#lines} equals 5
@@ -1283,7 +1283,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --squash='
 
         run cat
         assert ${#lines} equals 5
@@ -1325,7 +1325,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -c'
 
         run cat
         assert ${#lines} equals 5
@@ -1367,7 +1367,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -qc'
 
         run cat
         assert ${#lines} equals 5
@@ -1409,7 +1409,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -C'
 
         run cat
         assert ${#lines} equals 5
@@ -1451,7 +1451,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -qC'
 
         run cat
         assert ${#lines} equals 5
@@ -1986,7 +1986,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --cleanup='
 
         run cat
         assert ${#lines} equals 5
@@ -2028,7 +2028,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -u'
 
         run cat
         assert ${#lines} equals 3
@@ -2047,7 +2047,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit -qu'
 
         run cat
         assert ${#lines} equals 3
@@ -2066,7 +2066,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git commit '
+        assert $4 same_as 'git commit --untracked-files='
 
         run cat
         assert ${#lines} equals 3
@@ -2386,7 +2386,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --recurse-submodules='
 
         run cat
         assert ${#lines} equals 3
@@ -2405,7 +2405,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --cleanup='
 
         run cat
         assert ${#lines} equals 5
@@ -2468,7 +2468,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull -s'
 
         run cat
         assert ${#lines} equals 5
@@ -2510,7 +2510,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull -qs'
 
         run cat
         assert ${#lines} equals 5
@@ -2531,7 +2531,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --strategy='
 
         run cat
         assert ${#lines} equals 5
@@ -2608,7 +2608,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull -X'
 
         run cat
         assert ${#lines} equals 19
@@ -2678,7 +2678,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull -qX'
 
         run cat
         assert ${#lines} equals 19
@@ -2713,7 +2713,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --strategy-option='
 
         run cat
         assert ${#lines} equals 19
@@ -2782,7 +2782,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --rebase='
 
         run cat
         assert ${#lines} equals 5
@@ -2803,7 +2803,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --shallow-exclude='
 
         run cat
         assert ${#lines} equals 5
@@ -2845,7 +2845,7 @@
         assert $1 same_as '--ansi'
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--'
-        assert $4 same_as 'git pull '
+        assert $4 same_as 'git pull --negotiation-tip='
 
         run cat
         assert ${#lines} equals 5


### PR DESCRIPTION
This PR removes the prefix with options as `-m`, `--fixup=` and so on in the completions list.

before:
```
>
  5/5
> --fixup=another-branch  branch   2nd commit
  --fixup=master          branch  1st commit
  --fixup=v2              tag      2nd commit
  --fixup=v1              tag     1st commit
  --fixup=3e209a3         commit  1st commit
```

after:
```
>
  5/5
> another-branch  branch   2nd commit
  master          branch  1st commit
  v2              tag      2nd commit
  v1              tag     1st commit
  3e209a3         commit  1st commit
```