### PR TITLE
Fix prefixes in kubectl get pods (-l|--selector|-L|--label-columns)

### DIFF
--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -4620,17 +4620,17 @@
 
 @test 'Testing completion: kubectl get pods --selector=tier=control-plane,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4644,33 +4644,32 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 7
+        assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
         assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
         assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
         assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
-        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=--selector=tier=control-plane,
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
-@test 'Testing completion: kubectl get pods --selector=tier=control-plane,\!**' {
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4681,17 +4680,91 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl get pods --selector=tier=control-plane,!'
+        assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
-    prefix=--selector=tier=control-plane,\\!
+    prefix=--selector=tier=control-plane,component
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,\!**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='--selector=tier=control-plane,\!'
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,\!component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='--selector=tier=control-plane,\!component'
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -4701,7 +4774,7 @@
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '--selector=component'
+        assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
@@ -4729,6 +4802,191 @@
     }
 
     prefix=--selector=tier=control-plane,component=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=--selector=tier=control-plane,component=etcd
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component==**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=--selector=tier=control-plane,component==
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component==etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=--selector=tier=control-plane,component==etcd
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component!=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=--selector=tier=control-plane,component!=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=tier=control-plane,component!=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=--selector=tier=control-plane,component!=etcd
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -4774,17 +5032,17 @@
 
 @test 'Testing completion: kubectl get pods --selector tier=control-plane,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4798,33 +5056,32 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 7
+        assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
         assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
         assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
         assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
-        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=tier=control-plane,
     _fzf_complete_kubectl 'kubectl get pods --selector '
 }
 
-@test 'Testing completion: kubectl get pods --selector tier=control-plane,\!**' {
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4835,17 +5092,91 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl get pods --selector tier=control-plane,!'
+        assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
-    prefix=tier=control-plane,\\!
+    prefix=tier=control-plane,component
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,\!**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='tier=control-plane,\!'
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,\!component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='tier=control-plane,\!component'
     _fzf_complete_kubectl 'kubectl get pods --selector '
 }
 
@@ -4855,7 +5186,7 @@
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '--selector=component'
+        assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
@@ -4883,6 +5214,191 @@
     }
 
     prefix=tier=control-plane,component=
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component=etcd
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component==**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component==
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component==etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component==etcd
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component!=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component!=
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
+@test 'Testing completion: kubectl get pods --selector tier=control-plane,component!=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component!=etcd
     _fzf_complete_kubectl 'kubectl get pods --selector '
 }
 
@@ -4928,17 +5444,17 @@
 
 @test 'Testing completion: kubectl get pods -l tier=control-plane,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4952,33 +5468,32 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 7
+        assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
         assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
         assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
         assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
-        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=tier=control-plane,
     _fzf_complete_kubectl 'kubectl get pods -l '
 }
 
-@test 'Testing completion: kubectl get pods -l tier=control-plane,\!**' {
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -4989,17 +5504,91 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl get pods -l tier=control-plane,!'
+        assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
-    prefix=tier=control-plane,\\!
+    prefix=tier=control-plane,component
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,\!**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='tier=control-plane,\!'
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,\!component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='tier=control-plane,\!component'
     _fzf_complete_kubectl 'kubectl get pods -l '
 }
 
@@ -5009,7 +5598,7 @@
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '--selector=component'
+        assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
@@ -5037,6 +5626,191 @@
     }
 
     prefix=tier=control-plane,component=
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component=etcd
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component==**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component==
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component==etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component==etcd
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component!=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component!=
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
+@test 'Testing completion: kubectl get pods -l tier=control-plane,component!=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=tier=control-plane,component!=etcd
     _fzf_complete_kubectl 'kubectl get pods -l '
 }
 
@@ -5082,17 +5856,17 @@
 
 @test 'Testing completion: kubectl get pods -ltier=control-plane,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5106,33 +5880,32 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
-        assert ${#lines} equals 7
+        assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
         assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
         assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
         assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
-        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=-ltier=control-plane,
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
-@test 'Testing completion: kubectl get pods -ltier=control-plane,\!**' {
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5143,17 +5916,91 @@
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'kubectl get pods -ltier=control-plane,!'
+        assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
-        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
-    prefix=-ltier=control-plane,\\!
+    prefix=-ltier=control-plane,component
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,\!**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='-ltier=control-plane,\!'
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,\!component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix='-ltier=control-plane,\!component'
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -5163,7 +6010,7 @@
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '--selector=component'
+        assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
@@ -5191,6 +6038,191 @@
     }
 
     prefix=-ltier=control-plane,component=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=-ltier=control-plane,component=etcd
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component==**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=-ltier=control-plane,component==
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component==etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=-ltier=control-plane,component==etcd
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component!=**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=-ltier=control-plane,component!=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -ltier=control-plane,component!=etcd**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--selector=tier=control-plane,component'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
+
+        run cat
+        assert ${#lines} equals 5
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+    }
+
+    prefix=-ltier=control-plane,component!=etcd
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -5322,17 +6354,17 @@
 
 @test 'Testing completion: kubectl get pods --label-columns=tier,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5346,14 +6378,49 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
-        assert ${#lines} equals 4
+        assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=--label-columns=tier,
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --label-columns=tier,component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --label-columns=tier,'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=--label-columns=tier,component
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -5396,17 +6463,17 @@
 
 @test 'Testing completion: kubectl get pods --label-columns tier,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5420,14 +6487,49 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
-        assert ${#lines} equals 4
+        assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=tier,
+    _fzf_complete_kubectl 'kubectl get pods --label-columns '
+}
+
+@test 'Testing completion: kubectl get pods --label-columns tier,component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --label-columns tier,'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=tier,component
     _fzf_complete_kubectl 'kubectl get pods --label-columns '
 }
 
@@ -5470,17 +6572,17 @@
 
 @test 'Testing completion: kubectl get pods -L tier,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5494,14 +6596,49 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
-        assert ${#lines} equals 4
+        assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=tier,
+    _fzf_complete_kubectl 'kubectl get pods -L '
+}
+
+@test 'Testing completion: kubectl get pods -L tier,component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -L tier,'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=tier,component
     _fzf_complete_kubectl 'kubectl get pods -L '
 }
 
@@ -5544,17 +6681,17 @@
 
 @test 'Testing completion: kubectl get pods -Ltier,**' {
     kubectl_mock_1() {
-        assert $# equals 5
+        assert $# equals 6
         assert $1 same_as 'get'
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
-        assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
 
         echo -n '{"component":"etcd","tier":"control-plane"}'
         echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
         echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
@@ -5568,14 +6705,49 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
-        assert ${#lines} equals 4
+        assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
-        assert ${lines[3]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
-        assert ${lines[4]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
     }
 
     prefix=-Ltier,
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -Ltier,component**' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--all-namespaces'
+        assert $4 same_as '--label-columns=tier'
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -Ltier,'
+
+        run cat
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    prefix=-Ltier,component
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
@@ -11706,6 +12878,7 @@
         'tier       control-plane'
     )
 
+    prefix_option=--selector=
     run _fzf_complete_kubectl-selectors_post <<< ${(F)input}
 
     assert $state equals 0


### PR DESCRIPTION
The options `-l`/`--selector`/`-L`/`--label-columns` in `$prefix` are now passed to `kubectl get` calls so it can filter them incrementally. 