### PR TITLE
Show files outside tree object when `git rm **`

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -507,7 +507,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'rm' ]]; then
-        _fzf_complete_git-ls-tree '' '--multi' $@
+        _fzf_complete_git-ls-files '' '--multi' $@
         return
     fi
 
@@ -718,6 +718,33 @@ _fzf_complete_git-commit-messages_post() {
     fi
 
     echo ${(qq)message}
+}
+
+_fzf_complete_git-ls-files() {
+    local git_options=$1
+    local fzf_options=$2
+    shift 2
+
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+        local cdup=$(git rev-parse --show-cdup 2> /dev/null)
+        local git_prefix=$(git rev-parse --show-prefix 2> /dev/null)
+        cd $(git rev-parse --show-toplevel 2> /dev/null)
+
+        local files=$(git ls-files --deduplicate -z ${(Z+n+)git_options} 2> /dev/null)
+        files=(${(0)files})
+        local paths=($cdup${^files})
+
+        echo -n ${(pj:\0:)paths}
+    })
+}
+
+_fzf_complete_git-ls-files_post() {
+    local filename
+    local input=$(cat)
+
+    for filename in ${(0)input}; do
+        echo ${${(q+)filename}//\\n/\\\\n}
+    done
 }
 
 _fzf_complete_git-ls-tree() {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -4699,6 +4699,8 @@
     echo >> directory2/$'file4\ncontaining\nnewlines'
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
+    touch file_outside_tree_object
+    run git add file_outside_tree_object
 
     _fzf_complete() {
         assert $# equals 6
@@ -4723,21 +4725,24 @@
         assert ${actual2[1]} same_as 'containing'
 
         actual3=(${(0)lines[3]})
-        assert ${#actual3} equals 2
+        assert ${#actual3} equals 3
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as 'file1'
+        assert ${actual3[3]} same_as 'file_outside_tree_object'
     }
 
     prefix=
     _fzf_complete_git 'git rm '
 }
 
-@test 'Testing completion in subcommand: git rm **' {
+@test 'Testing completion in subdirectory: git rm **' {
     run git checkout another-branch
     echo >> ' file3 containing space '
     echo >> directory2/$'file4\ncontaining\nnewlines'
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
+    touch file_outside_tree_object
+    run git add file_outside_tree_object
 
     cd directory2
 
@@ -4755,18 +4760,19 @@
 
         actual1=(${(0)lines[1]})
         assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'directory2/file4'
+        assert ${actual1[1]} same_as '../ file3 containing space '
+        assert ${actual1[2]} same_as '../directory1/file2'
+        assert ${actual1[3]} same_as '../directory2/file4'
 
         actual2=(${(0)lines[2]})
         assert ${#actual2} equals 1
         assert ${actual2[1]} same_as 'containing'
 
         actual3=(${(0)lines[3]})
-        assert ${#actual3} equals 2
+        assert ${#actual3} equals 3
         assert ${actual3[1]} same_as 'newlines'
-        assert ${actual3[2]} same_as 'file1'
+        assert ${actual3[2]} same_as '../file1'
+        assert ${actual3[3]} same_as '../file_outside_tree_object'
     }
 
     prefix=

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -4699,7 +4699,7 @@
     echo >> directory2/$'file4\ncontaining\nnewlines'
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
-    touch file_outside_tree_object
+    run touch file_outside_tree_object
     run git add file_outside_tree_object
 
     _fzf_complete() {
@@ -4741,7 +4741,7 @@
     echo >> directory2/$'file4\ncontaining\nnewlines'
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
-    touch file_outside_tree_object
+    run touch file_outside_tree_object
     run git add file_outside_tree_object
 
     cd directory2


### PR DESCRIPTION
Fixes #110 
When adding new files, cherry-picking the commits including non-existence files in the current index and so on, `git rm` takes the files that actually exists in working tree.