### PR TITLE
Support `yarn workspace <workspace> **` for displaying npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ sequence that defaults to `**`.
 
 - [fzf][]
 - [Zsh][] >= 5.3
+- [jq][]
 
 ## Installation
 
@@ -91,8 +92,8 @@ git rebase -i **<TAB>
 - systemctl
 - yarn
   - run
-  - workspace (requires [jq][])
-  - workspace <workspace> run (requires [jq][])
+  - workspace
+  - workspace \<workspace\>
 - docker
   - attach
   - commit

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ git rebase -i **<TAB>
 - systemctl
 - yarn
   - run
-  - workspace
+  - workspace (requires [jq][])
+  - workspace <workspace> run (requires [jq][])
 - docker
   - attach
   - commit
@@ -138,3 +139,4 @@ tests/test.zsh
 [fzf-completions]: https://github.com/junegunn/fzf/blob/master/README.md#fuzzy-completion-for-bash-and-zsh
 [Zsh]:             https://www.zsh.org/
 [fzf-preview.zsh]: https://github.com/yuki-ycino/fzf-preview.zsh
+[jq]:              https://github.com/stedolan/jq

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -424,7 +424,7 @@ _fzf_complete_kubectl-annotations() {
     shift
 
     _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
-        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.annotations}' 2> /dev/null | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
+        { kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")' } 2> /dev/null
     )
 }
 
