### PR TITLE
Migrate to mock helpers

### DIFF
--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -1,0 +1,20 @@
+_zunit_assert_mock_times() {
+    local target=$1
+    local count=$2
+    shift 2
+
+    local len=$(cat -- ${target}_mock_times)
+    if [[ $len != $count ]]; then
+        echo "'$target' is called for $len times(s)"
+        exit 1
+    fi
+
+    local i
+    for (( i = 1; i <= $len; i++ )); do
+        local mock=${target}_mock_$i
+        if [[ -e ${mock}_fail ]]; then
+            echo "$mock: $(cat -- ${mock}_fail)"
+            exit 1
+        fi
+    done
+}

--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -10,7 +10,7 @@ _zunit_assert_mock_times() {
     fi
 
     local i
-    for (( i = 1; i <= $len; i++ )); do
+    for (( i = 1; i <= len; i++ )); do
         local mock=${target}_mock_$i
         if [[ -e ${mock}_fail ]]; then
             echo "$mock: $(cat -- ${mock}_fail)"

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -10,7 +10,7 @@ mock() {
         local mock_failfile=${target}_mock_${mock_times}_fail
         echo $mock_times > ${target}_mock_times
 
-        if (${target}_mock_$mock_times $@ &> $mock_failfile); then
+        if ${target}_mock_$mock_times $@ &> $mock_failfile; then
             cat -- $mock_failfile
             rm -- $mock_failfile
         fi

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -1,0 +1,29 @@
+mock() {
+    local target=$1
+    shift
+
+    echo 0 > ${target}_mock_times
+
+    $target() {
+        local target=${funcstack[1]}
+        local mock_times=$(($(cat -- ${target}_mock_times) + 1))
+        local mock_failfile=${target}_mock_${mock_times}_fail
+        echo $mock_times > ${target}_mock_times
+
+        if (${target}_mock_$mock_times $@ &> $mock_failfile); then
+            cat -- $mock_failfile
+            rm -- $mock_failfile
+        fi
+    }
+}
+
+unmock() {
+    local target=$1
+    shift
+
+    if (( $+functions[$target] )); then
+        unfunction $target
+    fi
+
+    rm -f -- ${target}_mock_times ${target}_mock_*_fail(N)
+}

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -2,10 +2,13 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock docker
 }
 
 @teardown {
-    rm -f docker_mock_times
+    unmock docker
 }
 
 @test 'Testing completion: docker **' {
@@ -24,15 +27,6 @@
 }
 
 @test 'Testing completion: docker create **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -56,6 +50,7 @@
         assert $5 same_as 'docker create '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -70,15 +65,6 @@
 }
 
 @test 'Testing completion: docker history **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -102,6 +88,7 @@
         assert $5 same_as 'docker history '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -116,15 +103,6 @@
 }
 
 @test 'Testing completion: docker push **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'images'
@@ -149,6 +127,7 @@
         assert $5 same_as 'docker push '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}REPOSITORY  ${reset_color}  ${reset_color}IMAGE ID    ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}alpine      ${reset_color}  ${reset_color}e7d92cdc71fe${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -162,15 +141,6 @@
 }
 
 @test 'Testing completion: docker run **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -194,6 +164,7 @@
         assert $5 same_as 'docker run '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -208,15 +179,6 @@
 }
 
 @test 'Testing completion: docker rmi **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -241,6 +203,7 @@
         assert $6 same_as 'docker rmi '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -255,15 +218,6 @@
 }
 
 @test 'Testing completion: docker save **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -288,6 +242,7 @@
         assert $6 same_as 'docker save '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -302,15 +257,6 @@
 }
 
 @test 'Testing completion: docker tag **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -335,6 +281,7 @@
         assert $6 same_as 'docker tag '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -349,15 +296,6 @@
 }
 
 @test 'Testing completion: docker attach **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -378,6 +316,7 @@
         assert $5 same_as 'docker attach '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -388,15 +327,6 @@
 }
 
 @test 'Testing completion: docker exec **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -417,6 +347,7 @@
         assert $5 same_as 'docker exec '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -427,15 +358,6 @@
 }
 
 @test 'Testing completion: docker top **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -456,6 +378,7 @@
         assert $5 same_as 'docker top '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -466,15 +389,6 @@
 }
 
 @test 'Testing completion: docker kill **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -496,6 +410,7 @@
         assert $6 same_as 'docker kill '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -506,15 +421,6 @@
 }
 
 @test 'Testing completion: docker pause **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -536,6 +442,7 @@
         assert $6 same_as 'docker pause '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -546,15 +453,6 @@
 }
 
 @test 'Testing completion: docker stop **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -576,6 +474,7 @@
         assert $6 same_as 'docker stop '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -586,15 +485,6 @@
 }
 
 @test 'Testing completion: docker unpause **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'container'
