### PR TITLE
Fix #105: Configure collation for stable testing

### DIFF
--- a/tests/test.zsh
+++ b/tests/test.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+export LC_COLLATE=C
+
 ROOT=${0:h:h:A}
 PATH=$ROOT/bin/revolver:$ROOT/bin/zunit:$PATH
 


### PR DESCRIPTION
It turns out that Zsh internally calls strcoll that relies on OS collation and it has caused a problem in some environments.