@@ -449,7 +449,7 @@ _fzf_complete_kubectl-labels() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <(cat \
             <(echo KEY VALUE) \
-            <(kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.labels}' 2> /dev/null | jq -r 'to_entries[] | "\(.key) \(.value)"') \
+            <({ kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.labels}' | jq -r 'to_entries[] | "\(.key) \(.value)"'} 2> /dev/null) \
         )
     )
 }

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -423,9 +423,9 @@ _fzf_complete_kubectl-annotations() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
-        { kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")' } 2> /dev/null
-    )
+    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
+        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
+    } 2> /dev/null)
 }
 
 _fzf_complete_kubectl-annotations_post() {
@@ -449,7 +449,9 @@ _fzf_complete_kubectl-labels() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <(cat \
             <(echo KEY VALUE) \
-            <({ kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.labels}' | jq -r 'to_entries[] | "\(.key) \(.value)"'} 2> /dev/null) \
+            <({
+              kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.labels}' | jq -r 'to_entries[] | "\(.key) \(.value)"'
+            } 2> /dev/null) \
         )
     )
 }

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -13,7 +13,7 @@ _fzf_complete_npm-run() {
     local fzf_options=$1
     shift
 
-    local package=$(dirname -- $(npm root))/package.json
+    local package=${npm_directory-$(dirname -- $(npm root))}/package.json
     if [[ ! -f $package ]]; then
         return
     fi

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -11,7 +11,7 @@ _fzf_complete_yarn() {
         fi
 
         local npm_directory=$({
-            yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location' 2> /dev/null
+            yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location'
         } 2> /dev/null)
         _fzf_complete_npm-run '' $@
         return

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,11 +1,12 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    local subcommand=${${(Q)${(z)@}}[2]}
+    local arguments=$@
+    local subcommand=${${(Q)${(z)arguments}}[2]}
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
-        if ! workspace=$(_fzf_complete_parse_argument 3 1 $@ '') && [[ -z $workspace ]]; then
+        if ! workspace=$(_fzf_complete_parse_argument 3 1 "$arguments" '') && [[ -z $workspace ]]; then
             _fzf_complete_yarn-workspace '' $@
             return
         fi

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -10,7 +10,9 @@ _fzf_complete_yarn() {
             return
         fi
 
-        local npm_directory=$(yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location')
+        local npm_directory=$({
+            yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location' 2> /dev/null
+        } 2> /dev/null)
         _fzf_complete_npm-run '' $@
         return
     fi
@@ -32,7 +34,7 @@ _fzf_complete_yarn-workspace() {
         return
     fi
 
-    local workspace_packages_patterns=$(jq -r '.workspaces | map(. + "/package.json") | join("\u0000")' "$parent_package")
+    local workspace_packages_patterns=$(jq -r '.workspaces | map(. + "/package.json") | join("\u0000")' "$parent_package" 2> /dev/null)
 
-   _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(jq -r '.name' ${~${(0)workspace_packages_patterns}})
+   _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(jq -r '.name' ${~${(0)workspace_packages_patterns}} 2> /dev/null)
 }

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -10,7 +10,7 @@ _fzf_complete_yarn() {
             return
         fi
 
-        local npm_directory=$(yarn workspaces --json info | jq -r ".data | fromjson | .[\"$workspace\"].location")
+        local npm_directory=$(yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location')
         _fzf_complete_npm-run '' $@
         return
     fi

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,8 +1,17 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    if [[ $@ = 'yarn workspace ' ]]; then
-        _fzf_complete_yarn-workspace '' $@
+    local subcommand=${${(Q)${(z)@}}[2]}
+
+    if [[ $subcommand = 'workspace' ]]; then
+        local workspace
+        if ! workspace=$(_fzf_complete_parse_argument 3 1 $@ '') && [[ -z $workspace ]]; then
+            _fzf_complete_yarn-workspace '' $@
+            return
+        fi
+
+        local npm_directory=$(yarn workspaces --json info | jq -r ".data | fromjson | .[\"$workspace\"].location")
+        _fzf_complete_npm-run '' $@
         return
     fi
 

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -87,7 +87,7 @@ _fzf_complete_parse_argument() {
             continue
         fi
 
-        local previous_argument=$(_fzf_complete_parse_completing_option '' ${(Q)arguments[i - 1]} ${(F)options_argument_required} '')
+        local previous_argument=$(_fzf_complete_parse_completing_option '' "${(Q)arguments[i - 1]}" "${(F)options_argument_required}" '')
         if [[ -n $previous_argument ]] && [[ ${options_argument_required[(r)$previous_argument]} = $previous_argument ]]; then
             continue
         fi

--- a/tests/_support/yarn/workspace/examples/a/package.json
+++ b/tests/_support/yarn/workspace/examples/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "examples/a",
+  "name": "examples-a",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT"

--- a/tests/_support/yarn/workspace/examples/a/package.json
+++ b/tests/_support/yarn/workspace/examples/a/package.json
@@ -2,5 +2,12 @@
   "name": "examples-a",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "examples-a-command": "exit 0",
+    " script containing spaces ": "echo \"This script contains spaces in its name\"",
+    "script\nthat\nconsists\nof\nmultiple\nlines": "echo \"The name of this script consists of multiple lines\""
+  }
 }

--- a/tests/_support/yarn/workspace/package.json
+++ b/tests/_support/yarn/workspace/package.json
@@ -3,5 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "private": true,
   "workspaces": ["packages/*", "examples/*"]
 }

--- a/tests/_support/yarn/workspace/packages/a/package.json
+++ b/tests/_support/yarn/workspace/packages/a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "package/a",
+  "name": "package-a",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT"

--- a/tests/_support/yarn/workspace/packages/a/package.json
+++ b/tests/_support/yarn/workspace/packages/a/package.json
@@ -2,5 +2,12 @@
   "name": "package-a",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "package-a-command": "exit 0",
+    " script containing spaces ": "echo \"This script contains spaces in its name\"",
+    "script\nthat\nconsists\nof\nmultiple\nlines": "echo \"The name of this script consists of multiple lines\""
+  }
 }

--- a/tests/_support/yarn/workspace/packages/b/package.json
+++ b/tests/_support/yarn/workspace/packages/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "package/b",
+  "name": "package-b",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT"

--- a/tests/_support/yarn/workspace/packages/b/package.json
+++ b/tests/_support/yarn/workspace/packages/b/package.json
@@ -2,5 +2,12 @@
   "name": "package-b",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "package-b-command": "exit 0",
+    " script containing spaces ": "echo \"This script contains spaces in its name\"",
+    "script\nthat\nconsists\nof\nmultiple\nlines": "echo \"The name of this script consists of multiple lines\""
+  }
 }

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -107,9 +107,9 @@
         run cat
         assert ${#lines} equals 3
 
-        assert ${lines[1]} same_as 'package/a'
-        assert ${lines[2]} same_as 'package/b'
-        assert ${lines[3]} same_as 'examples/a'
+        assert ${lines[1]} same_as 'package-a'
+        assert ${lines[2]} same_as 'package-b'
+        assert ${lines[3]} same_as 'examples-a'
     }
 
     prefix=

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -115,3 +115,161 @@
     prefix=
     _fzf_complete_yarn 'yarn workspace '
 }