@@ -616,6 +506,7 @@
         assert $6 same_as 'docker unpause '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}295e3ea0de41${reset_color}  ${reset_color}archlinux${reset_color}  ${reset_color}\"/bin/zsh --login\"${reset_color}  ${reset_color}4 weeks ago${reset_color}  ${reset_color}Up 1 second${reset_color}  ${reset_color}     ${reset_color}  thankful_smyth"
@@ -626,15 +517,6 @@
 }
 
 @test 'Testing completion: docker commit **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -660,6 +542,7 @@
         assert $5 same_as 'docker commit '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -674,15 +557,6 @@
 }
 
 @test 'Testing completion: docker cp **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -708,6 +582,7 @@
         assert $5 same_as 'docker cp '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -722,15 +597,6 @@
 }
 
 @test 'Testing completion: docker diff **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -756,6 +622,7 @@
         assert $5 same_as 'docker diff '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -770,15 +637,6 @@
 }
 
 @test 'Testing completion: docker export **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -804,6 +662,7 @@
         assert $5 same_as 'docker export '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -818,15 +677,6 @@
 }
 
 @test 'Testing completion: docker logs **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -852,6 +702,7 @@
         assert $5 same_as 'docker logs '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -866,15 +717,6 @@
 }
 
 @test 'Testing completion: docker port **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -900,6 +742,7 @@
         assert $5 same_as 'docker port '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -914,15 +757,6 @@
 }
 
 @test 'Testing completion: docker rename **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -948,6 +782,7 @@
         assert $5 same_as 'docker rename '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -962,15 +797,6 @@
 }
 
 @test 'Testing completion: docker inspect **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -997,6 +823,7 @@
         assert $6 same_as 'docker inspect '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1011,15 +838,6 @@
 }
 
 @test 'Testing completion: docker inspect --type=container **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1046,6 +864,7 @@
         assert $6 same_as 'docker inspect --type=container '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1060,15 +879,6 @@
 }
 
 @test 'Testing completion: docker inspect --type container **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1095,6 +905,7 @@
         assert $6 same_as 'docker inspect --type container '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1109,15 +920,6 @@
 }
 
 @test 'Testing completion: docker inspect --type=image **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -1142,6 +944,7 @@
         assert $6 same_as 'docker inspect --type=image '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -1156,15 +959,6 @@
 }
 
 @test 'Testing completion: docker inspect --type image **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 3
         assert $1 same_as 'images'
@@ -1189,6 +983,7 @@
         assert $6 same_as 'docker inspect --type image '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
         assert ${lines[2]} same_as "${fg[yellow]}e7d92cdc71fe${reset_color}  ${reset_color}alpine      ${reset_color}  ${reset_color}latest${reset_color}  ${reset_color}18 hours ago ${reset_color}  5.59MB"
@@ -1203,15 +998,6 @@
 }
 
 @test 'Testing completion: docker inspect --type=network **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'network'
@@ -1235,6 +1021,7 @@
         assert $6 same_as 'docker inspect --type=network '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}NETWORK ID  ${reset_color}  ${reset_color}NAME  ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
         assert ${lines[2]} same_as "${fg[yellow]}e19a403182e9${reset_color}  ${reset_color}bridge${reset_color}  ${reset_color}bridge${reset_color}  local"
@@ -1247,15 +1034,6 @@
 }
 
 @test 'Testing completion: docker inspect --type network **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'network'
@@ -1279,6 +1057,7 @@
         assert $6 same_as 'docker inspect --type network '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}NETWORK ID  ${reset_color}  ${reset_color}NAME  ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
         assert ${lines[2]} same_as "${fg[yellow]}e19a403182e9${reset_color}  ${reset_color}bridge${reset_color}  ${reset_color}bridge${reset_color}  local"
@@ -1291,15 +1070,6 @@
 }
 
 @test 'Testing completion: docker inspect --type=volume **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'volume'
@@ -1323,6 +1093,7 @@
         assert $6 same_as 'docker inspect --type=volume '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}VOLUME ID                                                       ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
         assert ${lines[2]} same_as "${fg[yellow]}0b9526ec0aa7f7ded03c88328e9b60f519be17ec53d9b504c2e4b07626a456ec${reset_color}  ${reset_color}local ${reset_color}  local"
@@ -1335,15 +1106,6 @@
 }
 
 @test 'Testing completion: docker inspect --type volume **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 4
         assert $1 same_as 'volume'
