### PR TITLE
Support `git push **`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ git rebase -i **<TAB>
   - log
   - merge
   - pull
+  - push
   - rebase
   - reset
   - restore

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -414,7 +414,7 @@ _fzf_complete_git-commits() {
 _fzf_complete_git-commits_post() {
     local input=$(awk '{ print $1 }')
 
-    if [[ $subcommand == 'push' ]] && [[ -z $prefix_ref ]]; then
+    if [[ $subcommand = 'push' ]] && [[ -z $prefix_ref ]]; then
         echo -n $input
         return
     fi

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -324,7 +324,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                repository=$repository _fzf_complete_git-refs '--multi' $@
+                _fzf_complete_git-refs '--multi' $@
                 ;;
         esac
 
@@ -381,7 +381,7 @@ _fzf_complete_git() {
                 fi
 
                 if [[ $prefix = *:* ]]; then
-                    prefix=${prefix#*:} repository=$repository _fzf_complete_git-refs '' $@
+                    prefix=${prefix#*:} _fzf_complete_git-refs '' $@
                     return
                 fi
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -385,7 +385,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                no_spacing=1 _fzf_complete_git-commits '--multi' $@
+                _fzf_complete_git-commits '--multi' $@
                 ;;
         esac
 
@@ -414,7 +414,7 @@ _fzf_complete_git-commits() {
 _fzf_complete_git-commits_post() {
     local input=$(awk '{ print $1 }')
 
-    if (( $no_spacing )); then
+    if [[ $subcommand == 'push' ]] && [[ -z $prefix_ref ]]; then
         echo -n $input
         return
     fi

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -57,6 +57,7 @@ PREVIEW_OPTIONS
 )
 
 _fzf_complete_git() {
+    setopt local_options extended_glob
     local arguments=$@
     local resolved_commands=()
 
@@ -330,6 +331,67 @@ _fzf_complete_git() {
         return
     fi
 
+    if [[ $subcommand = 'push' ]]; then
+        local prefix_option completing_option
+
+        local git_options_argument_required=(--exec -o --push-option --receive-pack --recurse-submodules --repo)
+        local git_options_argument_optional=(--force-with-lease --signed)
+
+        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" ${(F)git_options_argument_required} ${(F)git_options_argument_optional}); then
+            if [[ $completing_option = --* ]]; then
+                prefix_option=$completing_option=
+            else
+                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
+            fi
+            prefix=${prefix#$prefix_option}
+        fi
+
+        local prefix_ref=${prefix%[^:]#}
+
+        case $completing_option in
+            --signed)
+                local signed=(false if-asked true)
+                _fzf_complete_git_constants '' "${(F)signed}" $@
+                ;;
+
+            -o|--push-option)
+                ;;
+
+            --exec|--receive-pack)
+                ;;
+
+            --force-with-lease)
+                prefix=${prefix#*:} _fzf_complete_git-commits '' $@
+                ;;
+
+            --repo)
+                _fzf_complete_git-remotes '' $@
+                ;;
+
+            --recurse-submodules)
+                local recurse_submodules=(check no on-demand only)
+                _fzf_complete_git_constants '' "${(F)recurse_submodules}" $@
+                ;;
+
+            *)
+                local repository
+                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                    _fzf_complete_git-remotes '' $@
+                    return
+                fi
+
+                if [[ $prefix = *:* ]]; then
+                    prefix=${prefix#*:} repository=$repository _fzf_complete_git-refs '' $@
+                    return
+                fi
+
+                no_spacing=1 _fzf_complete_git-commits '--multi' $@
+                ;;
+        esac
+
+        return
+    fi
+
     if [[ $subcommand = 'rm' ]]; then
         _fzf_complete_git-ls-files '' '--multi' $@
         return
@@ -342,7 +404,7 @@ _fzf_complete_git-commits() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <({
         git for-each-ref refs/heads refs/remotes --format='%(refname:short) branch %(contents:subject)' 2> /dev/null
         git for-each-ref refs/tags --format='%(refname:short) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
@@ -350,7 +412,14 @@ _fzf_complete_git-commits() {
 }
 
 _fzf_complete_git-commits_post() {
-    awk '{ print $1 }'
+    local input=$(awk '{ print $1 }')
+
+    if (( $no_spacing )); then
+        echo -n $input
+        return
+    fi
+
+    echo $input
 }
 
 _fzf_complete_git-commit-messages() {
@@ -439,7 +508,7 @@ _fzf_complete_git-remotes() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(git remote --verbose 2> /dev/null | awk '
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(git remote --verbose 2> /dev/null | awk '
         /\(fetch\)$/ {
             gsub("\t", " ")
             print
@@ -457,7 +526,7 @@ _fzf_complete_git-refs() {
 
     local ref=${${$(git config remote.$repository.fetch 2> /dev/null)#*:}%\*}
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <(
         git for-each-ref "$ref" --format='%(refname:short) %(contents:subject)' 2> /dev/null |
             _fzf_complete_tabularize ${fg[yellow]}
     )

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -3826,15 +3826,47 @@
         '3e209a3         1st commit'
     )
 
-    run _fzf_complete_git-commits_post <<< ${(F)input}
+    run _fzf_complete_git-commits_post <<< ${(F)input} \| tr '\n' ' '
 
     assert $state equals 0
-    assert ${#lines} equals 5
-    assert ${lines[1]} same_as 'another-branch'
-    assert ${lines[2]} same_as 'master'
-    assert ${lines[3]} same_as 'v2'
-    assert ${lines[4]} same_as 'v1'
-    assert ${lines[5]} same_as '3e209a3'
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'another-branch master v2 v1 3e209a3 '
+}
+
+@test 'Testing post: git commits with push subcommand and without prefix_ref' {
+    input=(
+        'another-branch   2nd commit'
+        'master          1st commit'
+        'v2               2nd commit'
+        'v1              1st commit'
+        '3e209a3         1st commit'
+    )
+    subcommand=push
+    prefix_ref=
+
+    run _fzf_complete_git-commits_post <<< ${(F)input} \| tr '\n' ' '
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'another-branch master v2 v1 3e209a3'
+}
+
+@test 'Testing post: git commits with push subcommand and with prefix_ref' {
+    input=(
+        'another-branch   2nd commit'
+        'master          1st commit'
+        'v2               2nd commit'
+        'v1              1st commit'
+        '3e209a3         1st commit'
+    )
+    subcommand=push
+    prefix_ref=master:
+
+    run _fzf_complete_git-commits_post <<< ${(F)input} \| tr '\n' ' '
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'another-branch master v2 v1 3e209a3 '
 }
 
 @test 'Testing post: git commit messages containing space' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -3184,6 +3184,308 @@
     _fzf_complete_git 'git pull -- origin '
 }
 
+@test 'Testing completion: git push --signed=**' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --signed='
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as false
+        assert ${lines[2]} same_as if-asked
+        assert ${lines[3]} same_as true
+    }
+
+    prefix=--signed=
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push --push-option=**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=--push-option=
+    _fzf_complete_git 'git push '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --push-option **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=
+    _fzf_complete_git 'git push --push-option '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push -o**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=-o
+    _fzf_complete_git 'git push '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push -o **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=
+    _fzf_complete_git 'git push -o '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --exec=**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=--exec=
+    _fzf_complete_git 'git push '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --exec **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=
+    _fzf_complete_git 'git push --exec '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --receive-pack=**' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=--receive-pack=
+    _fzf_complete_git 'git push '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --receive-pack **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=
+    _fzf_complete_git 'git push --receive-pack '
+
+    assert $? equals 0
+}
+
+@test 'Testing completion: git push --force-with-lease=**' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --force-with-lease='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+    }
+
+    prefix=--force-with-lease=
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push --force-with-lease=master:**' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --force-with-lease=master:'
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+    }
+
+    prefix=--force-with-lease=master:
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push --repo=**' {
+    run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
+    run git remote add upstream git@example.com:example/fzf-zsh-completions
+    run git remote add example example
+
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --repo='
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
+        assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
+        assert ${lines[3]} same_as "${fg[yellow]}upstream$reset_color  git@example.com:example/fzf-zsh-completions (fetch)"
+    }
+
+    prefix=--repo
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push --repo **' {
+    run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
+    run git remote add upstream git@example.com:example/fzf-zsh-completions
+    run git remote add example example
+
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --repo '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
+        assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
+        assert ${lines[3]} same_as "${fg[yellow]}upstream$reset_color  git@example.com:example/fzf-zsh-completions (fetch)"
+    }
+
+    prefix=
+    _fzf_complete_git 'git push --repo '
+}
+
+@test 'Testing completion: git push --recurse-submodules=**' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --recurse-submodules='
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as check
+        assert ${lines[2]} same_as no
+        assert ${lines[3]} same_as on-demand
+        assert ${lines[4]} same_as only
+    }
+
+    prefix=--recurse-submodules=
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push --recurse-submodules **' {
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push --recurse-submodules '
+
+        run cat
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as check
+        assert ${lines[2]} same_as no
+        assert ${lines[3]} same_as on-demand
+        assert ${lines[4]} same_as only
+    }
+
+    prefix=
+    _fzf_complete_git 'git push --recurse-submodules '
+}
+
+@test 'Testing completion: git push **' {
+    run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
+    run git remote add upstream git@example.com:example/fzf-zsh-completions
+    run git remote add example example
+
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push '
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
+        assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
+        assert ${lines[3]} same_as "${fg[yellow]}upstream$reset_color  git@example.com:example/fzf-zsh-completions (fetch)"
+    }
+
+    prefix=
+    _fzf_complete_git 'git push '
+}
+
+@test 'Testing completion: git push origin **' {
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--multi'
+        assert $4 same_as '--'
+        assert $5 same_as 'git push origin '
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
+        assert ${lines[3]} same_as "${fg[yellow]}v2            $reset_color  ${fg[green]}tag   $reset_color   2nd commit"
+        assert ${lines[4]} same_as "${fg[yellow]}v1            $reset_color  ${fg[green]}tag   $reset_color  1st commit"
+        assert ${lines[5]} same_as "${fg[yellow]}3e209a3       $reset_color  ${fg[green]}commit$reset_color  1st commit"
+    }
+
+    prefix=
+    _fzf_complete_git 'git push origin '
+}
+
+@test 'Testing completion: git push origin master:**' {
+    run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
+    run git symbolic-ref refs/remotes/origin/master refs/heads/master
+    run git symbolic-ref refs/remotes/origin/another-branch refs/heads/another-branch
+
+    _fzf_complete() {
+        assert $# equals 4
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--'
+        assert $4 same_as 'git push origin master:'
+
+        run cat
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}origin/another-branch$reset_color   2nd commit"
+        assert ${lines[2]} same_as "${fg[yellow]}origin/master        $reset_color  1st commit"
+    }
+
+    prefix=master:
+    _fzf_complete_git 'git push origin '
+}
+
 @test 'Testing completion: git rm **' {
     run git checkout another-branch
     echo >> ' file3 containing space '


### PR DESCRIPTION
This PR supports the completions of `git push`. When the `<refspec>` is selected by the completion of `git push origin **`, the last whitespace is trimmed for easy inputting `<dst>`.

https://git-scm.com/docs/git-push