+
+@test 'Testing completion: yarn workspace package-a **' {
+    popd
+    pushd tests/_support/yarn/workspace
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--'
+        assert $6 same_as 'yarn workspace package-a '
+
+        run cat
+        assert ${#lines} equals 6
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 5
+        assert ${actual1[1]} same_as 'start'
+        assert ${actual1[2]} same_as 'test'
+        assert ${actual1[3]} same_as 'package-a-command'
+        assert ${actual1[4]} same_as ' script containing spaces '
+        assert ${actual1[5]} same_as 'script'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'that'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 1
+        assert ${actual3[1]} same_as 'consists'
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'of'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 1
+        assert ${actual5[1]} same_as 'multiple'
+
+        actual6=(${(0)lines[6]})
+        assert ${actual6[1]} same_as 'lines'
+    }
+
+    prefix=
+    _fzf_complete_yarn 'yarn workspace package-a '
+}
+
+@test 'Testing completion: yarn workspace package-b **' {
+    popd
+    pushd tests/_support/yarn/workspace
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--'
+        assert $6 same_as 'yarn workspace package-b '
+
+        run cat
+        assert ${#lines} equals 6
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 5
+        assert ${actual1[1]} same_as 'start'
+        assert ${actual1[2]} same_as 'test'
+        assert ${actual1[3]} same_as 'package-b-command'
+        assert ${actual1[4]} same_as ' script containing spaces '
+        assert ${actual1[5]} same_as 'script'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'that'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 1
+        assert ${actual3[1]} same_as 'consists'
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'of'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 1
+        assert ${actual5[1]} same_as 'multiple'
+
+        actual6=(${(0)lines[6]})
+        assert ${actual6[1]} same_as 'lines'
+    }
+
+    prefix=
+    _fzf_complete_yarn 'yarn workspace package-b '
+}
+
+@test 'Testing completion: yarn workspace examples-a **' {
+    popd
+    pushd tests/_support/yarn/workspace
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--'
+        assert $6 same_as 'yarn workspace examples-a '
+
+        run cat
+        assert ${#lines} equals 6
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 5
+        assert ${actual1[1]} same_as 'start'
+        assert ${actual1[2]} same_as 'test'
+        assert ${actual1[3]} same_as 'examples-a-command'
+        assert ${actual1[4]} same_as ' script containing spaces '
+        assert ${actual1[5]} same_as 'script'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'that'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 1
+        assert ${actual3[1]} same_as 'consists'
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'of'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 1
+        assert ${actual5[1]} same_as 'multiple'
+
+        actual6=(${(0)lines[6]})
+        assert ${actual6[1]} same_as 'lines'
+    }
+
+    prefix=
+    _fzf_complete_yarn 'yarn workspace examples-a '
+}
+
+@test 'Testing completion: yarn workspace no-workspace **' {
+    popd
+    pushd tests/_support/yarn/workspace
+
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    prefix=
+    _fzf_complete_yarn 'yarn workspace no-workspace '
+
+    assert $? equals 0
+}


### PR DESCRIPTION
This supports such `yarn workspace <workspace> [run] **` as `yarn [run]**` or `npm run **`. Besides invalid `package.json` as a workspace is fixed.

https://classic.yarnpkg.com/en/docs/cli/workspace
https://classic.yarnpkg.com/en/docs/cli/workspaces