@@ -1367,6 +1129,7 @@
         assert $6 same_as 'docker inspect --type volume '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}VOLUME ID                                                       ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
         assert ${lines[2]} same_as "${fg[yellow]}0b9526ec0aa7f7ded03c88328e9b60f519be17ec53d9b504c2e4b07626a456ec${reset_color}  ${reset_color}local ${reset_color}  local"
@@ -1379,15 +1142,6 @@
 }
 
 @test 'Testing completion: docker inspect --type=task **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1395,19 +1149,10 @@
     prefix=
     _fzf_complete_docker 'docker inspect --type=task '
 
-    assert $(cat docker_mock_times) equals 0
+    assert docker mock_times 0
 }
 
 @test 'Testing completion: docker inspect --type task **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1415,19 +1160,10 @@
     prefix=
     _fzf_complete_docker 'docker inspect --type task '
 
-    assert $(cat docker_mock_times) equals 0
+    assert docker mock_times 0
 }
 
 @test 'Testing completion: docker restart **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1454,6 +1190,7 @@
         assert $6 same_as 'docker restart '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1468,15 +1205,6 @@
 }
 
 @test 'Testing completion: docker rm **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1503,6 +1231,7 @@
         assert $6 same_as 'docker rm '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1517,15 +1246,6 @@
 }
 
 @test 'Testing completion: docker start **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1552,6 +1272,7 @@
         assert $6 same_as 'docker start '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1566,15 +1287,6 @@
 }
 
 @test 'Testing completion: docker stats **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1601,6 +1313,7 @@
         assert $6 same_as 'docker stats '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1615,15 +1328,6 @@
 }
 
 @test 'Testing completion: docker update **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1650,6 +1354,7 @@
         assert $6 same_as 'docker update '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"
@@ -1664,15 +1369,6 @@
 }
 
 @test 'Testing completion: docker wait **' {
-    echo 0 > docker_mock_times
-
-    docker() {
-        docker_mock_times=$(($(cat docker_mock_times) + 1))
-        echo $docker_mock_times > docker_mock_times
-
-        docker_mock_$docker_mock_times $@
-    }
-
     docker_mock_1() {
         assert $# equals 5
         assert $1 same_as 'container'
@@ -1699,6 +1395,7 @@
         assert $6 same_as 'docker wait '
 
         run cat
+        assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}728e677dd292${reset_color}  ${reset_color}5425b1e460b6${reset_color}  ${reset_color}\"/bin/sh\"         ${reset_color}  ${reset_color}12 days ago${reset_color}  ${reset_color}Exited (0) 12 days ago${reset_color}  ${reset_color}     ${reset_color}  affectionate_curie"

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -2,10 +2,13 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock gh
 }
 
 @teardown {
-    rm -f gh_mock_times
+    unmock gh
 }
 
 @test 'Testing completion: gh **' {
@@ -35,15 +38,6 @@
 }
 
 @test 'Testing completion: gh pr close **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -66,6 +60,7 @@
         assert $5 same_as 'gh pr close '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR ${reset_color}  ${fg[blue]}2nd-open ${reset_color}  ${fg[green]}OPEN ${reset_color}  "
@@ -79,15 +74,6 @@
 }
 
 @test 'Testing completion: gh pr merge **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -110,6 +96,7 @@
         assert $5 same_as 'gh pr merge '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR ${reset_color}  ${fg[blue]}2nd-open ${reset_color}  ${fg[green]}OPEN ${reset_color}  "
@@ -123,15 +110,6 @@
 }
 
 @test 'Testing completion: gh pr ready **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -154,6 +132,7 @@
         assert $5 same_as 'gh pr ready '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR ${reset_color}  ${fg[blue]}2nd-open ${reset_color}  ${fg[green]}OPEN ${reset_color}  "
@@ -167,15 +146,6 @@
 }
 
 @test 'Testing completion: gh pr reopen **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -196,6 +166,7 @@
         assert $5 same_as 'gh pr reopen '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}5${reset_color}  ${reset_color}2nd CLOSED PR${reset_color}  ${fg[blue]}2nd-closed${reset_color}  ${fg[green]}CLOSED${reset_color}  "
@@ -207,15 +178,6 @@
 }
 
 @test 'Testing completion: gh pr checkout **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -242,6 +204,7 @@
         assert $5 same_as 'gh pr checkout '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "
@@ -259,15 +222,6 @@
 }
 
 @test 'Testing completion: gh pr comment **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -294,6 +248,7 @@
         assert $5 same_as 'gh pr comment '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "
@@ -311,15 +266,6 @@
 }
 
 @test 'Testing completion: gh pr diff **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -346,6 +292,7 @@
         assert $5 same_as 'gh pr diff '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "
