### PR TITLE
Support --user and inactive units

### DIFF
--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -5,29 +5,40 @@ colors
 
 _fzf_complete_preview_systemctl_status=$(cat <<'PREVIEW_OPTIONS'
     --preview-window=right:70%:wrap
-    --preview='echo {} | awk '\''{ print $2 }'\'' | xargs systemctl status --'
+    --preview='echo {} | awk '\''{ print $2 }'\'' | SYSTEMD_COLORS=true xargs systemctl status $SYSTEMCTL_OPTIONS --'
 PREVIEW_OPTIONS
 )
 
 _fzf_complete_systemctl() {
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)_fzf_complete_preview_systemctl_status}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
-        <(systemctl list-units --full --no-legend --no-pager "$prefix*" | LC_ALL=C sort | awk \
-            -v green=${fg[green]} \
-            -v red=${fg[red]} \
-            -v reset=$reset_color '
-            {
-                unitname = $1
-                status = $3
+    local arguments=$@
+    local systemctl_options=(--full --no-legend --no-pager)
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $arguments)) || :
 
-                if (status == "active") {
-                    active_color = green
-                }
-                if (status == "failed") {
-                    active_color = red
-                }
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
+        <({
+            systemctl list-units ${(Q)${(Z+n+)systemctl_options}} "$prefix*"
+            systemctl list-unit-files ${(Q)${(Z+n+)systemctl_options}} "$prefix*" | awk '{ print $1 }'
+        } |
+            LC_ALL=C sort -b -f -k 1,1 -k 3,3r |
+            awk \
+                -v green=${fg[green]} \
+                -v red=${fg[red]} \
+                -v reset=$reset_color '
+                $1 !~ /@\.(service|socket|target)$/ && !($1 in units) {
+                    unitname = $1
+                    status = $3
+                    units[unitname] = 1
 
-                printf("%s●%s %s\n", active_color, reset, unitname)
-            }')
+                    if (status == "active") {
+                        indicator = green "●" reset
+                    } else if (status == "failed") {
+                        indicator = red "●" reset
+                    } else {
+                        indicator = "○"
+                    }
+
+                    print indicator, unitname
+                }')
 }
 
 _fzf_complete_systemctl_post() {

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -17,7 +17,7 @@ _fzf_complete_systemctl() {
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
         <({
             systemctl list-units ${(Q)${(Z+n+)systemctl_options}} "$prefix*"
-            systemctl list-unit-files ${(Q)${(Z+n+)systemctl_options}} "$prefix*" | awk '{ print $1 }'
+            systemctl list-unit-files ${(Q)${(Z+n+)systemctl_options}} "$prefix*"
         } |
             LC_ALL=C sort -b -f -k 1,1 -k 3,3r |
             awk \

--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -5,7 +5,7 @@ _zunit_assert_mock_times() {
 
     local len=$(cat -- ${target}_mock_times)
     if [[ $len != $count ]]; then
-        echo "'$target' is called for $len times(s)"
+        echo "'$target' is called $len time(s)"
         exit 1
     fi
 
@@ -14,6 +14,7 @@ _zunit_assert_mock_times() {
         local mock=${target}_mock_$i
         if [[ -e ${mock}_fail ]]; then
             echo "$mock: $(cat -- ${mock}_fail)"
+            rm -f -- ${mock}_fail
             exit 1
         fi
     done

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -25,5 +25,14 @@ unmock() {
         unfunction $target
     fi
 
+    local i
+    local len=$(cat -- ${target}_mock_times)
+    for (( i = 1; i <= len; i++ )); do
+        local mock=${target}_mock_$i
+        if [[ -e ${mock}_fail ]]; then
+            echo "$mock: $(cat -- ${mock}_fail)"
+        fi
+    done
+
     rm -f -- ${target}_mock_times ${target}_mock_*_fail(N)
 }

--- a/tests/systemctl.zunit
+++ b/tests/systemctl.zunit
@@ -41,6 +41,26 @@
         echo 'dbus.socket  loaded failed running D-Bus System Message Bus Socket'
     }
 
+    systemctl_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'list-unit-files'
+        assert $2 same_as '--full'
+        assert $3 same_as '--no-legend'
+        assert $4 same_as '--no-pager'
+        assert $5 same_as '*'
+
+        echo '-.mount           generated -'
+        echo 'boot.mount        generated -'
+        echo 'dbus.service      static    -'
+        echo 'ip6tables.service disabled  disabled'
+        echo 'iptables.service  disabled  disabled'
+        echo 'user@.service     static    -'
+        echo 'user.slice        static    -'
+        echo 'basic.target      static    -'
+        echo 'blockdev@.target  static    -'
+        echo 'dbus.socket       static    -'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -52,28 +72,93 @@
         assert $7 same_as 'systemctl status '
 
         run cat
-        assert systemctl mock_times 1
-        assert ${#lines} equals 8
+        assert systemctl mock_times 2
+        assert ${#lines} equals 10
         assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
         assert ${lines[2]} same_as "${fg[green]}●${reset_color} -.slice"
         assert ${lines[3]} same_as "${fg[green]}●${reset_color} basic.target"
         assert ${lines[4]} same_as "${fg[green]}●${reset_color} boot.mount"
         assert ${lines[5]} same_as "${fg[green]}●${reset_color} dbus.service"
         assert ${lines[6]} same_as "${fg[red]}●${reset_color} dbus.socket"
-        assert ${lines[7]} same_as "${fg[green]}●${reset_color} system.slice"
-        assert ${lines[8]} same_as "${fg[green]}●${reset_color} user.slice"
+        assert ${lines[7]} same_as "○ ip6tables.service"
+        assert ${lines[8]} same_as "○ iptables.service"
+        assert ${lines[9]} same_as "${fg[green]}●${reset_color} system.slice"
+        assert ${lines[10]} same_as "${fg[green]}●${reset_color} user.slice"
     }
 
     prefix=
     _fzf_complete_systemctl 'systemctl status '
 }
 
+@test 'Testing completion: systemctl status --user **' {
+    systemctl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'list-units'
+        assert $2 same_as '--full'
+        assert $3 same_as '--no-legend'
+        assert $4 same_as '--no-pager'
+        assert $5 same_as '--user'
+        assert $6 same_as '*'
+
+        echo '-.mount      loaded active mounted Root Mount'
+        echo 'boot.mount   loaded active mounted /boot'
+        echo 'dbus.service loaded active running D-Bus System Message Bus'
+        echo '-.slice      loaded active active  Root Slice'
+        echo 'basic.target loaded active active  Basic System'
+        echo 'dbus.socket  loaded failed running D-Bus System Message Bus Socket'
+    }
+
+    systemctl_mock_2() {
+        assert $# equals 6
+        assert $1 same_as 'list-unit-files'
+        assert $2 same_as '--full'
+        assert $3 same_as '--no-legend'
+        assert $4 same_as '--no-pager'
+        assert $5 same_as '--user'
+        assert $6 same_as '*'
+
+        echo 'dbus.service      static    -'
+        echo 'basic.target      static    -'
+        echo 'dbus.socket       static    -'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--preview-window=right:70%:wrap'
+        assert $4 matches '--preview=*'
+        assert $5 same_as '--reverse'
+        assert $6 same_as '--'
+        assert $7 same_as 'systemctl status --user '
+
+        run cat
+        assert systemctl mock_times 2
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
+        assert ${lines[2]} same_as "${fg[green]}●${reset_color} -.slice"
+        assert ${lines[3]} same_as "${fg[green]}●${reset_color} basic.target"
+        assert ${lines[4]} same_as "${fg[green]}●${reset_color} boot.mount"
+        assert ${lines[5]} same_as "${fg[green]}●${reset_color} dbus.service"
+        assert ${lines[6]} same_as "${fg[red]}●${reset_color} dbus.socket"
+    }
+
+    prefix=
+    _fzf_complete_systemctl 'systemctl status --user '
+}
+
 @test 'Testing preview: systemctl status **' {
+    systemctl_mock_1() {}
+    systemctl_mock_2() {}
+
     xargs_mock_1() {
-        assert $# equals 3
+        assert $# equals 6
         assert $1 same_as 'systemctl'
         assert $2 same_as 'status'
-        assert $3 same_as '--'
+        assert $3 same_as '--full'
+        assert $4 same_as '--no-legend'
+        assert $5 same_as '--no-pager'
+        assert $6 same_as '--'
 
         run cat
         assert ${#lines} equals 1
@@ -86,10 +171,13 @@
     }
 
     xargs_mock_2() {
-        assert $# equals 3
+        assert $# equals 6
         assert $1 same_as 'systemctl'
         assert $2 same_as 'status'
-        assert $3 same_as '--'
+        assert $3 same_as '--full'
+        assert $4 same_as '--no-legend'
+        assert $5 same_as '--no-pager'
+        assert $6 same_as '--'
 
         run cat
         assert ${#lines} equals 1
@@ -136,6 +224,87 @@
 
     prefix=
     _fzf_complete_systemctl 'systemctl status '
+}
+
+@test 'Testing preview: systemctl status --user **' {
+    systemctl_mock_1() {}
+    systemctl_mock_2() {}
+
+    xargs_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'systemctl'
+        assert $2 same_as 'status'
+        assert $3 same_as '--full'
+        assert $4 same_as '--no-legend'
+        assert $5 same_as '--no-pager'
+        assert $6 same_as '--user'
+        assert $7 same_as '--'
+
+        run cat
+        assert ${#lines} equals 1
+        assert ${lines[1]} same_as 'basic.target'
+
+        echo '● basic.target - Basic System'
+        echo '     Loaded: loaded (/usr/lib/systemd/system/basic.target; static; vendor preset: disabled)'
+        echo '     Active: active since Wed 2020-01-01 00:00:00 JST; 2h ago'
+        echo '       Docs: man:systemd.special(7)'
+    }
+
+    xargs_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'systemctl'
+        assert $2 same_as 'status'
+        assert $3 same_as '--full'
+        assert $4 same_as '--no-legend'
+        assert $5 same_as '--no-pager'
+        assert $6 same_as '--user'
+        assert $7 same_as '--'
+
+        run cat
+        assert ${#lines} equals 1
+        assert ${lines[1]} same_as 'boot.mount'
+
+        echo '● boot.mount - /boot'
+        echo '     Loaded: loaded (/etc/fstab; generated)'
+        echo '     Active: active (mounted) since Wed 2020-01-01 00:00:00 JST; 2h ago'
+        echo '       Docs: man:systemd.special(7)'
+        echo '      Where: /boot'
+        echo '       What: /dev/sda2'
+        echo '       Docs: man:fstab(5)'
+        echo '             man:systemd-fstab-generator(8)'
+        echo '      Tasks: 0 (limit: 2367)'
+        echo '     Memory: 120.0K'
+        echo '     CGroup: /system.slice/boot.mount'
+    }
+
+    _fzf_complete() {
+        output=$(fzf_options=($@) preview '● basic.target')
+        lines=(${(f)output})
+        assert xargs mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as '● basic.target - Basic System'
+        assert ${lines[2]} same_as '     Loaded: loaded (/usr/lib/systemd/system/basic.target; static; vendor preset: disabled)'
+        assert ${lines[3]} same_as '     Active: active since Wed 2020-01-01 00:00:00 JST; 2h ago'
+        assert ${lines[4]} same_as '       Docs: man:systemd.special(7)'
+
+        output=$(fzf_options=($@) preview '● boot.mount')
+        lines=(${(f)output})
+        assert xargs mock_times 2
+        assert ${lines[1]} same_as '● boot.mount - /boot'
+        assert ${lines[2]} same_as '     Loaded: loaded (/etc/fstab; generated)'
+        assert ${lines[3]} same_as '     Active: active (mounted) since Wed 2020-01-01 00:00:00 JST; 2h ago'
+        assert ${lines[4]} same_as '       Docs: man:systemd.special(7)'
+        assert ${lines[5]} same_as '      Where: /boot'
+        assert ${lines[6]} same_as '       What: /dev/sda2'
+        assert ${lines[7]} same_as '       Docs: man:fstab(5)'
+        assert ${lines[8]} same_as '             man:systemd-fstab-generator(8)'
+        assert ${lines[9]} same_as '      Tasks: 0 (limit: 2367)'
+        assert ${lines[10]} same_as '     Memory: 120.0K'
+        assert ${lines[11]} same_as '     CGroup: /system.slice/boot.mount'
+    }
+
+    prefix=
+    _fzf_complete_systemctl 'systemctl status --user '
 }
 
 @test 'Testing post: systemctl' {


### PR DESCRIPTION
Fix `systemctl **<TAB>` to correctly handle user units and inactive units.