### PR TITLE
Improve `git reset **`

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -824,7 +824,7 @@ _fzf_complete_git-ls-files-and-ls-tree() {
             files+=($ls_tree)
         fi
 
-        local paths=($cdup${^${(u)files}})
+        local paths=($cdup${^${(u)${(o)files}}})
 
         echo -n ${(pj:\0:)paths}
     })

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -87,7 +87,7 @@ _fzf_complete_git() {
             fi
 
             if [[ $subcommand = 'log' ]]; then
-                _fzf_complete_git-ls-tree '' '--multi' $@
+                _fzf_complete_git-files_index '' '--multi' $@
                 return
             fi
         fi
@@ -131,7 +131,7 @@ _fzf_complete_git() {
             *)
                 local treeish
                 if treeish=$(_fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
-                    _fzf_complete_git-ls-tree '' '--multi' $@
+                    _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
@@ -230,7 +230,7 @@ _fzf_complete_git() {
 
             *)
                 if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s*]} ]]; then
-                    _fzf_complete_git-ls-tree '' '--multi' $@
+                    _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
@@ -278,7 +278,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                _fzf_complete_git-ls-files-and-ls-tree '' '' '--multi' $@
+                _fzf_complete_git-files_tree_and_index '' '' '--multi' $@
                 ;;
         esac
 
@@ -546,7 +546,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'rm' ]]; then
-        _fzf_complete_git-ls-files '' '--multi' $@
+        _fzf_complete_git-files_tree '' '--multi' $@
         return
     fi
 
