### PR TITLE
Fix #102: Take no arguments in kubectl logs -f **

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -30,22 +30,6 @@ _fzf_complete_kubectl() {
         return
     fi
 
-    if [[ $last_argument =~ '(-[^-]*f|--filename)$' ]]; then
-        __fzf_generic_path_completion "$prefix" $@ _fzf_compgen_path '' '' ' '
-        return
-    fi
-
-    if [[ $prefix =~ '^(-[^-]*f|--filename=)' ]]; then
-        if [[ $prefix = --* ]]; then
-            prefix_option=${prefix/=*/=}
-        else
-            prefix_option=${prefix%%f*}f
-        fi
-
-        __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
-        return
-    fi
-
     local kubectl_options_argument_required=(
         --application-metrics-count-limit
         --as
@@ -157,6 +141,24 @@ _fzf_complete_kubectl() {
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
     namespace=$(_fzf_complete_parse_option_argument '-n' '--namespace' $@$RBUFFER || :)
+
+    if [[ ${subcommands[1]} != 'logs' ]]; then
+        if [[ $last_argument =~ '(-[^-]*f|--filename)$' ]]; then
+            __fzf_generic_path_completion "$prefix" $@ _fzf_compgen_path '' '' ' '
+            return
+        fi
+
+        if [[ $prefix =~ '^(-[^-]*f|--filename=)' ]]; then
+            if [[ $prefix = --* ]]; then
+                prefix_option=${prefix/=*/=}
+            else
+                prefix_option=${prefix%%f*}f
+            fi
+
+            __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
+            return
+        fi
+    fi
 
     if [[ ${subcommands[1]} =~ '^(rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -3123,6 +3123,47 @@
     _fzf_complete_kubectl 'kubectl logs '
 }
 
+@test 'Testing completion: kubectl logs -f **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--all-namespaces'
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs -f '
+
+        run cat
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs -f '
+}
+
 @test 'Testing completion: kubectl logs pods/**' {
     kubectl_mock_1() {
         assert $# equals 5


### PR DESCRIPTION
Fixes a bug in `kubectl logs -f **<TAB>` where `-f` was mistaken for `--filename` options and resulted in completions for filenames instead of Pods.