### PR TITLE
Fix regexp for git remotes group

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -640,7 +640,7 @@ _fzf_complete_git-repositories() {
     shift
 
     if [[ $subcommand = 'fetch' ]]; then
-        local groups=$(git config --get-regexp remotes 2> /dev/null)
+        local groups=$(git config --get-regexp '^remotes\.' 2> /dev/null)
         groups=${(Q)${(F)${${(q)${(f)groups}}#remotes.}}}
     fi
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -3032,6 +3032,7 @@
     run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
+    run git config alias.remotes 'remote -v'
     run git config remotes.group1 'origin upstream'
     run git config remotes.group2 'origin upstream example'
 


### PR DESCRIPTION
This PR fixes the issue where there are `remotes` such as alias in `.git/config`.