@@ -670,7 +670,7 @@ _fzf_complete_git() {
 
                 if [[ $prefix = *:* ]]; then
                     treeish=${prefix%:*}
-                    prefix=${prefix#*:} _fzf_complete_git-ls-tree '' '' $@
+                    prefix=${prefix#*:} _fzf_complete_git-files_index '' '' $@
                     return
                 fi
 
@@ -759,7 +759,7 @@ _fzf_complete_git-commit-messages_post() {
     echo ${(qq)message}
 }
 
-_fzf_complete_git-ls-files() {
+_fzf_complete_git-files_tree() {
     local git_options=$1
     local fzf_options=$2
     shift 2
@@ -777,7 +777,7 @@ _fzf_complete_git-ls-files() {
     })
 }
 
-_fzf_complete_git-ls-files_post() {
+_fzf_complete_git-files_tree_post() {
     local filename
     local input=$(cat)
 
@@ -786,7 +786,7 @@ _fzf_complete_git-ls-files_post() {
     done
 }
 
-_fzf_complete_git-ls-tree() {
+_fzf_complete_git-files_index() {
     local git_options=$1
     local fzf_options=$2
     shift 2
@@ -794,7 +794,7 @@ _fzf_complete_git-ls-tree() {
     _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_ref < <(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_options} ${treeish-HEAD} 2> /dev/null)
 }
 
-_fzf_complete_git-ls-tree_post() {
+_fzf_complete_git-files_index_post() {
     local filename
     local input=$(cat)
 
@@ -803,7 +803,7 @@ _fzf_complete_git-ls-tree_post() {
     done
 }
 
-_fzf_complete_git-ls-files-and-ls-tree() {
+_fzf_complete_git-files_tree_and_index() {
     local git_ls_files_options=$1
     local git_ls_tree_options=$2
     local fzf_options=$3
@@ -826,7 +826,7 @@ _fzf_complete_git-ls-files-and-ls-tree() {
     })
 }
 
-_fzf_complete_git-ls-files-and-ls-tree_post() {
+_fzf_complete_git-files_tree_and_index_post() {
     local filename
     local input=$(cat)
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -274,7 +274,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' $arguments > /dev/null; then
+                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' $arguments > /dev/null; then
                     return
                 fi
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -813,7 +813,7 @@ _fzf_complete_git-ls-files-and-ls-tree() {
 
         local files=()
         local ls_files=$(git ls-files --deduplicate -z ${(Z+n+)git_ls_files_options} 2> /dev/null)
-        local ls_tree=$(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_ls_tree_options} ${treeish-HEAD} 2> /dev/null)
+        local ls_tree=$(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_ls_tree_options} ${treeish:-HEAD} 2> /dev/null)
         ls_files=(${(0)ls_files})
         ls_tree=(${(0)ls_tree})
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -274,7 +274,10 @@ _fzf_complete_git() {
                     return
                 fi
 
-                local both=$(_fzf_complete_parse_option '' '--soft --hard --merge --keep' $arguments || :)
+                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' $arguments > /dev/null; then
+                    return
+                fi
+
                 _fzf_complete_git-ls-files-and-ls-tree '' '' '--multi' $@
                 ;;
         esac
@@ -814,15 +817,8 @@ _fzf_complete_git-ls-files-and-ls-tree() {
         local files=()
         local ls_files=$(git ls-files --deduplicate -z ${(Z+n+)git_ls_files_options} 2> /dev/null)
         local ls_tree=$(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_ls_tree_options} ${treeish:-HEAD} 2> /dev/null)
-        ls_files=(${(0)ls_files})
-        ls_tree=(${(0)ls_tree})
-
-        if [[ -n $both ]]; then
-            files=(${ls_files:*ls_tree})
-        else
-            files+=($ls_files)
-            files+=($ls_tree)
-        fi
+        files+=(${(0)ls_files})
+        files+=(${(0)ls_tree})
 
         local paths=($cdup${^${(u)${(o)files}}})
 

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -103,6 +103,40 @@ _fzf_complete_parse_argument() {
     return $(( index > #command_arguments ))
 }
 
+_fzf_complete_parse_option() {
+    local result=()
+    local short=$1
+    local long=$2
+    shift 2
+
+    local shorts=${(pj::)${${(z)short}#*-}}
+    local longs=${(pj:|:)${(z)long}}
+
+    local cmd=(${(Q)${(z)@}})
+    local idx=1
+    while [[ $idx -le ${#cmd} ]]; do
+        if [[ -n $shorts ]]; then
+            if [[ ${cmd[idx]} =~ ^-([^\-$shorts]*[$shorts]+[^$shorts]*)+$ ]]; then
+                result+=(${(qq)cmd[idx]})
+            fi
+        fi
+
+        if [[ -n $longs ]]; then
+            if [[ ${cmd[idx]} =~ $longs ]]; then
+                result+=(${(qq)cmd[idx]})
+            fi
+        fi
+
+        (( idx += 1 ))
+    done
+
+    if [[ -z $result ]]; then
+        return 1
+    fi
+
+    echo - $result
+}
+
 _fzf_complete_parse_option_arguments() {
     local result=()
     local current idx indices preoptions
@@ -160,40 +194,6 @@ _fzf_complete_parse_option_arguments() {
         fi
 
         idx=(${${(n)indices}[1]})
-    done
-
-    if [[ -z $result ]]; then
-        return 1
-    fi
-
-    echo - $result
-}
-
-_fzf_complete_parse_option() {
-    local result=()
-    local short=$1
-    local long=$2
-    shift 2
-
-    local shorts=${(pj::)${${(z)short}#*-}}
-    local longs=${(pj:|:)${(z)long}}
-
-    local cmd=(${(Q)${(z)@}})
-    local idx=1
-    while [[ $idx -le ${#cmd} ]]; do
-        if [[ -n $shorts ]]; then
-            if [[ ${cmd[idx]} =~ ^-([^\-$shorts]*[$shorts]+[^$shorts]*)+$ ]]; then
-                result+=(${(qq)cmd[idx]})
-            fi
-        fi
-
-        if [[ -n $longs ]]; then
-            if [[ ${cmd[idx]} =~ $longs ]]; then
-                result+=(${(qq)cmd[idx]})
-            fi
-        fi
-
-        (( idx += 1 ))
     done
 
     if [[ -z $result ]]; then

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -168,3 +168,37 @@ _fzf_complete_parse_option_arguments() {
 
     echo - $result
 }
+
+_fzf_complete_parse_option() {
+    local result=()
+    local short=$1
+    local long=$2
+    shift 2
+
+    local shorts=${(pj::)${${(z)short}#*-}}
+    local longs=${(pj:|:)${(z)long}}
+
+    local cmd=(${(Q)${(z)@}})
+    local idx=1
+    while [[ $idx -le ${#cmd} ]]; do
+        if [[ -n $shorts ]]; then
+            if [[ ${cmd[idx]} =~ ^-([^\-$shorts]*[$shorts]+[^$shorts]*)+$ ]]; then
+                result+=(${(qq)cmd[idx]})
+            fi
+        fi
+
+        if [[ -n $longs ]]; then
+            if [[ ${cmd[idx]} =~ $longs ]]; then
+                result+=(${(qq)cmd[idx]})
+            fi
+        fi
+
+        (( idx += 1 ))
+    done
+
+    if [[ -z $result ]]; then
+        return 1
+    fi
+
+    echo - $result
+}

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -105,30 +105,23 @@ _fzf_complete_parse_argument() {
 
 _fzf_complete_parse_option() {
     local result=()
-    local short=$1
-    local long=$2
-    shift 2
-
-    local shorts=${(pj::)${${(z)short}#*-}}
-    local longs=${(pj:|:)${(z)long}}
+    local shorts=(${(z)1})
+    local longs=(${(z)2})
+    local options_argument_required=(${(z)3})
+    shift 3
 
     local cmd=(${(Q)${(z)@}})
-    local idx=1
-    while [[ $idx -le ${#cmd} ]]; do
-        if [[ -n $shorts ]]; then
-            if [[ ${cmd[idx]} =~ ^-([^\-$shorts]*[$shorts]+[^$shorts]*)+$ ]]; then
-                result+=(${(qq)cmd[idx]})
-            fi
-        fi
+    local cmd_shorts=(${(M)cmd:#-[^-]*})
 
-        if [[ -n $longs ]]; then
-            if [[ ${cmd[idx]} =~ $longs ]]; then
-                result+=(${(qq)cmd[idx]})
-            fi
-        fi
-
-        (( idx += 1 ))
+    local option_argument_required
+    for option_argument_required in $options_argument_required; do
+        cmd_shorts=(${cmd_shorts%%${option_argument_required#-}*})
     done
+
+    cmd_shorts=(-${^${(ps::)cmd_shorts}})
+
+    result+=(${cmd_shorts:*shorts})
+    result+=(${cmd:*longs})
 
     if [[ -z $result ]]; then
         return 1

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -882,7 +882,7 @@
     prefix=
     _fzf_complete_git 'git reset --soft -- '
 
-    pass
+    assert $? equals 0
 }
 
 @test 'Testing completion: git reset --hard -- **' {
@@ -893,7 +893,7 @@
     prefix=
     _fzf_complete_git 'git reset --hard -- '
 
-    pass
+    assert $? equals 0
 }
 
 @test 'Testing completion: git reset --merge -- **' {
@@ -904,7 +904,7 @@
     prefix=
     _fzf_complete_git 'git reset --merge -- '
 
-    pass
+    assert $? equals 0
 }
 
 @test 'Testing completion: git reset --keep -- **' {
@@ -915,7 +915,7 @@
     prefix=
     _fzf_complete_git 'git reset --keep -- '
 
-    pass
+    assert $? equals 0
 }
 
 @test 'Testing completion in subdirectory: git reset -- **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -5589,6 +5589,29 @@
     assert ${lines[6]} same_as "\$'directory2/file6\\ncontaining\\nnewlines'"
 }
 
+@test 'Testing post: git files in tree and index' {
+    input=(
+        'file1'
+        'directory1/file2'
+        ' file3 containing space '
+        $'file4\ncontaining\nnewlines'
+        ' file5 containing space '
+        $'directory2/file6\ncontaining\nnewlines'
+    )
+
+    run _fzf_complete_git-files_tree_and_index_post <<< ${(pj:\0:)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 6
+
+    assert ${lines[1]} same_as 'file1'
+    assert ${lines[2]} same_as 'directory1/file2'
+    assert ${lines[3]} same_as "' file3 containing space '"
+    assert ${lines[4]} same_as "\$'file4\\ncontaining\\nnewlines'"
+    assert ${lines[5]} same_as "' file5 containing space '"
+    assert ${lines[6]} same_as "\$'directory2/file6\\ncontaining\\nnewlines'"
+}
+
 @test 'Testing post: git notes' {
     input=(
         "notes/note1    Notes added by 'git notes add'"

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -874,120 +874,48 @@
     _fzf_complete_git 'git reset another-branch -- '
 }
 
-@test 'Testing completion: git reset --soft another-branch -- **' {
-    echo >> newfile
-    echo >> ' file3 containing space '
-    run git add newfile
-    run git add ' file3 containing space '
-
+@test 'Testing completion: git reset --soft -- **' {
     _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--read0'
-        assert $3 same_as '--print0'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset --soft another-branch -- '
-
-        run cat
-        assert ${#lines} equals 1
-
-        actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'file1'
+        fail '_fzf_complete should not be invoked'
     }
 
     prefix=
-    _fzf_complete_git 'git reset --soft another-branch -- '
+    _fzf_complete_git 'git reset --soft -- '
+
+    pass
 }
 
-@test 'Testing completion: git reset --hard another-branch -- **' {
-    echo >> newfile
-    echo >> ' file3 containing space '
-    run git add newfile
-    run git add ' file3 containing space '
-
+@test 'Testing completion: git reset --hard -- **' {
     _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--read0'
-        assert $3 same_as '--print0'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset --hard another-branch -- '
-
-        run cat
-        assert ${#lines} equals 1
-
-        actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'file1'
+        fail '_fzf_complete should not be invoked'
     }
 
     prefix=
-    _fzf_complete_git 'git reset --hard another-branch -- '
+    _fzf_complete_git 'git reset --hard -- '
+
+    pass
 }
 
-@test 'Testing completion: git reset --merge another-branch -- **' {
-    echo >> newfile
-    echo >> ' file3 containing space '
-    run git add newfile
-    run git add ' file3 containing space '
-
+@test 'Testing completion: git reset --merge -- **' {
     _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--read0'
-        assert $3 same_as '--print0'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset --merge another-branch -- '
-
-        run cat
-        assert ${#lines} equals 1
-
-        actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'file1'
+        fail '_fzf_complete should not be invoked'
     }
 
     prefix=
-    _fzf_complete_git 'git reset --merge another-branch -- '
+    _fzf_complete_git 'git reset --merge -- '
+
+    pass
 }
 
-@test 'Testing completion: git reset --keep another-branch -- **' {
-    echo >> newfile
-    echo >> ' file3 containing space '
-    run git add newfile
-    run git add ' file3 containing space '
-
+@test 'Testing completion: git reset --keep -- **' {
     _fzf_complete() {
-        assert $# equals 6
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--read0'
-        assert $3 same_as '--print0'
-        assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset --keep another-branch -- '
-
-        run cat
-        assert ${#lines} equals 1
-
-        actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'file1'
+        fail '_fzf_complete should not be invoked'
     }
 
     prefix=
-    _fzf_complete_git 'git reset --keep another-branch -- '
+    _fzf_complete_git 'git reset --keep -- '
+
+    pass
 }
 
 @test 'Testing completion in subdirectory: git reset -- **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -775,7 +775,7 @@
 
 @test 'Testing completion: git reset another-branch **' {
     echo >> newfile
-    run git add newlines
+    run git add newfile
 
     _fzf_complete() {
         assert $# equals 6
@@ -929,7 +929,7 @@
     }
 
     prefix=
-    _fzf_complete_git 'git reset --hard another-branch-- '
+    _fzf_complete_git 'git reset --hard another-branch -- '
 }
 
 @test 'Testing completion: git reset --merge another-branch -- **' {
@@ -958,7 +958,7 @@
     }
 
     prefix=
-    _fzf_complete_git 'git reset --merge another-branch-- '
+    _fzf_complete_git 'git reset --merge another-branch -- '
 }
 
 @test 'Testing completion: git reset --keep another-branch -- **' {
@@ -1013,9 +1013,9 @@
 
         actual1=(${(0)lines[1]})
         assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as ' file3 containing space '
-        assert ${actual1[2]} same_as 'directory1/file2'
-        assert ${actual1[3]} same_as 'directory2/file4'
+        assert ${actual1[1]} same_as '../ file3 containing space '
+        assert ${actual1[2]} same_as '../directory1/file2'
+        assert ${actual1[3]} same_as '../directory2/file4'
 
         actual2=(${(0)lines[2]})
         assert ${#actual2} equals 1
@@ -1024,7 +1024,7 @@
         actual3=(${(0)lines[3]})
         assert ${#actual3} equals 2
         assert ${actual3[1]} same_as 'newlines'
-        assert ${actual3[2]} same_as 'file1'
+        assert ${actual3[2]} same_as '../file1'
     }
 
     prefix=

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -773,12 +773,9 @@
     _fzf_complete_git 'git reset '
 }
 
-@test 'Testing completion: git reset -- **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
+@test 'Testing completion: git reset another-branch **' {
+    echo >> newfile
+    run git add newlines
 
     _fzf_complete() {
         assert $# equals 6
@@ -787,7 +784,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git reset -- '
+        assert $6 same_as 'git reset another-branch '
 
         run cat
         assert ${#lines} equals 3
@@ -803,13 +800,194 @@
         assert ${actual2[1]} same_as 'containing'
 
         actual3=(${(0)lines[3]})
-        assert ${#actual3} equals 2
+        assert ${#actual3} equals 3
         assert ${actual3[1]} same_as 'newlines'
         assert ${actual3[2]} same_as 'file1'
+        assert ${actual3[3]} same_as 'newfile'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset another-branch '
+}
+
+@test 'Testing completion: git reset -- **' {
+    echo >> newfile
+    run git add newfile
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset -- '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as 'directory1/file2'
+        assert ${actual1[2]} same_as 'file1'
+        assert ${actual1[3]} same_as 'newfile'
     }
 
     prefix=
     _fzf_complete_git 'git reset -- '
+}
+
+@test 'Testing completion: git reset another-branch -- **' {
+    echo >> newfile
+    run git add newfile
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset another-branch -- '
+
+        run cat
+        assert ${#lines} equals 3
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'directory2/file4'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'containing'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 3
+        assert ${actual3[1]} same_as 'newlines'
+        assert ${actual3[2]} same_as 'file1'
+        assert ${actual3[3]} same_as 'newfile'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset another-branch -- '
+}
+
+@test 'Testing completion: git reset --soft another-branch -- **' {
+    echo >> newfile
+    echo >> ' file3 containing space '
+    run git add newfile
+    run git add ' file3 containing space '
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset --soft another-branch -- '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset --soft another-branch -- '
+}
+
+@test 'Testing completion: git reset --hard another-branch -- **' {
+    echo >> newfile
+    echo >> ' file3 containing space '
+    run git add newfile
+    run git add ' file3 containing space '
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset --hard another-branch -- '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset --hard another-branch-- '
+}
+
+@test 'Testing completion: git reset --merge another-branch -- **' {
+    echo >> newfile
+    echo >> ' file3 containing space '
+    run git add newfile
+    run git add ' file3 containing space '
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset --merge another-branch -- '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset --merge another-branch-- '
+}
+
+@test 'Testing completion: git reset --keep another-branch -- **' {
+    echo >> newfile
+    echo >> ' file3 containing space '
+    run git add newfile
+    run git add ' file3 containing space '
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'git reset --keep another-branch -- '
+
+        run cat
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 3
+        assert ${actual1[1]} same_as ' file3 containing space '
+        assert ${actual1[2]} same_as 'directory1/file2'
+        assert ${actual1[3]} same_as 'file1'
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset --keep another-branch -- '
 }
 
 @test 'Testing completion in subdirectory: git reset -- **' {


### PR DESCRIPTION
Resolves #129 

`_fzf_complete_parse_option` is checking whether the specified options exist. What are listed differ in whether one of `--soft`, `--hard`, `--merge` or `--keep` exists.  `[[ -n ${${(Q)${(z)arguments}}[(r)--soft]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)--hard]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)--merged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)--keep]} ]]` is very long so this function is implemented.

When `--mixed` exists (in case the options don't exist is also the same), we can reset the files either under the working tree or the `<tree-ish>`. For example (1852ebb is the first commit of this repository):
```zsh
$ git reset 1852ebb -- .editorconfig
$ git status --porcelain=v1
D  .editorconfig
?? .editorconfig

$ git reset 1852ebb -- git.zsh
$ git status --porcelain=v1
AD git.zsh
```
Because of that, it displays the files that are merged `git ls-files` and `git ls-tree <tree-ish>`:
https://github.com/chitoku-k/fzf-zsh-completions/blob/fd5c585db4814c8b4fd2642a1f4b4e212b72357b/src/completers/git.zsh#L823-L824

ref: https://git-scm.com/docs/git-reset