@@ -363,15 +310,6 @@
 }
 
 @test 'Testing completion: gh pr edit **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -398,6 +336,7 @@
         assert $5 same_as 'gh pr edit '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "
@@ -415,15 +354,6 @@
 }
 
 @test 'Testing completion: gh pr review **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -450,6 +380,7 @@
         assert $5 same_as 'gh pr review '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "
@@ -467,15 +398,6 @@
 }
 
 @test 'Testing completion: gh pr view **' {
-    echo 0 > gh_mock_times
-
-    gh() {
-        gh_mock_times=$(($(cat gh_mock_times) + 1))
-        echo $gh_mock_times > gh_mock_times
-
-        gh_mock_$gh_mock_times $@
-    }
-
     gh_mock_1() {
         assert $# equals 4
         assert $1 same_as 'pr'
@@ -502,6 +424,7 @@
         assert $5 same_as 'gh pr view '
 
         run cat
+        assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}  "
         assert ${lines[2]} same_as "${fg[yellow]}8${reset_color}  ${reset_color}2nd OPEN PR  ${reset_color}  ${fg[blue]}2nd-open  ${reset_color}  ${fg[green]}OPEN  ${reset_color}  "

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -2,19 +2,13 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
-
-    echo 0 > kubectl_mock_times
-
-    kubectl() {
-        kubectl_mock_times=$(($(cat kubectl_mock_times) + 1))
-        echo $kubectl_mock_times > kubectl_mock_times
-
-        kubectl_mock_$kubectl_mock_times $@
-    }
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock kubectl
 }
 
 @teardown {
-    rm -f kubectl_mock_times
+    unmock kubectl
 }
 
 @test 'Testing completion: kubectl **' {
@@ -55,6 +49,7 @@
         assert $5 same_as 'kubectl --namespace='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
         assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
@@ -88,6 +83,7 @@
         assert $5 same_as 'kubectl --namespace '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
         assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
@@ -121,6 +117,7 @@
         assert $5 same_as 'kubectl -n '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
         assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
@@ -154,6 +151,7 @@
         assert $5 same_as 'kubectl -n'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
         assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
@@ -190,6 +188,7 @@
         assert $6 same_as 'kubectl diff --labels='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -230,6 +229,7 @@
         assert $6 same_as 'kubectl diff --labels '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -270,6 +270,7 @@
         assert $6 same_as 'kubectl diff -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -310,6 +311,7 @@
         assert $6 same_as 'kubectl diff -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -350,6 +352,7 @@
         assert $6 same_as 'kubectl run --labels='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -390,6 +393,7 @@
         assert $6 same_as 'kubectl run --labels '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -430,6 +434,7 @@
         assert $6 same_as 'kubectl run -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -470,6 +475,7 @@
         assert $6 same_as 'kubectl run -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -510,6 +516,7 @@
         assert $6 same_as 'kubectl scale --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -550,6 +557,7 @@
         assert $6 same_as 'kubectl scale --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -590,6 +598,7 @@
         assert $6 same_as 'kubectl scale -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -630,6 +639,7 @@
         assert $6 same_as 'kubectl scale -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -668,6 +678,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000   ${reset_color}1/1     1            1           1d    web          nginx:latest                    app=test"
@@ -702,6 +713,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000   ${reset_color}1/1     1            1           1d    web          nginx:latest                    app=test"
@@ -740,6 +752,7 @@
         assert $5 same_as 'kubectl wait '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -784,6 +797,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -826,6 +840,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -866,6 +881,7 @@
         assert $6 same_as 'kubectl wait pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -906,6 +922,7 @@
         assert $6 same_as 'kubectl wait pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -946,6 +963,7 @@
         assert $6 same_as 'kubectl wait pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -986,6 +1004,7 @@
         assert $6 same_as 'kubectl wait pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -1028,6 +1047,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1071,6 +1091,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1113,6 +1134,7 @@
         assert $5 same_as 'kubectl annotate '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -1156,6 +1178,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1197,6 +1220,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1237,6 +1261,7 @@
         assert $6 same_as 'kubectl annotate pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -1277,6 +1302,7 @@
         assert $6 same_as 'kubectl annotate pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -1317,6 +1343,7 @@
         assert $6 same_as 'kubectl annotate pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -1357,6 +1384,7 @@
         assert $6 same_as 'kubectl annotate pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -1394,6 +1422,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
 
         actual1=(${(0)lines[1]})
@@ -1435,6 +1464,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
 
         actual1=(${(0)lines[1]})
@@ -1480,6 +1510,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1522,6 +1553,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1561,6 +1593,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
 
         actual1=(${(0)lines[1]})
@@ -1604,6 +1637,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
 
         actual1=(${(0)lines[1]})
@@ -1726,6 +1760,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -1769,6 +1804,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1810,6 +1846,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1851,6 +1888,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1893,6 +1931,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -1935,6 +1974,7 @@
         assert $5 same_as 'kubectl apply view-last-applied '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -1979,6 +2019,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2021,6 +2062,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2061,6 +2103,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -2101,6 +2144,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -2141,6 +2185,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -2181,6 +2226,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -2223,6 +2269,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2266,6 +2313,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2308,6 +2356,7 @@
         assert $5 same_as 'kubectl autoscale '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -2351,6 +2400,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2392,6 +2442,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2433,6 +2484,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2475,6 +2527,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2517,6 +2570,7 @@
         assert $5 same_as 'kubectl edit '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -2560,6 +2614,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2601,6 +2656,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2642,6 +2698,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2684,6 +2741,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2726,6 +2784,7 @@
         assert $5 same_as 'kubectl expose '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -2769,6 +2828,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2810,6 +2870,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2851,6 +2912,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2893,6 +2955,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -2935,6 +2998,7 @@
         assert $5 same_as 'kubectl patch '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -2978,6 +3042,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3019,6 +3084,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3060,6 +3126,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3102,6 +3169,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3139,6 +3207,7 @@
         assert $5 same_as 'kubectl cordon '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
         assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
@@ -3172,6 +3241,7 @@
         assert $6 same_as 'kubectl cordon --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3210,6 +3280,7 @@
         assert $6 same_as 'kubectl cordon --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3248,6 +3319,7 @@
         assert $6 same_as 'kubectl cordon -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3286,6 +3358,7 @@
         assert $6 same_as 'kubectl cordon -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3322,6 +3395,7 @@
         assert $5 same_as 'kubectl drain '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
         assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
@@ -3355,6 +3429,7 @@
         assert $6 same_as 'kubectl drain --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3393,6 +3468,7 @@
         assert $6 same_as 'kubectl drain --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3431,6 +3507,7 @@
         assert $6 same_as 'kubectl drain -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3469,6 +3546,7 @@
         assert $6 same_as 'kubectl drain -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3505,6 +3583,7 @@
         assert $5 same_as 'kubectl uncordon '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
         assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
@@ -3538,6 +3617,7 @@
         assert $6 same_as 'kubectl uncordon --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3576,6 +3656,7 @@
         assert $6 same_as 'kubectl uncordon --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3614,6 +3695,7 @@
         assert $6 same_as 'kubectl uncordon -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3652,6 +3734,7 @@
         assert $6 same_as 'kubectl uncordon -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -3675,6 +3758,7 @@
         assert $4 same_as 'kubectl create '
 
         run cat
+        assert kubectl mock_times 0
         assert ${#lines} equals 23
         assert ${lines[1]} same_as 'clusterrole'
         assert ${lines[2]} same_as 'clusterrolebinding'
@@ -3732,6 +3816,7 @@
         assert $5 same_as 'kubectl delete '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -3776,6 +3861,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3818,6 +3904,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -3858,6 +3945,7 @@
         assert $6 same_as 'kubectl delete pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -3898,6 +3986,7 @@
         assert $6 same_as 'kubectl delete pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -3938,6 +4027,7 @@
         assert $6 same_as 'kubectl delete pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -3978,6 +4068,7 @@
         assert $6 same_as 'kubectl delete pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4020,6 +4111,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4063,6 +4155,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4105,6 +4198,7 @@
         assert $5 same_as 'kubectl describe '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -4149,6 +4243,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4191,6 +4286,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4231,6 +4327,7 @@
         assert $6 same_as 'kubectl describe pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4271,6 +4368,7 @@
         assert $6 same_as 'kubectl describe pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4311,6 +4409,7 @@
         assert $6 same_as 'kubectl describe pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4351,6 +4450,7 @@
         assert $6 same_as 'kubectl describe pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4393,6 +4493,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4436,6 +4537,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4478,6 +4580,7 @@
         assert $5 same_as 'kubectl get '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -4522,6 +4625,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4564,6 +4668,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -4604,6 +4709,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4644,6 +4750,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4683,6 +4790,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4722,6 +4830,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -4758,6 +4867,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -4793,6 +4903,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4830,6 +4941,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4867,6 +4979,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4904,6 +5017,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4941,6 +5055,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -4978,6 +5093,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5016,6 +5132,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5056,6 +5173,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5095,6 +5213,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5134,6 +5253,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -5170,6 +5290,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -5205,6 +5326,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5242,6 +5364,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5279,6 +5402,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5316,6 +5440,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5353,6 +5478,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5390,6 +5516,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5428,6 +5555,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5468,6 +5596,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5507,6 +5636,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5546,6 +5676,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -5582,6 +5713,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -5617,6 +5749,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5654,6 +5787,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5691,6 +5825,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5728,6 +5863,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5765,6 +5901,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5802,6 +5939,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5840,6 +5978,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5880,6 +6019,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5919,6 +6059,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -5958,6 +6099,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -5994,6 +6136,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6029,6 +6172,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6066,6 +6210,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6103,6 +6248,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6140,6 +6286,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6177,6 +6324,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6214,6 +6362,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -6255,6 +6404,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6300,6 +6450,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6341,6 +6492,7 @@
         assert $6 same_as 'kubectl get pods --label-columns='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6378,6 +6530,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6414,6 +6567,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6450,6 +6604,7 @@
         assert $6 same_as 'kubectl get pods --label-columns '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6487,6 +6642,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6523,6 +6679,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6559,6 +6716,7 @@
         assert $6 same_as 'kubectl get pods -L '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6596,6 +6754,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6632,6 +6791,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6668,6 +6828,7 @@
         assert $6 same_as 'kubectl get pods -L'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6705,6 +6866,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6741,6 +6903,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd, kube-apiserver, kube-controller-manager, kube-scheduler"
@@ -6779,6 +6942,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6822,6 +6986,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6864,6 +7029,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6905,6 +7071,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -6951,6 +7118,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -6993,6 +7161,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7035,6 +7204,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7077,6 +7247,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7119,6 +7290,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7161,6 +7333,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7203,6 +7376,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7245,6 +7419,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7281,6 +7456,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -7321,6 +7497,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -7369,6 +7546,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7414,6 +7592,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7459,6 +7638,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7504,6 +7684,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7549,6 +7730,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7594,6 +7776,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7639,6 +7822,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7684,6 +7868,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -7722,6 +7907,7 @@
         assert $5 same_as 'kubectl explain '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -7765,6 +7951,7 @@
         assert $5 same_as 'kubectl label '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -7808,6 +7995,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -7849,6 +8037,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -7889,6 +8078,7 @@
         assert $6 same_as 'kubectl label pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -7929,6 +8119,7 @@
         assert $6 same_as 'kubectl label pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -7969,6 +8160,7 @@
         assert $6 same_as 'kubectl label pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8009,6 +8201,7 @@
         assert $6 same_as 'kubectl label pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8045,6 +8238,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8077,6 +8271,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8114,6 +8309,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -8156,6 +8352,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -8194,6 +8391,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8228,6 +8426,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8266,6 +8465,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -8307,6 +8507,7 @@
         assert $5 same_as 'kubectl logs -f '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -8348,6 +8549,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -8388,6 +8590,7 @@
         assert $6 same_as 'kubectl logs pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8428,6 +8631,7 @@
         assert $6 same_as 'kubectl logs pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8468,6 +8672,7 @@
         assert $6 same_as 'kubectl logs pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8508,6 +8713,7 @@
         assert $6 same_as 'kubectl logs pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -8554,6 +8760,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8596,6 +8803,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8638,6 +8846,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8680,6 +8889,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8722,6 +8932,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8764,6 +8975,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8806,6 +9018,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8848,6 +9061,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -8884,6 +9098,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -8924,6 +9139,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -8972,6 +9188,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9017,6 +9234,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9062,6 +9280,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9107,6 +9326,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9152,6 +9372,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9197,6 +9418,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9242,6 +9464,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9287,6 +9510,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -9322,6 +9546,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000     ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -9357,6 +9582,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000     ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -9391,6 +9617,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME         ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}kubernetes   ${reset_color}ClusterIP   10.96.0.1    <none>        443/TCP                  1d    <none>"
@@ -9426,6 +9653,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9462,6 +9690,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9498,6 +9727,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9534,6 +9764,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9570,6 +9801,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9606,6 +9838,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9640,6 +9873,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -9674,6 +9908,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
@@ -9707,6 +9942,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
         assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
@@ -9743,6 +9979,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9781,6 +10018,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9819,6 +10057,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9857,6 +10096,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9895,6 +10135,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9933,6 +10174,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
         assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
@@ -9954,6 +10196,7 @@
         assert $4 same_as 'kubectl rollout '
 
         run cat
+        assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as history
         assert ${lines[2]} same_as pause
@@ -9994,6 +10237,7 @@
         assert $5 same_as 'kubectl rollout restart '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -10038,6 +10282,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10080,6 +10325,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10122,6 +10368,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10165,6 +10412,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10189,6 +10437,7 @@
         assert $4 same_as 'kubectl set '
 
         run cat
+        assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as env
         assert ${lines[2]} same_as image
@@ -10229,6 +10478,7 @@
         assert $5 same_as 'kubectl set env '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -10272,6 +10522,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10313,6 +10564,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10353,6 +10605,7 @@
         assert $6 same_as 'kubectl set env pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10393,6 +10646,7 @@
         assert $6 same_as 'kubectl set env pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10433,6 +10687,7 @@
         assert $6 same_as 'kubectl set env pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10473,6 +10728,7 @@
         assert $6 same_as 'kubectl set env pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10514,6 +10770,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10556,6 +10813,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10598,6 +10856,7 @@
         assert $5 same_as 'kubectl set image '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -10641,6 +10900,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10682,6 +10942,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -10722,6 +10983,7 @@
         assert $6 same_as 'kubectl set image pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10762,6 +11024,7 @@
         assert $6 same_as 'kubectl set image pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10802,6 +11065,7 @@
         assert $6 same_as 'kubectl set image pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10842,6 +11106,7 @@
         assert $6 same_as 'kubectl set image pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -10889,6 +11154,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -10932,6 +11198,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -10969,6 +11236,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11011,6 +11279,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11061,6 +11330,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -11107,6 +11377,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
         assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
@@ -11145,6 +11416,7 @@
         assert $5 same_as 'kubectl set resources '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -11188,6 +11460,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11229,6 +11502,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11269,6 +11543,7 @@
         assert $6 same_as 'kubectl set resources pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11309,6 +11584,7 @@
         assert $6 same_as 'kubectl set resources pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11349,6 +11625,7 @@
         assert $6 same_as 'kubectl set resources pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11389,6 +11666,7 @@
         assert $6 same_as 'kubectl set resources pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11430,6 +11708,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11472,6 +11751,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11514,6 +11794,7 @@
         assert $5 same_as 'kubectl set subject '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
         assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
@@ -11557,6 +11838,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11598,6 +11880,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11638,6 +11921,7 @@
         assert $6 same_as 'kubectl set subject pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11678,6 +11962,7 @@
         assert $6 same_as 'kubectl set subject pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11718,6 +12003,7 @@
         assert $6 same_as 'kubectl set subject pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11758,6 +12044,7 @@
         assert $6 same_as 'kubectl set subject pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -11799,6 +12086,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11841,6 +12129,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -11865,6 +12154,7 @@
         assert $4 same_as 'kubectl taint '
 
         run cat
+        assert kubectl mock_times 0
         assert ${#lines} equals 1
         assert ${lines[1]} same_as nodes
     }
@@ -11897,6 +12187,7 @@
         assert $6 same_as 'kubectl taint --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -11935,6 +12226,7 @@
         assert $6 same_as 'kubectl taint --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -11973,6 +12265,7 @@
         assert $6 same_as 'kubectl taint -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12011,6 +12304,7 @@
         assert $6 same_as 'kubectl taint -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12047,6 +12341,7 @@
         assert $5 same_as 'kubectl taint nodes '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
         assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
@@ -12080,6 +12375,7 @@
         assert $6 same_as 'kubectl taint nodes --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12118,6 +12414,7 @@
         assert $6 same_as 'kubectl taint nodes --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12156,6 +12453,7 @@
         assert $6 same_as 'kubectl taint nodes -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12194,6 +12492,7 @@
         assert $6 same_as 'kubectl taint nodes -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12231,6 +12530,7 @@
         assert $6 same_as 'kubectl taint nodes minikube '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY ${reset_color}  ${reset_color}VALUE ${reset_color}  EFFECT"
         assert ${lines[2]} same_as "${fg[yellow]}key1${reset_color}  ${reset_color}value1${reset_color}  NoSchedule"
@@ -12250,6 +12550,7 @@
         assert $4 same_as 'kubectl top '
 
         run cat
+        assert kubectl mock_times 0
         assert ${#lines} equals 2
         assert ${lines[1]} same_as nodes
         assert ${lines[2]} same_as pods
@@ -12281,6 +12582,7 @@
         assert $5 same_as 'kubectl top nodes '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
         assert ${lines[2]} same_as "${fg[yellow]}minikube   ${reset_color}Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13"
@@ -12314,6 +12616,7 @@
         assert $6 same_as 'kubectl top nodes --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12352,6 +12655,7 @@
         assert $6 same_as 'kubectl top nodes --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12390,6 +12694,7 @@
         assert $6 same_as 'kubectl top nodes -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12428,6 +12733,7 @@
         assert $6 same_as 'kubectl top nodes -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}kubernetes.io/arch                   ${reset_color}  amd64"
@@ -12469,6 +12775,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
@@ -12509,6 +12816,7 @@
         assert $6 same_as 'kubectl top pods --selector='
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -12549,6 +12857,7 @@
         assert $6 same_as 'kubectl top pods --selector '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -12589,6 +12898,7 @@
         assert $6 same_as 'kubectl top pods -l '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -12629,6 +12939,7 @@
         assert $6 same_as 'kubectl top pods -l'
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
         assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
@@ -12670,6 +12981,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
         assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"

--- a/tests/make.zunit
+++ b/tests/make.zunit
@@ -12,7 +12,7 @@
 
 @teardown {
     unmock grep
-    rm -f $tmpfile
+    rm -f -- $tmpfile
 }
 
 @test 'Testing completion: make **' {

--- a/tests/make.zunit
+++ b/tests/make.zunit
@@ -2,13 +2,17 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+
     pushd tests/_support/make
     tmpfile=$(mktemp)
     zmodload zsh/stat
 }
 
 @teardown {
-    rm -f $tmpfile grep_mock_times
+    unmock grep
+    rm -f $tmpfile
 }
 
 @test 'Testing completion: make **' {
@@ -30,14 +34,7 @@
 }
 
 @test 'Testing output: make **' {
-    echo 0 > grep_mock_times
-
-    grep() {
-        grep_mock_times=$(($(cat grep_mock_times) + 1))
-        echo $grep_mock_times > grep_mock_times
-
-        grep_mock_$grep_mock_times $@
-    }
+    mock grep
 
     grep_mock_1() {
         assert $# equals 3
@@ -46,7 +43,6 @@
         assert $3 same_as 'Makefile'
 
         echo "grep_mock_$grep_mock_times error" >&2
-        return 1
     }
 
     _fzf_complete() {
@@ -57,6 +53,7 @@
         assert $4 same_as 'make '
 
         run cat
+        assert grep mock_times 1
         assert ${#lines} equals 1
     }
 

--- a/tests/systemctl.zunit
+++ b/tests/systemctl.zunit
@@ -2,6 +2,10 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock systemctl
+    mock xargs
     FZF_DEFAULT_OPTS=--reverse
 
     preview() {
@@ -14,20 +18,11 @@
 }
 
 @teardown {
-    rm -f systemctl_mock_times
-    rm -f xargs_mock_times
+    unmock systemctl
+    unmock xargs
 }
 
 @test 'Testing completion: systemctl status **' {
-    echo 0 > systemctl_mock_times
-
-    systemctl() {
-        systemctl_mock_times=$(($(cat systemctl_mock_times) + 1))
-        echo $systemctl_mock_times > systemctl_mock_times
-
-        systemctl_mock_$systemctl_mock_times $@
-    }
-
     systemctl_mock_1() {
         assert $# equals 5
         assert $1 same_as 'list-units'
@@ -57,6 +52,7 @@
         assert $7 same_as 'systemctl status '
 
         run cat
+        assert systemctl mock_times 1
         assert ${#lines} equals 8
         assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
         assert ${lines[2]} same_as "${fg[green]}●${reset_color} -.slice"
@@ -73,15 +69,6 @@
 }
 
 @test 'Testing preview: systemctl status **' {
-    echo 0 > xargs_mock_times
-
-    xargs() {
-        xargs_mock_times=$(($(cat xargs_mock_times) + 1))
-        echo $xargs_mock_times > xargs_mock_times
-
-        xargs_mock_$xargs_mock_times $@
-    }
-
     xargs_mock_1() {
         assert $# equals 3
         assert $1 same_as 'systemctl'
@@ -124,6 +111,7 @@
     _fzf_complete() {
         output=$(fzf_options=($@) preview '● basic.target')
         lines=(${(f)output})
+        assert xargs mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as '● basic.target - Basic System'
         assert ${lines[2]} same_as '     Loaded: loaded (/usr/lib/systemd/system/basic.target; static; vendor preset: disabled)'
@@ -132,6 +120,7 @@
 
         output=$(fzf_options=($@) preview '● boot.mount')
         lines=(${(f)output})
+        assert xargs mock_times 2
         assert ${lines[1]} same_as '● boot.mount - /boot'
         assert ${lines[2]} same_as '     Loaded: loaded (/etc/fstab; generated)'
         assert ${lines[3]} same_as '     Active: active (mounted) since Wed 2020-01-01 00:00:00 JST; 2h ago'


### PR DESCRIPTION
Fixes and simplifies mocking in fzf-zsh-completions in a way every assertion error in mock functions is correctly handled!