### PR TITLE
Fix a bug where stacked short option did not consider the other options that require an argument

### DIFF
--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -48,7 +48,7 @@ _fzf_complete_docker() {
 
     if [[ $subcommand = 'inspect' ]]; then
         local inspect_type
-        inspect_type=($(_fzf_complete_parse_option_arguments '' '--type' $arguments || :))
+        inspect_type=($(_fzf_complete_parse_option_arguments '' '--type' '' $arguments || :))
         inspect_type=${${${(Q)inspect_type}[-1]}#--type=}
 
         case $inspect_type in

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -9,7 +9,36 @@ _fzf_complete_kubectl() {
     local last_argument=${${(Q)${(z)@}}[-1]}
     local prefix_option completing_option arg subcommands namespace resource name
 
+    local inherit_option inherit_values
+    local kubectl_inherited_options_argument_required=(
+        --as
+        --as-group
+        --certificate-authority
+        --client-certificate
+        --client-key
+        --cluster
+        --context
+        -l
+        --label-columns
+        -L
+        -n
+        --namespace
+        --password
+        -s
+        --selector
+        --server
+        --tls-server-name
+        --token
+        --user
+        --username
+    )
+    local kubectl_inherited_options=(
+        --insecure-skip-tls-verify
+        --match-server-version
+    )
+
     local kubectl_options_argument_required=(
+        $kubectl_inherited_options_argument_required
         --application-metrics-count-limit
         --as
         --as-group
@@ -72,44 +101,17 @@ _fzf_complete_kubectl() {
     )
     local kubectl_options_argument_optional=()
 
-    local inherit_option inherit_values
-    local kubectl_inherited_options_argument_required=(
-        --as
-        --as-group
-        --certificate-authority
-        --client-certificate
-        --client-key
-        --cluster
-        --context
-        -l
-        --label-columns
-        -L
-        -n
-        --namespace
-        --password
-        -s
-        --selector
-        --server
-        --tls-server-name
-        --token
-        --user
-        --username
-    )
-    local kubectl_inherited_options=(
-        --insecure-skip-tls-verify
-        --match-server-version
-    )
 
     for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
         if [[ $inherit_option = --* ]]; then
             for arg in "$@" "$RBUFFER"; do
-                if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "$arg"); then
+                if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
             done
         else
             for arg in "$@" "$RBUFFER"; do
-                if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "$arg"); then
+                if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
             done
@@ -117,7 +119,7 @@ _fzf_complete_kubectl() {
     done
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' $@$RBUFFER || :)
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $@$RBUFFER || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -105,24 +105,29 @@ _fzf_complete_parse_argument() {
 
 _fzf_complete_parse_option_arguments() {
     local result=()
-    local current idx indices
+    local current idx indices preoptions
     local short=${1#*-}
     local long=${2#*--}
-    shift 2
+    local options_argument_required=(${(z)3})
+    shift 3
 
     local cmd=(${(Q)${(z)@}})
     while [[ $idx -le ${#cmd} ]]; do
         indices=()
 
         if [[ -n $short ]]; then
-            if [[ -n ${cmd[(rb:idx+1:)-[^-]#$short?##]} ]]; then
-                current=${cmd[(ib:idx+1:)-[^-]#$short?##]}
-                indices+=($current)
-                result[current]=${(qq)${cmd[current]/-[^-$short]#$short/-$short}}
+            if [[ -n ${cmd[(rb:idx+1:)-[^-=]#$short?##]} ]]; then
+                current=${cmd[(ib:idx+1:)-[^-=]#$short?##]}
+                preoptions=(-${^${(ps::)${${cmd[current]%%$short*}#-}}})
+
+                if [[ -z ${options_argument_required:*preoptions} ]]; then
+                    indices+=($current)
+                    result[current]=${(qq)${cmd[current]/-[^-=$short]#$short/-$short}}
+                fi
             fi
 
-            if [[ -n ${cmd[(rb:idx+1:)-[^-]#$short]} ]]; then
-                current=${cmd[(ib:idx+1:)-[^-]#$short]}
+            if [[ -n ${cmd[(rb:idx+1:)-[^-=]#$short]} ]]; then
+                current=${cmd[(ib:idx+1:)-[^-=]#$short]}
 
                 if [[ ${#cmd} != $current ]]; then
                     indices+=($current)


### PR DESCRIPTION
Fixes a parser that extracts `-name` by `-n` from `kubectl get pods -lname` as it doesn't know `-l` requires an argument. It now accepts the list of options that require an argument to correctly catch this case.

## Before
```zsh
_fzf_complete_parse_option_arguments '-n' '--namespace' 'kubectl get pods -lname'
# => '-name'
```

## After
```zsh
_fzf_complete_parse_option_arguments '-n' '--namespace' '-l -n' 'kubectl get pods -lname'
# =>
```