### PR TITLE
Support rich assertion messages

### DIFF
--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -18,3 +18,28 @@ _zunit_assert_mock_times() {
         fi
     done
 }
+
+_zunit_post_assert() {
+    local -A replacements=(
+        \$reset_color $reset_color
+        \$bold_color $bold_color
+    )
+
+    local var key value name target
+    for var in fg fg_bold fg_no_bold bg bg_bold bg_no_bold; do
+        for key in ${(k)${(P)var}}; do
+            name="\$$var\[$key\]"
+            replacements[$name]=${${(P)var}[$key]}
+        done
+    done
+
+    local input=$(cat)
+    for key in ${(k)replacements}; do
+        target=${key//\\/}
+        [[ -z $tap ]] && target='\e[4;38;5;242m'$target'\e[4;31m'
+
+        input=${input//${replacements[$key]}/$target}
+    done
+
+    echo -n - $input
+}

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -2,6 +2,8 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/assertions.zsh
+
     pushd tests/_support/composer
 }
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -2,6 +2,8 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/assertions.zsh
+
     pushd tests/_support/git
     DIR=$PWD
     FZF_DEFAULT_OPTS=--reverse

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -2,6 +2,8 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/assertions.zsh
+
     pushd tests/_support/npm
 }
 

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -2,6 +2,8 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/assertions.zsh
+
     pushd tests/_support/npm
 }
 


### PR DESCRIPTION
The assertion messages that contain `$reset_color`, `$bold_color`, `$fg[*]`, `$fg_bold[*]`, `$fg_no_bold[*]`, `$bg[*]`, `$bg_bold[*]`, and `$bg_no_bold[*]` now get formatted so to print easy-to-understand ones.

## Before
![image](https://user-images.githubusercontent.com/6535425/118003414-86e25680-b383-11eb-94a3-e49a6b00b5c8.png)

## After
![image](https://user-images.githubusercontent.com/6535425/118003483-95c90900-b383-11eb-83c9-ef929a37564e.png)
