### PR TITLE
Support parameter assignment before command

### DIFF
--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -1,10 +1,10 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_composer() {
-    local arguments=$(_fzf_complete_trim_env $@)
-    local cmd=${${(Q)${(z)arguments}}[(w)1]}
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local subcommand=${arguments[2]}
 
-    if [[ $cmd = 'composer' ]]; then
+    if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run-script' ]]; then
         _fzf_complete_composer-run-script '' $@
         return
     fi

--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -1,10 +1,10 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_composer() {
-    local arguments=("${(Q)${(z)@}[@]}")
-    local subcommand=${arguments[2]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local cmd=${${(Q)${(z)arguments}}[(w)1]}
 
-    if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run-script' ]]; then
+    if [[ $cmd = 'composer' ]]; then
         _fzf_complete_composer-run-script '' $@
         return
     fi

--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -1,15 +1,15 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_composer() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 
     if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run-script' ]]; then
-        _fzf_complete_composer-run-script '' $@
+        _fzf_complete_composer-run-script '' "$@"
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_composer-run-script() {
@@ -21,7 +21,7 @@ _fzf_complete_composer-run-script() {
         return
     fi
 
-    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(php -r '
+    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(php -r '
         echo implode(
             "\0",
             array_keys(

--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -1,7 +1,9 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_composer() {
-    if [[ $@ = 'composer'* ]]; then
+    local arguments=$(_fzf_complete_trim_env $@)
+
+    if [[ $arguments = 'composer'* ]]; then
         _fzf_complete_composer-run-script '' $@
         return
     fi

--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -2,8 +2,9 @@
 
 _fzf_complete_composer() {
     local arguments=$(_fzf_complete_trim_env $@)
+    local cmd=${${(Q)${(z)arguments}}[(w)1]}
 
-    if [[ $arguments = 'composer'* ]]; then
+    if [[ $cmd = 'composer' ]]; then
         _fzf_complete_composer-run-script '' $@
         return
     fi

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -4,8 +4,8 @@ autoload -U colors
 colors
 
 _fzf_complete_docker() {
-    local arguments=$(_fzf_complete_trim_env $@)
-    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local subcommand=${arguments[2]}
 
     if [[ $subcommand =~ ^(create|history|run)$ ]]; then
         _fzf_complete_docker-images '' $@

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -4,44 +4,44 @@ autoload -U colors
 colors
 
 _fzf_complete_docker() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 
     if [[ $subcommand =~ ^(create|history|run)$ ]]; then
-        _fzf_complete_docker-images '' $@
+        _fzf_complete_docker-images '' "$@"
         return
     fi
 
     if [[ $subcommand = 'push' ]]; then
-        _fzf_complete_docker-images-repository '' $@
+        _fzf_complete_docker-images-repository '' "$@"
         return
     fi
 
     if [[ $subcommand =~ ^(rmi|save|tag)$ ]]; then
-        _fzf_complete_docker-images '--multi' $@
+        _fzf_complete_docker-images '--multi' "$@"
         return
     fi
 
     if [[ $subcommand =~ ^(attach|exec|top)$ ]]; then
-        _fzf_complete_docker-containers '' '' $@
+        _fzf_complete_docker-containers '' '' "$@"
         return
     fi
 
     if [[ $subcommand =~ ^(kill|pause|stop|unpause)$ ]]; then
-        _fzf_complete_docker-containers '' '--multi' $@
+        _fzf_complete_docker-containers '' '--multi' "$@"
         return
     fi
 
     if [[ $subcommand =~ ^(commit|diff|export|logs|port|rename)$ ]]; then
-        _fzf_complete_docker-containers '--all' '' $@
+        _fzf_complete_docker-containers '--all' '' "$@"
         return
     fi
 
     if [[ $subcommand = 'cp' ]]; then
         if [[ $prefix = */* ]]; then
-            _fzf_path_completion "$prefix" $@
+            _fzf_path_completion "$prefix" "$@"
         else
-            _fzf_complete_docker-containers '--all' '' $@
+            _fzf_complete_docker-containers '--all' '' "$@"
         fi
         return
     fi
@@ -53,26 +53,26 @@ _fzf_complete_docker() {
 
         case $inspect_type in
             image)
-                _fzf_complete_docker-images '--multi' $@
+                _fzf_complete_docker-images '--multi' "$@"
                 ;;
 
             network)
-                _fzf_complete_docker-networks '--multi' $@
+                _fzf_complete_docker-networks '--multi' "$@"
                 ;;
 
             volume)
-                _fzf_complete_docker-volumes '--multi' $@
+                _fzf_complete_docker-volumes '--multi' "$@"
                 ;;
 
             container)
-                _fzf_complete_docker-containers '--all' '--multi' $@
+                _fzf_complete_docker-containers '--all' '--multi' "$@"
                 ;;
 
             task)
                 ;;
 
             '')
-                _fzf_complete_docker-containers '--all' '--multi' $@
+                _fzf_complete_docker-containers '--all' '--multi' "$@"
                 ;;
         esac
 
@@ -80,18 +80,18 @@ _fzf_complete_docker() {
     fi
 
     if [[ $subcommand =~ ^(restart|rm|start|stats|update|wait)$ ]]; then
-        _fzf_complete_docker-containers '--all' '--multi' $@
+        _fzf_complete_docker-containers '--all' '--multi' "$@"
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_docker-images() {
     local fzf_options=$1
     shift 1
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
         docker images --format 'table {{.ID}};{{.Repository}};{{.Tag}};{{if .CreatedSince}}{{.CreatedSince}}{{else}}N/A{{end}};{{.Size}}' 2> /dev/null \
             | FS=';' _fzf_complete_tabularize $fg[yellow] $reset_color{,,}
     )
@@ -105,7 +105,7 @@ _fzf_complete_docker-images-repository() {
     local fzf_options=$1
     shift 1
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
         docker images --filter 'dangling=false' --format 'table {{.Repository}};{{.ID}};{{.Tag}};{{if .CreatedSince}}{{.CreatedSince}}{{else}}N/A{{end}};{{.Size}}' 2> /dev/null \
             | FS=';' _fzf_complete_tabularize $fg[yellow] $reset_color{,,}
     )
@@ -126,7 +126,7 @@ _fzf_complete_docker-containers() {
     local fzf_options=$2
     shift 2
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
         docker container list ${(Q)${(Z+n+)docker_options}} \
             --format 'table {{.ID}};{{.Image}};{{.Command}};{{.RunningFor}};{{.Status}};{{.Ports}};{{.Names}}' 2> /dev/null \
                 | FS=';' _fzf_complete_tabularize $fg[yellow] $reset_color{,,,,}
@@ -151,7 +151,7 @@ _fzf_complete_docker-networks() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
         docker network list --format 'table {{.ID}};{{.Name}};{{.Driver}};{{.Scope}}' 2> /dev/null \
             | FS=';' _fzf_complete_tabularize $fg[yellow] $reset_color{,}
     )
@@ -165,7 +165,7 @@ _fzf_complete_docker-volumes() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
         docker volume list --format 'table {{.Name}};{{.Driver}};{{.Scope}}' 2> /dev/null \
             | FS=';' _fzf_complete_tabularize $fg[yellow] $reset_color
     )

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -4,8 +4,8 @@ autoload -U colors
 colors
 
 _fzf_complete_docker() {
-    local arguments=$@
-    local subcommand=${${(Q)${(z)@}}[2]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local subcommand=${${(Q)${(z)arguments}}[2]}
 
     if [[ $subcommand =~ ^(create|history|run)$ ]]; then
         _fzf_complete_docker-images '' $@

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -5,7 +5,7 @@ colors
 
 _fzf_complete_docker() {
     local arguments=$(_fzf_complete_trim_env $@)
-    local subcommand=${${(Q)${(z)arguments}}[2]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand =~ ^(create|history|run)$ ]]; then
         _fzf_complete_docker-images '' $@

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -4,8 +4,8 @@ autoload -U colors
 colors
 
 _fzf_complete_docker() {
-    local arguments=("${(Q)${(z)@}[@]}")
-    local subcommand=${arguments[2]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand =~ ^(create|history|run)$ ]]; then
         _fzf_complete_docker-images '' $@

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+
+_fzf_complete_env() {
+    local arguments=(${(Q)${(z)@}})
+    arguments=($(_fzf_complete_trim_env "${arguments[2,-1]}"))
+    local cmd=${${${arguments}}[1]}
+
+    if (( $+functions[_fzf_complete_$cmd] )); then
+        LBUFFER=${LBUFFER/env /}
+        _fzf_complete_$cmd ${@/env /}
+        LBUFFER="env $LBUFFER"
+        return
+    fi
+
+    _fzf_path_completion "$prefix" $@
+}

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -7,10 +7,10 @@ _fzf_complete_env() {
 
     if (( $+functions[_fzf_complete_$cmd] )); then
         LBUFFER=${LBUFFER/env /}
-        _fzf_complete_$cmd ${@/env /}
+        _fzf_complete_$cmd "${@/env /}"
         LBUFFER="env $LBUFFER"
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -2,8 +2,8 @@
 
 _fzf_complete_env() {
     local arguments=("${(Q)${(z)@}[@]}")
-    arguments=($(_fzf_complete_trim_env "${arguments[2,-1]}"))
-    local cmd=${arguments[1]}
+    arguments=($(_fzf_complete_trim_env "${${(q)arguments[2,-1][@]}}"))
+    local cmd=${(Q)arguments[1]}
 
     if (( $+functions[_fzf_complete_$cmd] )); then
         LBUFFER=${LBUFFER/env /}

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -1,9 +1,9 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_env() {
-    local arguments=(${(Q)${(z)@}})
+    local arguments=("${(Q)${(z)@}[@]}")
     arguments=($(_fzf_complete_trim_env "${arguments[2,-1]}"))
-    local cmd=${${${arguments}}[1]}
+    local cmd=${arguments[1]}
 
     if (( $+functions[_fzf_complete_$cmd] )); then
         LBUFFER=${LBUFFER/env /}

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_gh() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local gh_command=${arguments[2]}
     local gh_subcommand=${arguments[3]}
     local last_argument=${arguments[-1]}
@@ -23,15 +23,15 @@ _fzf_complete_gh() {
 
             *)
                 if [[ $gh_subcommand =~ '(close|merge|ready)' ]]; then
-                    _fzf_complete_gh-pr '' 'open' $@
+                    _fzf_complete_gh-pr '' 'open' "$@"
                 fi
 
                 if [[ $gh_subcommand = 'reopen' ]]; then
-                    _fzf_complete_gh-pr '' 'closed' $@
+                    _fzf_complete_gh-pr '' 'closed' "$@"
                 fi
 
                 if [[ $gh_subcommand =~ '(checkout|comment|diff|edit|review|view)' ]]; then
-                    _fzf_complete_gh-pr '' 'all' $@
+                    _fzf_complete_gh-pr '' 'all' "$@"
                 fi
 
                 return
@@ -41,7 +41,7 @@ _fzf_complete_gh() {
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_gh-pr() {
@@ -49,7 +49,7 @@ _fzf_complete_gh-pr() {
     local pr_state=$2
     shift 2
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <({
         echo "#\tTITLE\tHEAD\tSTATE"
         gh pr list --state $pr_state
     } | FS="\t" _fzf_complete_tabularize ${fg[yellow]} $reset_color ${fg[blue]} ${fg[green]})

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_gh() {
-    local arguments=$@
+    local arguments=$(_fzf_complete_trim_env $@)
     local gh_command=${${(Q)${(z)arguments}}[2]}
     local gh_subcommand=${${(Q)${(z)arguments}}[3]}
     local last_argument=${${(Q)${(z)arguments}}[-1]}

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -5,9 +5,9 @@ colors
 
 _fzf_complete_gh() {
     local arguments=$(_fzf_complete_trim_env $@)
-    local gh_command=${${(Q)${(z)arguments}}[2]}
-    local gh_subcommand=${${(Q)${(z)arguments}}[3]}
-    local last_argument=${${(Q)${(z)arguments}}[-1]}
+    local gh_command=${${(Q)${(z)arguments}}[(w)2]}
+    local gh_subcommand=${${(Q)${(z)arguments}}[(w)3]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
 
     if [[ $gh_command = 'pr' ]]; then
         local prefix_option completing_option

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -4,10 +4,10 @@ autoload -U colors
 colors
 
 _fzf_complete_gh() {
-    local arguments=("${(Q)${(z)@}[@]}")
-    local gh_command=${arguments[2]}
-    local gh_subcommand=${arguments[3]}
-    local last_argument=${arguments[-1]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local gh_command=${${(Q)${(z)arguments}}[(w)2]}
+    local gh_subcommand=${${(Q)${(z)arguments}}[(w)3]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
 
     if [[ $gh_command = 'pr' ]]; then
         local prefix_option completing_option

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -4,10 +4,10 @@ autoload -U colors
 colors
 
 _fzf_complete_gh() {
-    local arguments=$(_fzf_complete_trim_env $@)
-    local gh_command=${${(Q)${(z)arguments}}[(w)2]}
-    local gh_subcommand=${${(Q)${(z)arguments}}[(w)3]}
-    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local gh_command=${arguments[2]}
+    local gh_subcommand=${arguments[3]}
+    local last_argument=${arguments[-1]}
 
     if [[ $gh_command = 'pr' ]]; then
         local prefix_option completing_option

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -317,7 +317,7 @@ _fzf_complete_git() {
                 ;;
 
             -F|-t|--file|--pathspec-from-file|--template)
-                __fzf_generic_path_completion "${prefix#$prefix_option}" "$@"$prefix_option _fzf_compgen_path '' '' ' '
+                __fzf_generic_path_completion "${prefix#$prefix_option}" "$@$prefix_option" _fzf_compgen_path '' '' ' '
                 ;;
 
             --cleanup)
@@ -385,7 +385,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if [[ "$@" =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '--multi' "$@"
                     return
                 fi
@@ -696,7 +696,7 @@ _fzf_complete_git-commits() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <({
         git for-each-ref refs/heads refs/remotes --format='%(refname:short) branch %(contents:subject)' 2> /dev/null
         git for-each-ref refs/tags --format='%(refname:short) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
@@ -727,7 +727,7 @@ _fzf_complete_git-commits-not-in-head() {
     local rev_list_head=$(git rev-list HEAD --oneline 2> /dev/null)
     rev_list_head=(${(q)${(f)rev_list_head}})
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <(
         _fzf_complete_tabularize ${fg[yellow]} <<< ${(Q)${(F)rev_list_all:|rev_list_head}}
     )
 }
@@ -740,7 +740,7 @@ _fzf_complete_git-commit-messages() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         git log --format='%h %s' 2> /dev/null | _fzf_complete_tabularize ${fg[yellow]}
     )
 }
@@ -791,7 +791,7 @@ _fzf_complete_git-files_index() {
     local fzf_options=$2
     shift 2
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_ref < <(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_options} ${treeish-HEAD} 2> /dev/null)
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_ref" < <(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_options} ${treeish-HEAD} 2> /dev/null)
 }
 
 _fzf_complete_git-files_index_post() {
@@ -886,7 +886,7 @@ _fzf_complete_git-repositories() {
         groups=${(Q)${(F)${${(q)${(f)groups}}#remotes.}}}
     fi
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <({
         git remote --verbose 2> /dev/null | awk '
             /\(fetch\)$/ {
                 gsub(/\t/, " ")
@@ -905,7 +905,7 @@ _fzf_complete_git-refs() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <(
         git ls-remote --quiet --heads --tags "$repository" 2> /dev/null | awk '
             match($2, /^refs\/heads\//) {
                 print substr($2, RSTART + RLENGTH), "branch"
@@ -925,7 +925,7 @@ _fzf_complete_git-notes() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <(
         git for-each-ref refs/notes --format='%(refname:short) %(contents:subject)' 2> /dev/null |
             _fzf_complete_tabularize ${fg[yellow]}
     )
@@ -939,7 +939,7 @@ _fzf_complete_git-show-files() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         local result=$(git show --pretty=format: --name-only -z ${(ps: :)treeish} 2> /dev/null)
         echo -n ${(pj:\0:)${(u)${(o)${(0)result}}}}
     )

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -58,7 +58,7 @@ PREVIEW_OPTIONS
 
 _fzf_complete_git() {
     setopt local_options extended_glob
-    local arguments=$@
+    local arguments=$(_fzf_complete_trim_env $@)
     local resolved_commands=()
 
     while true; do

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -58,29 +58,29 @@ PREVIEW_OPTIONS
 
 _fzf_complete_git() {
     setopt local_options extended_glob
-    local arguments=$(_fzf_complete_trim_env $@)
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
     local resolved_commands=()
 
     while true; do
-        local resolved=$(_fzf_complete_git_resolve_alias ${(Q)${(z)arguments}})
+        local resolved=$(_fzf_complete_git_resolve_alias "${(q)arguments[@]}")
         if [[ -z $resolved ]]; then
             break
         fi
 
-        local subcommand=${${(Q)${(z)resolved}}[2]}
+        local subcommand=${(Q)${(z)resolved}[2]}
         if [[ ${resolved_commands[(r)$subcommand]} = $subcommand ]]; then
             break
         fi
 
-        arguments=$resolved
+        arguments=("${(Q)${(z)resolved}[@]}")
         resolved_commands+=($subcommand)
     done
 
-    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
-    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
+    local subcommand=${arguments[2]}
+    local last_argument=${arguments[-1]}
 
     if [[ $subcommand =~ '(diff|log|rebase|switch)' ]]; then
-        if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
+        if [[ ${arguments[(r)--]} = -- ]]; then
             if [[ $subcommand =~ 'diff' ]]; then
                 _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
@@ -130,12 +130,12 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if treeish=$(_fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
+                if treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
                     _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
-                if [[ -z ${${(Q)${(z)arguments}}[(r)--]} ]]; then
+                if [[ -z ${arguments[(r)--]} ]]; then
                     _fzf_complete_git-commits '' $@
                     return
                 fi
@@ -229,12 +229,12 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s*]} ]]; then
+                if [[ -n ${arguments[(r)--source(|(=*))]} ]] || [[ -n ${arguments[(r)-[^-]#s*]} ]]; then
                     _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
-                if [[ -n ${${(Q)${(z)arguments}}[(r)--staged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#S[[:alpha:]]#]} ]]; then
+                if [[ -n ${arguments[(r)--staged]} ]] || [[ -n ${arguments[(r)-[^-]#S[[:alpha:]]#]} ]]; then
                     _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" $@
                     return
                 fi
@@ -266,15 +266,15 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if ! treeish=$(_fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}") &&
+                if ! treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") &&
                     [[ -z $treeish ]] &&
-                    [[ -z ${(Q)${(z)arguments}[(r)--]} ]]; then
+                    [[ -z ${arguments[(r)--]} ]]; then
 
                     _fzf_complete_git-commits '' $@
                     return
                 fi
 
-                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' $arguments > /dev/null; then
+                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' "${(q)arguments[@]}" > /dev/null; then
                     return
                 fi
 
@@ -286,7 +286,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'commit' ]]; then
-        if [[ -n ${${(Q)${(z)arguments}}[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
+        if [[ -n ${arguments[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
             _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
             return
         fi
@@ -385,7 +385,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '--multi' $@
                     return
                 fi
@@ -473,7 +473,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' $@
                     return
                 fi
@@ -528,7 +528,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' $@
                     return
                 fi
@@ -674,8 +674,8 @@ _fzf_complete_git() {
                     return
                 fi
 
-                if [[ -n ${(Q)${(Z+n+)arguments}[(r)--]} ]]; then
-                    local args=($(_fzf_complete_git_parse_argument 0 "${arguments%% -- *}" "${(F)git_options_argument_required}"))
+                if [[ -n ${arguments[(r)--]} ]]; then
+                    local args=($(_fzf_complete_parse_argument 3 0 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}"))
                     treeish=${args:#*:*}
                     _fzf_complete_git-show-files '--multi' $@
                     return
@@ -965,14 +965,4 @@ _fzf_complete_git_resolve_alias() {
     done
 
     echo $git_alias_resolved
-}
-
-_fzf_complete_git_parse_argument() {
-    local arguments=(${(z)2})
-
-    if (( ${#arguments} <= 2 )); then
-        return 1
-    fi
-
-    _fzf_complete_parse_argument 3 $@
 }

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -76,8 +76,8 @@ _fzf_complete_git() {
         resolved_commands+=($subcommand)
     done
 
-    local subcommand=${${(Q)${(z)arguments}}[2]}
-    local last_argument=${${(Q)${(z)arguments}}[-1]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
 
     if [[ $subcommand =~ '(diff|log|rebase|switch)' ]]; then
         if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -58,7 +58,7 @@ PREVIEW_OPTIONS
 
 _fzf_complete_git() {
     setopt local_options extended_glob
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local resolved_commands=()
 
     while true; do
@@ -82,22 +82,22 @@ _fzf_complete_git() {
     if [[ $subcommand =~ '(diff|log|rebase|switch)' ]]; then
         if [[ ${arguments[(r)--]} = -- ]]; then
             if [[ $subcommand =~ 'diff' ]]; then
-                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
                 return
             fi
 
             if [[ $subcommand = 'log' ]]; then
-                _fzf_complete_git-files_index '' '--multi' $@
+                _fzf_complete_git-files_index '' '--multi' "$@"
                 return
             fi
         fi
 
-        _fzf_complete_git-commits '' $@
+        _fzf_complete_git-commits '' "$@"
         return
     fi
 
     if [[ $subcommand =~ '(branch|merge|revert)' ]]; then
-        _fzf_complete_git-commits '--multi' $@
+        _fzf_complete_git-commits '--multi' "$@"
         return
     fi
 
@@ -131,16 +131,16 @@ _fzf_complete_git() {
             *)
                 local treeish
                 if treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
-                    _fzf_complete_git-files_index '' '--multi' $@
+                    _fzf_complete_git-files_index '' '--multi' "$@"
                     return
                 fi
 
                 if [[ -z ${arguments[(r)--]} ]]; then
-                    _fzf_complete_git-commits '' $@
+                    _fzf_complete_git-commits '' "$@"
                     return
                 fi
 
-                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
                 return
                 ;;
         esac
@@ -165,7 +165,7 @@ _fzf_complete_git() {
         case $completing_option in
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" "$@"
                 ;;
 
             --gpg-sign|-S)
@@ -173,7 +173,7 @@ _fzf_complete_git() {
 
             --strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                _fzf_complete_constants '' "${(F)strategies}" $@
+                _fzf_complete_constants '' "${(F)strategies}" "$@"
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -198,11 +198,11 @@ _fzf_complete_git() {
                     subtree=
                     theirs
                 )
-                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" $@
+                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" "$@"
                 ;;
 
             *)
-                _fzf_complete_git-commits-not-in-head '--multi' $@
+                _fzf_complete_git-commits-not-in-head '--multi' "$@"
                 ;;
         esac
 
@@ -225,21 +225,21 @@ _fzf_complete_git() {
 
         case $completing_option in
             -s|--source)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             *)
                 if [[ -n ${arguments[(r)--source(|(=*))]} ]] || [[ -n ${arguments[(r)-[^-]#s*]} ]]; then
-                    _fzf_complete_git-files_index '' '--multi' $@
+                    _fzf_complete_git-files_index '' '--multi' "$@"
                     return
                 fi
 
                 if [[ -n ${arguments[(r)--staged]} ]] || [[ -n ${arguments[(r)-[^-]#S[[:alpha:]]#]} ]]; then
-                    _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" $@
+                    _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" "$@"
                     return
                 fi
 
-                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
                 ;;
         esac
 
@@ -270,7 +270,7 @@ _fzf_complete_git() {
                     [[ -z $treeish ]] &&
                     [[ -z ${arguments[(r)--]} ]]; then
 
-                    _fzf_complete_git-commits '' $@
+                    _fzf_complete_git-commits '' "$@"
                     return
                 fi
 
@@ -278,7 +278,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                _fzf_complete_git-files_tree_and_index '' '' '--multi' $@
+                _fzf_complete_git-files_tree_and_index '' '' '--multi' "$@"
                 ;;
         esac
 
@@ -287,7 +287,7 @@ _fzf_complete_git() {
 
     if [[ $subcommand = 'commit' ]]; then
         if [[ -n ${arguments[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
-            _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+            _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
             return
         fi
 
@@ -306,32 +306,32 @@ _fzf_complete_git() {
 
         case $completing_option in
             -c|-C|--fixup|--reedit-message|--reuse-message|--squash)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             -m|--message)
-                _fzf_complete_git-commit-messages '' $@
+                _fzf_complete_git-commit-messages '' "$@"
                 ;;
 
             --author|--date)
                 ;;
 
             -F|-t|--file|--pathspec-from-file|--template)
-                __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
+                __fzf_generic_path_completion "${prefix#$prefix_option}" "$@"$prefix_option _fzf_compgen_path '' '' ' '
                 ;;
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" "$@"
                 ;;
 
             -u|--untracked-files)
                 local untracked_file_modes=(no normal all)
-                _fzf_complete_constants '' "${(F)untracked_file_modes}" $@
+                _fzf_complete_constants '' "${(F)untracked_file_modes}" "$@"
                 ;;
 
             *)
-                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+                _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
                 ;;
         esac
 
@@ -339,7 +339,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'add' ]]; then
-        _fzf_complete_git-status-files 'unstaged' '--untracked-files=all' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
+        _fzf_complete_git-status-files 'unstaged' '--untracked-files=all' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" "$@"
         return
     fi
 
@@ -360,24 +360,24 @@ _fzf_complete_git() {
         case $completing_option in
             --recurse-submodules)
                 local recurse_submodules=(yes on-demand no)
-                _fzf_complete_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules}" "$@"
                 ;;
 
             --recurse-submodules-default)
                 local recurse_submodules_default=(yes on-demand)
-                _fzf_complete_constants '' "${(F)recurse_submodules_default}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules_default}" "$@"
                 ;;
 
             --refmap)
-                _fzf_complete_git-refs '' $@
+                _fzf_complete_git-refs '' "$@"
                 ;;
 
             --shallow-exclude)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             --negotiation-tip)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             --depth|--deepen|-j|--jobs|-o|--server-option|--shallow-since|--submodule-prefix|--upload-pack)
@@ -385,12 +385,12 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
-                    _fzf_complete_git-repositories '--multi' $@
+                if [[ "$@" =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                    _fzf_complete_git-repositories '--multi' "$@"
                     return
                 fi
 
-                _fzf_complete_git-refs '--multi' $@
+                _fzf_complete_git-refs '--multi' "$@"
                 ;;
         esac
 
@@ -414,17 +414,17 @@ _fzf_complete_git() {
         case $completing_option in
             --recurse-submodules)
                 local recurse_submodules=(yes on-demand no)
-                _fzf_complete_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules}" "$@"
                 ;;
 
             --cleanup)
                 local cleanup_modes=(strip whitespace verbatim scissors default)
-                _fzf_complete_constants '' "${(F)cleanup_modes}" $@
+                _fzf_complete_constants '' "${(F)cleanup_modes}" "$@"
                 ;;
 
             -s|--strategy)
                 local strategies=(octopus ours subtree recursive resolve)
-                _fzf_complete_constants '' "${(F)strategies}" $@
+                _fzf_complete_constants '' "${(F)strategies}" "$@"
                 ;;
 
             --strategy-option|--strategy-option=diff-algorithm|-X)
@@ -449,20 +449,20 @@ _fzf_complete_git() {
                     subtree=
                     theirs
                 )
-                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" $@
+                prefix_option=${prefix_option/=*/=} prefix=${prefix#$prefix_option} _fzf_complete_constants '' "${(F)strategy_options}" "$@"
                 ;;
 
             --rebase)
                 local rebases=(false interactive merges preserve true)
-                _fzf_complete_constants '' "${(F)rebases}" $@
+                _fzf_complete_constants '' "${(F)rebases}" "$@"
                 ;;
 
             --shallow-exclude)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             --negotiation-tip)
-                _fzf_complete_git-commits '' $@
+                _fzf_complete_git-commits '' "$@"
                 ;;
 
             --gpg-sign|-S)
@@ -474,11 +474,11 @@ _fzf_complete_git() {
             *)
                 local repository
                 if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
-                    _fzf_complete_git-repositories '' $@
+                    _fzf_complete_git-repositories '' "$@"
                     return
                 fi
 
-                _fzf_complete_git-refs '--multi' $@
+                _fzf_complete_git-refs '--multi' "$@"
                 ;;
         esac
 
@@ -504,7 +504,7 @@ _fzf_complete_git() {
         case $completing_option in
             --signed)
                 local signed=(false if-asked true)
-                _fzf_complete_constants '' "${(F)signed}" $@
+                _fzf_complete_constants '' "${(F)signed}" "$@"
                 ;;
 
             -o|--push-option)
@@ -514,31 +514,31 @@ _fzf_complete_git() {
                 ;;
 
             --force-with-lease)
-                prefix=${prefix#*:} _fzf_complete_git-commits '' $@
+                prefix=${prefix#*:} _fzf_complete_git-commits '' "$@"
                 ;;
 
             --repo)
-                _fzf_complete_git-repositories '' $@
+                _fzf_complete_git-repositories '' "$@"
                 ;;
 
             --recurse-submodules)
                 local recurse_submodules=(check no on-demand only)
-                _fzf_complete_constants '' "${(F)recurse_submodules}" $@
+                _fzf_complete_constants '' "${(F)recurse_submodules}" "$@"
                 ;;
 
             *)
                 local repository
                 if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
-                    _fzf_complete_git-repositories '' $@
+                    _fzf_complete_git-repositories '' "$@"
                     return
                 fi
 
                 if [[ $prefix = *:* ]]; then
-                    prefix=${prefix#*:} _fzf_complete_git-refs '' $@
+                    prefix=${prefix#*:} _fzf_complete_git-refs '' "$@"
                     return
                 fi
 
-                _fzf_complete_git-commits '--multi' $@
+                _fzf_complete_git-commits '--multi' "$@"
                 ;;
         esac
 
@@ -546,7 +546,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'rm' ]]; then
-        _fzf_complete_git-files_tree '' '--multi' $@
+        _fzf_complete_git-files_tree '' '--multi' "$@"
         return
     fi
 
@@ -617,7 +617,7 @@ _fzf_complete_git() {
                 ;;
 
             --notes|--show-notes)
-                _fzf_complete_git-notes '' $@
+                _fzf_complete_git-notes '' "$@"
                 return
                 ;;
 
@@ -670,18 +670,18 @@ _fzf_complete_git() {
 
                 if [[ $prefix = *:* ]]; then
                     treeish=${prefix%:*}
-                    prefix=${prefix#*:} _fzf_complete_git-files_index '' '' $@
+                    prefix=${prefix#*:} _fzf_complete_git-files_index '' '' "$@"
                     return
                 fi
 
                 if [[ -n ${arguments[(r)--]} ]]; then
                     local args=($(_fzf_complete_parse_argument 3 0 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}"))
                     treeish=${args:#*:*}
-                    _fzf_complete_git-show-files '--multi' $@
+                    _fzf_complete_git-show-files '--multi' "$@"
                     return
                 fi
 
-                _fzf_complete_git-commits '--multi' $@
+                _fzf_complete_git-commits '--multi' "$@"
                 return
                 ;;
         esac
@@ -689,14 +689,14 @@ _fzf_complete_git() {
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_git-commits() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <({
         git for-each-ref refs/heads refs/remotes --format='%(refname:short) branch %(contents:subject)' 2> /dev/null
         git for-each-ref refs/tags --format='%(refname:short) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
@@ -727,7 +727,7 @@ _fzf_complete_git-commits-not-in-head() {
     local rev_list_head=$(git rev-list HEAD --oneline 2> /dev/null)
     rev_list_head=(${(q)${(f)rev_list_head}})
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
         _fzf_complete_tabularize ${fg[yellow]} <<< ${(Q)${(F)rev_list_all:|rev_list_head}}
     )
 }
@@ -740,7 +740,7 @@ _fzf_complete_git-commit-messages() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         git log --format='%h %s' 2> /dev/null | _fzf_complete_tabularize ${fg[yellow]}
     )
 }
@@ -764,7 +764,7 @@ _fzf_complete_git-files_tree() {
     local fzf_options=$2
     shift 2
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <({
         local cdup=$(git rev-parse --show-cdup 2> /dev/null)
         local git_prefix=$(git rev-parse --show-prefix 2> /dev/null)
         cd $(git rev-parse --show-toplevel 2> /dev/null)
@@ -791,7 +791,7 @@ _fzf_complete_git-files_index() {
     local fzf_options=$2
     shift 2
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_ref < <(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_options} ${treeish-HEAD} 2> /dev/null)
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_ref < <(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_options} ${treeish-HEAD} 2> /dev/null)
 }
 
 _fzf_complete_git-files_index_post() {
@@ -809,7 +809,7 @@ _fzf_complete_git-files_tree_and_index() {
     local fzf_options=$3
     shift 3
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <({
         local cdup=$(git rev-parse --show-cdup 2> /dev/null)
         local git_prefix=$(git rev-parse --show-prefix 2> /dev/null)
         cd $(git rev-parse --show-toplevel 2> /dev/null)
@@ -841,7 +841,7 @@ _fzf_complete_git-status-files() {
     local fzf_options=$3
     shift 3
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@ < <({
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <({
         local previous_status
         local filename
         local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
@@ -886,7 +886,7 @@ _fzf_complete_git-repositories() {
         groups=${(Q)${(F)${${(q)${(f)groups}}#remotes.}}}
     fi
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
         git remote --verbose 2> /dev/null | awk '
             /\(fetch\)$/ {
                 gsub(/\t/, " ")
@@ -905,7 +905,7 @@ _fzf_complete_git-refs() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
         git ls-remote --quiet --heads --tags "$repository" 2> /dev/null | awk '
             match($2, /^refs\/heads\//) {
                 print substr($2, RSTART + RLENGTH), "branch"
@@ -925,7 +925,7 @@ _fzf_complete_git-notes() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option$prefix_ref < <(
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option$prefix_ref < <(
         git for-each-ref refs/notes --format='%(refname:short) %(contents:subject)' 2> /dev/null |
             _fzf_complete_tabularize ${fg[yellow]}
     )
@@ -939,7 +939,7 @@ _fzf_complete_git-show-files() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         local result=$(git show --pretty=format: --name-only -z ${(ps: :)treeish} 2> /dev/null)
         echo -n ${(pj:\0:)${(u)${(o)${(0)result}}}}
     )

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -58,29 +58,29 @@ PREVIEW_OPTIONS
 
 _fzf_complete_git() {
     setopt local_options extended_glob
-    local arguments=("${(Q)${(z)@}[@]}")
+    local arguments=$(_fzf_complete_trim_env $@)
     local resolved_commands=()
 
     while true; do
-        local resolved=$(_fzf_complete_git_resolve_alias "${(q)arguments[@]}")
+        local resolved=$(_fzf_complete_git_resolve_alias ${(Q)${(z)arguments}})
         if [[ -z $resolved ]]; then
             break
         fi
 
-        local subcommand=${(Q)${(z)resolved}[2]}
+        local subcommand=${${(Q)${(z)resolved}}[2]}
         if [[ ${resolved_commands[(r)$subcommand]} = $subcommand ]]; then
             break
         fi
 
-        arguments=("${(Q)${(z)resolved}[@]}")
+        arguments=$resolved
         resolved_commands+=($subcommand)
     done
 
-    local subcommand=${arguments[2]}
-    local last_argument=${arguments[-1]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
 
     if [[ $subcommand =~ '(diff|log|rebase|switch)' ]]; then
-        if [[ ${arguments[(r)--]} = -- ]]; then
+        if [[ ${${(Q)${(z)arguments}}[(r)--]} = -- ]]; then
             if [[ $subcommand =~ 'diff' ]]; then
                 _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
                 return
@@ -130,12 +130,12 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
+                if treeish=$(_fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
                     _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
-                if [[ -z ${arguments[(r)--]} ]]; then
+                if [[ -z ${${(Q)${(z)arguments}}[(r)--]} ]]; then
                     _fzf_complete_git-commits '' $@
                     return
                 fi
@@ -229,12 +229,12 @@ _fzf_complete_git() {
                 ;;
 
             *)
-                if [[ -n ${arguments[(r)--source(|(=*))]} ]] || [[ -n ${arguments[(r)-[^-]#s*]} ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--source(|(=*))]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#s*]} ]]; then
                     _fzf_complete_git-files_index '' '--multi' $@
                     return
                 fi
 
-                if [[ -n ${arguments[(r)--staged]} ]] || [[ -n ${arguments[(r)-[^-]#S[[:alpha:]]#]} ]]; then
+                if [[ -n ${${(Q)${(z)arguments}}[(r)--staged]} ]] || [[ -n ${${(Q)${(z)arguments}}[(r)-[^-]#S[[:alpha:]]#]} ]]; then
                     _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" $@
                     return
                 fi
@@ -266,15 +266,15 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if ! treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") &&
+                if ! treeish=$(_fzf_complete_git_parse_argument 1 "${arguments%% -- *}" "${(F)git_options_argument_required}") &&
                     [[ -z $treeish ]] &&
-                    [[ -z ${arguments[(r)--]} ]]; then
+                    [[ -z ${(Q)${(z)arguments}[(r)--]} ]]; then
 
                     _fzf_complete_git-commits '' $@
                     return
                 fi
 
-                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' "${(q)arguments[@]}" > /dev/null; then
+                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' $arguments > /dev/null; then
                     return
                 fi
 
@@ -286,7 +286,7 @@ _fzf_complete_git() {
     fi
 
     if [[ $subcommand = 'commit' ]]; then
-        if [[ -n ${arguments[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
+        if [[ -n ${${(Q)${(z)arguments}}[(r)--]} ]] || [[ $last_argument != -* && $prefix != -* ]]; then
             _fzf_complete_git-status-files 'unstaged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff $FZF_DEFAULT_OPTS" $@
             return
         fi
@@ -385,7 +385,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '--multi' $@
                     return
                 fi
@@ -473,7 +473,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' $@
                     return
                 fi
@@ -528,7 +528,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_git_parse_argument 1 "$arguments" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' $@
                     return
                 fi
@@ -674,8 +674,8 @@ _fzf_complete_git() {
                     return
                 fi
 
-                if [[ -n ${arguments[(r)--]} ]]; then
-                    local args=($(_fzf_complete_parse_argument 3 0 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}"))
+                if [[ -n ${(Q)${(Z+n+)arguments}[(r)--]} ]]; then
+                    local args=($(_fzf_complete_git_parse_argument 0 "${arguments%% -- *}" "${(F)git_options_argument_required}"))
                     treeish=${args:#*:*}
                     _fzf_complete_git-show-files '--multi' $@
                     return
@@ -965,4 +965,14 @@ _fzf_complete_git_resolve_alias() {
     done
 
     echo $git_alias_resolved
+}
+
+_fzf_complete_git_parse_argument() {
+    local arguments=(${(z)2})
+
+    if (( ${#arguments} <= 2 )); then
+        return 1
+    fi
+
+    _fzf_complete_parse_argument 3 $@
 }

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,9 +4,9 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
-    local arguments=$(_fzf_complete_trim_env $@)
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
     local kubectl_arguments=()
-    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
+    local last_argument=${arguments[-1]}
     local prefix_option completing_option arg subcommands namespace resource name
 
     local inherit_option inherit_values
@@ -118,16 +118,16 @@ _fzf_complete_kubectl() {
         fi
     done
 
-    subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $arguments$RBUFFER || :)
+    subcommands=($(_fzf_complete_parse_argument 2 1 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $@$RBUFFER || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
-        subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))
-        resource=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
+        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
     else
-        resource=$(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
     fi
 
     if [[ $resource = */* ]]; then

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -118,7 +118,7 @@ _fzf_complete_kubectl() {
     done
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "$@"$RBUFFER || :)
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "$@$RBUFFER" || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
@@ -926,7 +926,7 @@ _fzf_complete_kubectl-resource-names() {
         kubectl_arguments+=(--all-namespaces)
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         local result=$(kubectl get "$resource" -o wide "${kubectl_arguments[@]}" 2> /dev/null)
         if [[ $result = NAMESPACE\ * ]]; then
             _fzf_complete_colorize $fg[green] $fg[yellow] | awk '{ print SUBSEP $0 }'
@@ -963,7 +963,7 @@ _fzf_complete_kubectl-containers() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <({
         echo NAME IMAGE
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..initContainers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..containers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
@@ -983,7 +983,7 @@ _fzf_complete_kubectl-ports() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='PORT PROTOCOL NAME{"\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\n"}{end}' 2> /dev/null |
         awk '{ print $1, $2, $3 }' |
         _fzf_complete_tabularize $fg[yellow] $reset_color
@@ -998,7 +998,7 @@ _fzf_complete_kubectl-annotations() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
+    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <({
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
     } 2> /dev/null)
 }
@@ -1021,7 +1021,7 @@ _fzf_complete_kubectl-labels() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUE
             kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.labels}' |
@@ -1058,7 +1058,7 @@ _fzf_complete_kubectl-selectors() {
         return
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             if [[ $prefix_option = *! ]]; then
                 echo KEY VALUES
@@ -1101,7 +1101,7 @@ _fzf_complete_kubectl-label-columns() {
         kubectl_arguments+=(--label-columns=$label_columns)
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUES
             kubectl get "$resource" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
@@ -1118,7 +1118,7 @@ _fzf_complete_kubectl-taints() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] $reset_color < <(
             echo KEY VALUE EFFECT
             kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range .spec.taints[*]}{.key} {.value} {.effect}{"\n"}{end}' 2> /dev/null

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -6,7 +6,7 @@ colors
 _fzf_complete_kubectl() {
     local arguments=$(_fzf_complete_trim_env $@)
     local kubectl_arguments=()
-    local last_argument=${${(Q)${(z)arguments}}[-1]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
     local prefix_option completing_option arg subcommands namespace resource name
 
     local inherit_option inherit_values

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,9 +4,9 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
-    local arguments=$@
+    local arguments=$(_fzf_complete_trim_env $@)
     local kubectl_arguments=()
-    local last_argument=${${(Q)${(z)@}}[-1]}
+    local last_argument=${${(Q)${(z)arguments}}[-1]}
     local prefix_option completing_option arg subcommands namespace resource name
 
     local inherit_option inherit_values
@@ -104,13 +104,13 @@ _fzf_complete_kubectl() {
 
     for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
         if [[ $inherit_option = --* ]]; then
-            for arg in "$@" "$RBUFFER"; do
+            for arg in "$arguments" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
             done
         else
-            for arg in "$@" "$RBUFFER"; do
+            for arg in "$arguments" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
@@ -119,7 +119,7 @@ _fzf_complete_kubectl() {
     done
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $@$RBUFFER || :)
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $arguments$RBUFFER || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local kubectl_arguments=()
     local last_argument=${arguments[-1]}
     local prefix_option completing_option arg subcommands namespace resource name
@@ -118,7 +118,7 @@ _fzf_complete_kubectl() {
     done
 
     subcommands=($(_fzf_complete_parse_argument 2 1 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $@$RBUFFER || :)
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "$@"$RBUFFER || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
@@ -881,7 +881,7 @@ _fzf_complete_kubectl() {
             return
         fi
 
-        __fzf_generic_path_completion "${prefix#$prefix_option}" $@$prefix_option _fzf_compgen_path '' '' ' '
+        __fzf_generic_path_completion "${prefix#$prefix_option}" "$@"$prefix_option _fzf_compgen_path '' '' ' '
         return
     fi
 
@@ -926,7 +926,7 @@ _fzf_complete_kubectl-resource-names() {
         kubectl_arguments+=(--all-namespaces)
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         local result=$(kubectl get "$resource" -o wide "${kubectl_arguments[@]}" 2> /dev/null)
         if [[ $result = NAMESPACE\ * ]]; then
             _fzf_complete_colorize $fg[green] $fg[yellow] | awk '{ print SUBSEP $0 }'
@@ -963,7 +963,7 @@ _fzf_complete_kubectl-containers() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
         echo NAME IMAGE
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..initContainers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..containers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
@@ -983,7 +983,7 @@ _fzf_complete_kubectl-ports() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='PORT PROTOCOL NAME{"\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\n"}{end}' 2> /dev/null |
         awk '{ print $1, $2, $3 }' |
         _fzf_complete_tabularize $fg[yellow] $reset_color
@@ -998,7 +998,7 @@ _fzf_complete_kubectl-annotations() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
+    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <({
         kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
     } 2> /dev/null)
 }
@@ -1021,7 +1021,7 @@ _fzf_complete_kubectl-labels() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUE
             kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.labels}' |
@@ -1058,7 +1058,7 @@ _fzf_complete_kubectl-selectors() {
         return
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             if [[ $prefix_option = *! ]]; then
                 echo KEY VALUES
@@ -1101,7 +1101,7 @@ _fzf_complete_kubectl-label-columns() {
         kubectl_arguments+=(--label-columns=$label_columns)
     fi
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUES
             kubectl get "$resource" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
@@ -1118,7 +1118,7 @@ _fzf_complete_kubectl-taints() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@"$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] $reset_color < <(
             echo KEY VALUE EFFECT
             kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range .spec.taints[*]}{.key} {.value} {.effect}{"\n"}{end}' 2> /dev/null

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,9 +4,9 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
-    local arguments=("${(Q)${(z)@}[@]}")
+    local arguments=$(_fzf_complete_trim_env $@)
     local kubectl_arguments=()
-    local last_argument=${arguments[-1]}
+    local last_argument=${${(Q)${(z)arguments}}[(w)-1]}
     local prefix_option completing_option arg subcommands namespace resource name
 
     local inherit_option inherit_values
@@ -104,13 +104,13 @@ _fzf_complete_kubectl() {
 
     for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
         if [[ $inherit_option = --* ]]; then
-            for arg in "$@" "$RBUFFER"; do
+            for arg in "$arguments" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
             done
         else
-            for arg in "$@" "$RBUFFER"; do
+            for arg in "$arguments" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "${(F)kubectl_options_argument_required}" "$arg"); then
                     kubectl_arguments+=($inherit_values)
                 fi
@@ -118,16 +118,16 @@ _fzf_complete_kubectl() {
         fi
     done
 
-    subcommands=($(_fzf_complete_parse_argument 2 1 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $@$RBUFFER || :)
+    subcommands=($(_fzf_complete_parse_argument 2 1 "$arguments" "${(F)kubectl_options_argument_required}" || :))
+    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" $arguments$RBUFFER || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
-        subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        subcommands+=($(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :))
+        resource=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "$arguments" "${(F)kubectl_options_argument_required}" || :)
     else
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        resource=$(_fzf_complete_parse_argument 2 2 "$arguments" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "$arguments" "${(F)kubectl_options_argument_required}" || :)
     fi
 
     if [[ $resource = */* ]]; then

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -881,7 +881,7 @@ _fzf_complete_kubectl() {
             return
         fi
 
-        __fzf_generic_path_completion "${prefix#$prefix_option}" "$@"$prefix_option _fzf_compgen_path '' '' ' '
+        __fzf_generic_path_completion "${prefix#$prefix_option}" "$@$prefix_option" _fzf_compgen_path '' '' ' '
         return
     fi
 

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -1,12 +1,12 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_make() {
-    _fzf_complete_make-target '' $@
+    _fzf_complete_make-target '' "$@"
 }
 
 _fzf_complete_make-target() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(grep -E '^[a-zA-Z_-]+:.*?$$' Makefile 2> /dev/null | uniq | awk -F ':' '{ print $1 }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^[a-zA-Z_-]+:.*?$$' Makefile 2> /dev/null | uniq | awk -F ':' '{ print $1 }')
 }

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -1,15 +1,15 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_npm() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 
     if [[ $subcommand = 'run' ]]; then
-        _fzf_complete_npm-run '' $@
+        _fzf_complete_npm-run '' "$@"
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_npm-run() {
@@ -21,7 +21,7 @@ _fzf_complete_npm-run() {
         return
     fi
 
-    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(node -e '
+    _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(node -e '
         process.stdout.write(
             Object.keys(
                 JSON.parse(

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -1,8 +1,8 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_npm() {
-    local arguments=$(_fzf_complete_trim_env $@)
-    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local subcommand=${arguments[2]}
 
     if [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -1,8 +1,8 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_npm() {
-    local arguments=("${(Q)${(z)@}[@]}")
-    local subcommand=${arguments[2]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -1,7 +1,10 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_npm() {
-    if [[ $@ = 'npm run'* ]]; then
+    local arguments=$(_fzf_complete_trim_env $@)
+    local subcommand=${${(Q)${(z)arguments}}[2]}
+
+    if [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@
         return
     fi

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -2,7 +2,7 @@
 
 _fzf_complete_npm() {
     local arguments=$(_fzf_complete_trim_env $@)
-    local subcommand=${${(Q)${(z)arguments}}[2]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@

--- a/src/completers/sudo.zsh
+++ b/src/completers/sudo.zsh
@@ -11,5 +11,5 @@ _fzf_complete_sudo() {
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }

--- a/src/completers/sudo.zsh
+++ b/src/completers/sudo.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_sudo() {
-    local args=(${(Q)${(z)@}})
+    local args=("${(Q)${(z)@}[@]}")
     local subcommand=${args:1:1}
 
     if (( $+functions[_fzf_complete_$subcommand] )); then

--- a/src/completers/sudo.zsh
+++ b/src/completers/sudo.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_sudo() {
-    local args=("${(Q)${(z)@}[@]}")
+    local args=(${(Q)${(z)@}})
     local subcommand=${args:1:1}
 
     if (( $+functions[_fzf_complete_$subcommand] )); then

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -17,9 +17,9 @@ _fzf_complete_systemctl-units() {
     local fzf_options=$1
     shift
 
-    local arguments=$(_fzf_complete_trim_env $@)
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
     local systemctl_options=(--full --no-legend --no-pager)
-    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $arguments)) || :
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${${(q)arguments[@]}}")) || :
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
         <({

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -19,7 +19,7 @@ _fzf_complete_systemctl-units() {
 
     local arguments=$(_fzf_complete_trim_env $@)
     local systemctl_options=(--full --no-legend --no-pager)
-    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $arguments)) || :
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${${(q)arguments[@]}}")) || :
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
         <({

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -17,8 +17,9 @@ _fzf_complete_systemctl-units() {
     local fzf_options=$1
     shift
 
+    local arguments=$(_fzf_complete_trim_env $@)
     local systemctl_options=(--full --no-legend --no-pager)
-    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $@)) || :
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $arguments)) || :
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
         <({

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -19,7 +19,7 @@ _fzf_complete_systemctl-units() {
 
     local arguments=$(_fzf_complete_trim_env $@)
     local systemctl_options=(--full --no-legend --no-pager)
-    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${${(q)arguments[@]}}")) || :
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' $arguments)) || :
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
         <({

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -10,18 +10,18 @@ PREVIEW_OPTIONS
 )
 
 _fzf_complete_systemctl() {
-    _fzf_complete_systemctl-units '' $@
+    _fzf_complete_systemctl-units '' "$@"
 }
 
 _fzf_complete_systemctl-units() {
     local fzf_options=$1
     shift
 
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local systemctl_options=(--full --no-legend --no-pager)
     systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${${(q)arguments[@]}}")) || :
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- $@ < \
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- "$@" < \
         <({
             systemctl list-units ${(Q)${(Z+n+)systemctl_options}} "$prefix*"
             systemctl list-unit-files ${(Q)${(Z+n+)systemctl_options}} "$prefix*"

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    local arguments=$@
+    local arguments=$(_fzf_complete_trim_env $@)
     local subcommand=${${(Q)${(z)arguments}}[2]}
 
     if [[ $subcommand = 'workspace' ]]; then

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,9 +1,8 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    local arguments=$(_fzf_complete_trim_env $@)
-    local cmd=${${(Q)${(z)arguments}}[(w)1]}
-    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local subcommand=${arguments[2]}
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
@@ -19,7 +18,7 @@ _fzf_complete_yarn() {
         return
     fi
 
-    if [[ $cmd = 'yarn' ]] || [[ $subcommand = 'run' ]]; then
+    if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@
         return
     fi

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,8 +1,9 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    local arguments=("${(Q)${(z)@}[@]}")
-    local subcommand=${arguments[2]}
+    local arguments=$(_fzf_complete_trim_env $@)
+    local cmd=${${(Q)${(z)arguments}}[(w)1]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
@@ -18,7 +19,7 @@ _fzf_complete_yarn() {
         return
     fi
 
-    if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run' ]]; then
+    if [[ $cmd = 'yarn' ]] || [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@
         return
     fi

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,29 +1,29 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
-    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env $@)"}[@]}")
+    local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
         if ! workspace=$(_fzf_complete_parse_argument 3 1 "$arguments" '') && [[ -z $workspace ]]; then
-            _fzf_complete_yarn-workspace '' $@
+            _fzf_complete_yarn-workspace '' "$@"
             return
         fi
 
         local npm_directory=$({
             yarn workspaces --json info | jq --arg workspace "$workspace" -r '.data | fromjson | .[$workspace].location'
         } 2> /dev/null)
-        _fzf_complete_npm-run '' $@
+        _fzf_complete_npm-run '' "$@"
         return
     fi
 
     if [[ ${#arguments} = 1 ]] || [[ $subcommand = 'run' ]]; then
-        _fzf_complete_npm-run '' $@
+        _fzf_complete_npm-run '' "$@"
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_yarn-workspace() {
@@ -37,5 +37,5 @@ _fzf_complete_yarn-workspace() {
 
     local workspace_packages_patterns=$(jq -r '.workspaces | map(. + "/package.json") | join("\u0000")' "$parent_package" 2> /dev/null)
 
-   _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@ < <(jq -r '.name' ${~${(0)workspace_packages_patterns}} 2> /dev/null)
+   _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(jq -r '.name' ${~${(0)workspace_packages_patterns}} 2> /dev/null)
 }

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -2,7 +2,8 @@
 
 _fzf_complete_yarn() {
     local arguments=$(_fzf_complete_trim_env $@)
-    local subcommand=${${(Q)${(z)arguments}}[2]}
+    local cmd=${${(Q)${(z)arguments}}[(w)1]}
+    local subcommand=${${(Q)${(z)arguments}}[(w)2]}
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
@@ -18,7 +19,7 @@ _fzf_complete_yarn() {
         return
     fi
 
-    if [[ $@ = 'yarn ' ]] || [[ $@ = 'yarn run ' ]]; then
+    if [[ $cmd = 'yarn' ]] || [[ $subcommand = 'run' ]]; then
         _fzf_complete_npm-run '' $@
         return
     fi

--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -1,6 +1,6 @@
 _fzf_complete_enable_aliases() {
     local expr name value completer arguments
-    local completers=(${@:t:r})
+    local completers=("${@[@]:t:r}")
 
     local IFS=$'\n'
     for expr in $(alias); do
@@ -10,13 +10,13 @@ _fzf_complete_enable_aliases() {
         arguments=${(@)value[2,-1]}
 
         if [[ -n $completer ]]; then
-            source -- ${@[(r)*completers/$completer.zsh]}
+            source -- "${@[(r)*completers/$completer.zsh]}"
             eval "
                 _fzf_complete_$name() {
                     LBUFFER=\"\${LBUFFER/$name/$completer $arguments}\"
                     () {
                         $functions[_fzf_complete_$completer]
-                    } \${@/$name/$completer $arguments}
+                    } \"\${@/$name/$completer $arguments}\"
                     LBUFFER=\"\${LBUFFER/$completer $arguments/$name}\"
                 }
             "

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,10 +1,10 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_trim_env() {
-    local arguments=(${(Q)${(z)@}})
+    local arguments=(${(z)@})
     local cmd=$(__fzf_extract_command $@)
-
-    echo ${(q)arguments[${arguments[(i)$cmd]}, -1]}
+    local idx=${${(Q)arguments}[(i)$cmd]}
+    echo ${arguments[$idx, -1]}
 }
 
 _fzf_complete_parse_completing_option() {

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -79,7 +79,7 @@ _fzf_complete_parse_completing_option() {
 _fzf_complete_parse_argument() {
     local start_index=$1
     local index=$2
-    local arguments=(${(z)3})
+    local arguments=("${(Q)${(z)3}[@]}")
     local options_argument_required=(${(z)4})
     shift 4
 
@@ -90,11 +90,11 @@ _fzf_complete_parse_argument() {
     local i
     local command_arguments=()
     for i in {$start_index..${#arguments}}; do
-        if [[ ${(Q)arguments[$i]} = -(#c1,2)* ]]; then
+        if [[ ${arguments[$i]} = -(#c1,2)* ]]; then
             continue
         fi
 
-        local previous_argument=$(_fzf_complete_parse_completing_option '' "${(Q)arguments[i - 1]}" "${(F)options_argument_required}" '')
+        local previous_argument=$(_fzf_complete_parse_completing_option '' "${arguments[i - 1]}" "${(F)options_argument_required}" '')
         if [[ -n $previous_argument ]] && [[ ${options_argument_required[(r)$previous_argument]} = $previous_argument ]]; then
             continue
         fi
@@ -103,11 +103,11 @@ _fzf_complete_parse_argument() {
     done
 
     if [[ $index = 0 ]]; then
-        echo - ${command_arguments}
+        echo - $command_arguments
         return
     fi
     echo - ${command_arguments[$index]}
-    return $(( index > #command_arguments ))
+    return $(( index > ${#command_arguments} ))
 }
 
 _fzf_complete_parse_option() {
@@ -117,7 +117,7 @@ _fzf_complete_parse_option() {
     local options_argument_required=(${(z)3})
     shift 3
 
-    local cmd=(${(Q)${(z)@}})
+    local cmd=("${(Q)${(z)@}[@]}")
     local cmd_shorts=(${(M)cmd:#-[^-]*})
 
     local option_argument_required
@@ -145,7 +145,7 @@ _fzf_complete_parse_option_arguments() {
     local options_argument_required=(${(z)3})
     shift 3
 
-    local cmd=(${(Q)${(z)@}})
+    local cmd=("${(Q)${(z)@}[@]}")
     while [[ $idx -le ${#cmd} ]]; do
         indices=()
 

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -2,7 +2,7 @@
 
 _fzf_complete_trim_env() {
     local arguments=("${(Q)${(z)@}[@]}")
-    local cmd=$(__fzf_extract_command $@)
+    local cmd=$(__fzf_extract_command "$@")
     local idx=${arguments[(i)$cmd]}
     echo ${(q)arguments[$idx, -1]}
 }

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -79,7 +79,7 @@ _fzf_complete_parse_completing_option() {
 _fzf_complete_parse_argument() {
     local start_index=$1
     local index=$2
-    local arguments=("${(Q)${(z)3}[@]}")
+    local arguments=(${(z)3})
     local options_argument_required=(${(z)4})
     shift 4
 
@@ -90,11 +90,11 @@ _fzf_complete_parse_argument() {
     local i
     local command_arguments=()
     for i in {$start_index..${#arguments}}; do
-        if [[ ${arguments[$i]} = -(#c1,2)* ]]; then
+        if [[ ${(Q)arguments[$i]} = -(#c1,2)* ]]; then
             continue
         fi
 
-        local previous_argument=$(_fzf_complete_parse_completing_option '' "${arguments[i - 1]}" "${(F)options_argument_required}" '')
+        local previous_argument=$(_fzf_complete_parse_completing_option '' "${(Q)arguments[i - 1]}" "${(F)options_argument_required}" '')
         if [[ -n $previous_argument ]] && [[ ${options_argument_required[(r)$previous_argument]} = $previous_argument ]]; then
             continue
         fi
@@ -103,11 +103,11 @@ _fzf_complete_parse_argument() {
     done
 
     if [[ $index = 0 ]]; then
-        echo - $command_arguments
+        echo - ${command_arguments}
         return
     fi
     echo - ${command_arguments[$index]}
-    return $(( index > ${#command_arguments} ))
+    return $(( index > #command_arguments ))
 }
 
 _fzf_complete_parse_option() {
@@ -117,7 +117,7 @@ _fzf_complete_parse_option() {
     local options_argument_required=(${(z)3})
     shift 3
 
-    local cmd=("${(Q)${(z)@}[@]}")
+    local cmd=(${(Q)${(z)@}})
     local cmd_shorts=(${(M)cmd:#-[^-]*})
 
     local option_argument_required
@@ -145,7 +145,7 @@ _fzf_complete_parse_option_arguments() {
     local options_argument_required=(${(z)3})
     shift 3
 
-    local cmd=("${(Q)${(z)@}[@]}")
+    local cmd=(${(Q)${(z)@}})
     while [[ $idx -le ${#cmd} ]]; do
         indices=()
 

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,10 +1,10 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_trim_env() {
-    local arguments=(${(z)@})
+    local arguments=("${(Q)${(z)@}[@]}")
     local cmd=$(__fzf_extract_command $@)
-    local idx=${${(Q)arguments}[(i)$cmd]}
-    echo ${arguments[$idx, -1]}
+    local idx=${arguments[(i)$cmd]}
+    echo ${(q)arguments[$idx, -1]}
 }
 
 _fzf_complete_parse_completing_option() {

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,5 +1,12 @@
 #!/usr/bin/env zsh
 
+_fzf_complete_trim_env() {
+    local arguments=(${(Q)${(z)@}})
+    local cmd=$(__fzf_extract_command $@)
+
+    echo ${(q)arguments[${arguments[(i)$cmd]}, -1]}
+}
+
 _fzf_complete_parse_completing_option() {
     local prefix=$1
     local last_argument=$2

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -5,6 +5,10 @@
     load _helpers/assertions.zsh
 
     pushd tests/_support/composer
+
+    __fzf_extract_command() {
+        echo 'composer'
+    }
 }
 
 @test 'Testing completion: composer **' {

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -142,3 +142,18 @@
     prefix=
     _fzf_complete_composer 'composer run-script '
 }
+
+@test 'Testing completion: composer "" run-script **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'composer "" run-script '
+    }
+
+    prefix=
+    _fzf_complete_composer 'composer "" run-script '
+}

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -142,18 +142,3 @@
     prefix=
     _fzf_complete_composer 'composer run-script '
 }
-
-@test 'Testing completion: composer "" run-script **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'composer "" run-script '
-    }
-
-    prefix=
-    _fzf_complete_composer 'composer "" run-script '
-}

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -55,6 +55,50 @@
     _fzf_complete_composer 'composer '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 composer **' {
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--'
+        assert $6 same_as 'TEST1=value1 TEST2=value2 composer '
+
+        run cat
+        assert ${#lines} equals 6
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'start'
+        assert ${actual1[2]} same_as 'test'
+        assert ${actual1[3]} same_as ' script containing spaces '
+        assert ${actual1[4]} same_as 'script'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'that'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 1
+        assert ${actual3[1]} same_as 'consists'
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'of'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 1
+        assert ${actual5[1]} same_as 'multiple'
+
+        actual6=(${(0)lines[6]})
+        assert ${actual6[1]} same_as 'lines'
+    }
+
+    prefix=
+    _fzf_complete_composer 'TEST1=value1 TEST2=value2 composer '
+}
+
 @test 'Testing completion: composer run-script **' {
     _fzf_complete() {
         assert $# equals 6

--- a/tests/composer.zunit
+++ b/tests/composer.zunit
@@ -3,15 +3,24 @@
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
     load _helpers/assertions.zsh
+    load _helpers/mock.zsh
+    mock __fzf_extract_command
 
     pushd tests/_support/composer
+}
 
-    __fzf_extract_command() {
-        echo 'composer'
-    }
+@teardown {
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: composer **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'composer '
+
+        echo 'composer'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -22,6 +31,7 @@
         assert $6 same_as 'composer '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -56,6 +66,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 composer **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 composer '
+
+        echo 'composer'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -66,6 +83,7 @@
         assert $6 same_as 'TEST1=value1 TEST2=value2 composer '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -100,6 +118,13 @@
 }
 
 @test 'Testing completion: composer run-script **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'composer run-script '
+
+        echo 'composer'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -110,6 +135,7 @@
         assert $6 same_as 'composer run-script '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -144,6 +170,13 @@
 }
 
 @test 'Testing completion: composer "" run-script **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'composer "" run-script '
+
+        echo 'composer'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -152,6 +185,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'composer "" run-script '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -30,6 +30,21 @@
     _fzf_complete_docker 'docker '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 docker **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'TEST1=value1 TEST2=value2 docker '
+    }
+
+    prefix=
+    _fzf_complete_docker 'TEST1=value1 TEST2=value2 docker '
+}
+
 @test 'Testing completion: docker create **' {
     docker_mock_1() {
         assert $# equals 3

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -5,17 +5,22 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock docker
-
-    __fzf_extract_command() {
-        echo 'docker'
-    }
+    mock __fzf_extract_command
 }
 
 @teardown {
-    unmock docker
+    (unmock docker)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: docker **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -24,6 +29,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'docker '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -31,6 +38,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 docker **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 docker '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -39,6 +53,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'TEST1=value1 TEST2=value2 docker '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -60,6 +76,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker create '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -69,6 +92,7 @@
         assert $5 same_as 'docker create '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -98,6 +122,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker history '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -107,6 +138,7 @@
         assert $5 same_as 'docker history '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -137,6 +169,13 @@
         echo 'archlinux;0152bf6f0800;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker push '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -146,6 +185,7 @@
         assert $5 same_as 'docker push '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}REPOSITORY  ${reset_color}  ${reset_color}IMAGE ID    ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -174,6 +214,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker run '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -183,6 +230,7 @@
         assert $5 same_as 'docker run '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -212,6 +260,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker rmi '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -222,6 +277,7 @@
         assert $6 same_as 'docker rmi '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -251,6 +307,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker save '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -261,6 +324,7 @@
         assert $6 same_as 'docker save '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -290,6 +354,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker tag '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -300,6 +371,7 @@
         assert $6 same_as 'docker tag '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -326,6 +398,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker attach '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -335,6 +414,7 @@
         assert $5 same_as 'docker attach '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -357,6 +437,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker exec '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -366,6 +453,7 @@
         assert $5 same_as 'docker exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -388,6 +476,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker top '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -397,6 +492,7 @@
         assert $5 same_as 'docker top '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -419,6 +515,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker kill '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -429,6 +532,7 @@
         assert $6 same_as 'docker kill '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -451,6 +555,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker pause '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -461,6 +572,7 @@
         assert $6 same_as 'docker pause '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -483,6 +595,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker stop '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -493,6 +612,7 @@
         assert $6 same_as 'docker stop '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -515,6 +635,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker unpause '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -525,6 +652,7 @@
         assert $6 same_as 'docker unpause '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE    ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS     ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -552,6 +680,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker commit '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -561,6 +696,7 @@
         assert $5 same_as 'docker commit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -592,6 +728,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker cp '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -601,6 +744,7 @@
         assert $5 same_as 'docker cp '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -632,6 +776,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker diff '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -641,6 +792,7 @@
         assert $5 same_as 'docker diff '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -672,6 +824,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker export '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -681,6 +840,7 @@
         assert $5 same_as 'docker export '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -712,6 +872,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker logs '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -721,6 +888,7 @@
         assert $5 same_as 'docker logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -752,6 +920,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker port '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -761,6 +936,7 @@
         assert $5 same_as 'docker port '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -792,6 +968,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker rename '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -801,6 +984,7 @@
         assert $5 same_as 'docker rename '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -832,6 +1016,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -842,6 +1033,7 @@
         assert $6 same_as 'docker inspect '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -873,6 +1065,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type=container '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -883,6 +1082,7 @@
         assert $6 same_as 'docker inspect --type=container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -914,6 +1114,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type container '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -924,6 +1131,7 @@
         assert $6 same_as 'docker inspect --type container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -953,6 +1161,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type=image '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -963,6 +1178,7 @@
         assert $6 same_as 'docker inspect --type=image '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -992,6 +1208,13 @@
         echo '0152bf6f0800;archlinux;latest;18 months ago;409MB'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type image '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1002,6 +1225,7 @@
         assert $6 same_as 'docker inspect --type image '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}IMAGE ID    ${reset_color}  ${reset_color}REPOSITORY  ${reset_color}  ${reset_color}TAG   ${reset_color}  ${reset_color}CREATED      ${reset_color}  SIZE"
@@ -1030,6 +1254,13 @@
         echo '97628061152b;none;null;local'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type=network '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1040,6 +1271,7 @@
         assert $6 same_as 'docker inspect --type=network '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}NETWORK ID  ${reset_color}  ${reset_color}NAME  ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
@@ -1066,6 +1298,13 @@
         echo '97628061152b;none;null;local'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type network '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1076,6 +1315,7 @@
         assert $6 same_as 'docker inspect --type network '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}NETWORK ID  ${reset_color}  ${reset_color}NAME  ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
@@ -1102,6 +1342,13 @@
         echo '7fb9e47eb7e7efd9672213fdc0f77296f8230abd5a2682bb5eacfad8cbb93ca2;local;local'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type=volume '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1112,6 +1359,7 @@
         assert $6 same_as 'docker inspect --type=volume '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}VOLUME ID                                                       ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
@@ -1138,6 +1386,13 @@
         echo '7fb9e47eb7e7efd9672213fdc0f77296f8230abd5a2682bb5eacfad8cbb93ca2;local;local'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type volume '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1148,6 +1403,7 @@
         assert $6 same_as 'docker inspect --type volume '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}VOLUME ID                                                       ${reset_color}  ${reset_color}DRIVER${reset_color}  SCOPE"
@@ -1161,6 +1417,13 @@
 }
 
 @test 'Testing completion: docker inspect --type=task **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type=task '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1168,10 +1431,18 @@
     prefix=
     _fzf_complete_docker 'docker inspect --type=task '
 
+    assert __fzf_extract_command mock_times 1
     assert docker mock_times 0
 }
 
 @test 'Testing completion: docker inspect --type task **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker inspect --type task '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1179,6 +1450,7 @@
     prefix=
     _fzf_complete_docker 'docker inspect --type task '
 
+    assert __fzf_extract_command mock_times 1
     assert docker mock_times 0
 }
 
@@ -1199,6 +1471,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker restart '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1209,6 +1488,7 @@
         assert $6 same_as 'docker restart '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1240,6 +1520,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker rm '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1250,6 +1537,7 @@
         assert $6 same_as 'docker rm '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1281,6 +1569,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker start '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1291,6 +1586,7 @@
         assert $6 same_as 'docker start '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1322,6 +1618,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker stats '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1332,6 +1635,7 @@
         assert $6 same_as 'docker stats '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1363,6 +1667,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker update '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1373,6 +1684,7 @@
         assert $6 same_as 'docker update '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1404,6 +1716,13 @@
         echo '295e3ea0de41;archlinux;"/bin/zsh --login";4 weeks ago;Up 1 second;;thankful_smyth'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker wait '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1414,6 +1733,7 @@
         assert $6 same_as 'docker wait '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert docker mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}CONTAINER ID${reset_color}  ${reset_color}IMAGE       ${reset_color}  ${reset_color}COMMAND           ${reset_color}  ${reset_color}CREATED    ${reset_color}  ${reset_color}STATUS                ${reset_color}  ${reset_color}PORTS${reset_color}  NAME"
@@ -1429,6 +1749,13 @@
 }
 
 @test 'Testing completion: docker "" wait **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'docker "" wait '
+
+        echo 'docker'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1437,6 +1764,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'docker "" wait '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -5,6 +5,10 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock docker
+
+    __fzf_extract_command() {
+        echo 'docker'
+    }
 }
 
 @teardown {

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -1428,6 +1428,23 @@
     _fzf_complete_docker 'docker wait '
 }
 
+@test 'Testing completion: docker "" wait **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'docker "" wait '
+    }
+
+    prefix=
+    _fzf_complete_docker 'docker "" wait '
+
+    assert docker mock_times 0
+}
+
 @test 'Testing post: docker-images' {
     input=(
         'e7d92cdc71fe  alpine        latest  18 hours ago   5.59MB'

--- a/tests/docker.zunit
+++ b/tests/docker.zunit
@@ -1428,23 +1428,6 @@
     _fzf_complete_docker 'docker wait '
 }
 
-@test 'Testing completion: docker "" wait **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'docker "" wait '
-    }
-
-    prefix=
-    _fzf_complete_docker 'docker "" wait '
-
-    assert docker mock_times 0
-}
-
 @test 'Testing post: docker-images' {
     input=(
         'e7d92cdc71fe  alpine        latest  18 hours ago   5.59MB'

--- a/tests/env.zunit
+++ b/tests/env.zunit
@@ -5,14 +5,12 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock _fzf_complete_docker
-
-    __fzf_extract_command() {
-        echo 'docker'
-    }
+    mock __fzf_extract_command
 }
 
 @teardown {
-    unmock _fzf_complete_docker
+    (unmock _fzf_complete_docker)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: env TEST1=value1 TEST2=value2 docker **' {
@@ -21,10 +19,18 @@
         assert $1 same_as 'TEST1=value1 TEST2=value2 docker '
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 docker'
+
+        echo 'docker'
+    }
+
     LBUFFER='env TEST1=value1 TEST2=value2 docker '
     prefix=
     _fzf_complete_env 'env TEST1=value1 TEST2=value2 docker '
 
+    assert __fzf_extract_command mock_times 1
     assert $LBUFFER same_as 'env TEST1=value1 TEST2=value2 docker '
 }
 
@@ -34,9 +40,17 @@
         assert $1 same_as 'TEST1=value1 TEST2=value2 docker start '
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 docker start'
+
+        echo 'docker'
+    }
+
     LBUFFER='env TEST1=value1 TEST2=value2 docker start '
     prefix=
     _fzf_complete_env 'env TEST1=value1 TEST2=value2 docker start '
 
+    assert __fzf_extract_command mock_times 1
     assert $LBUFFER same_as 'env TEST1=value1 TEST2=value2 docker start '
 }

--- a/tests/env.zunit
+++ b/tests/env.zunit
@@ -1,0 +1,42 @@
+#!/usr/bin/env zunit
+
+@setup {
+    load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock _fzf_complete_docker
+
+    __fzf_extract_command() {
+        echo 'docker'
+    }
+}
+
+@teardown {
+    unmock _fzf_complete_docker
+}
+
+@test 'Testing completion: env TEST1=value1 TEST2=value2 docker **' {
+    _fzf_complete_docker() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 docker '
+    }
+
+    LBUFFER='env TEST1=value1 TEST2=value2 docker '
+    prefix=
+    _fzf_complete_env 'env TEST1=value1 TEST2=value2 docker '
+
+    assert $LBUFFER same_as 'env TEST1=value1 TEST2=value2 docker '
+}
+
+@test 'Testing completion: env TEST1=value1 TEST2=value2 docker start **' {
+    _fzf_complete_docker() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 docker start '
+    }
+
+    LBUFFER='env TEST1=value1 TEST2=value2 docker start '
+    prefix=
+    _fzf_complete_env 'env TEST1=value1 TEST2=value2 docker start '
+
+    assert $LBUFFER same_as 'env TEST1=value1 TEST2=value2 docker start '
+}

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -30,6 +30,21 @@
     _fzf_complete_docker 'gh '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 gh **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'TEST1=value1 TEST2=value2 gh '
+    }
+
+    prefix=
+    _fzf_complete_docker 'TEST1=value1 TEST2=value2 gh '
+}
+
 @test 'Testing completion: gh pr **' {
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -564,23 +564,6 @@
     _fzf_complete_gh 'gh pr view '
 }
 
-@test 'Testing completion: gh "" pr view **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'gh "" pr view '
-    }
-
-    prefix=
-    _fzf_complete_gh 'gh "" pr view '
-
-    assert gh mock_times 0
-}
-
 @test 'Testing post: gh-pr' {
     input=(
         '8  2nd OPEN PR  2nd-open  OPEN'

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -9,8 +9,8 @@
 }
 
 @teardown {
-    unmock gh
-    unmock __fzf_extract_command
+    (unmock gh)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: gh **' {

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -5,6 +5,10 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock gh
+
+    __fzf_extract_command() {
+        echo 'gh'
+    }
 }
 
 @teardown {

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -569,6 +569,13 @@
         fail '_fzf_complete should not be invoked'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh "" pr view '
+
+        echo 'gh'
+    }
+
     _fzf_path_completion() {
         assert $# equals 2
         assert $1 same_as ''
@@ -578,6 +585,7 @@
     prefix=
     _fzf_complete_gh 'gh "" pr view '
 
+    assert __fzf_extract_command mock_times 1
     assert gh mock_times 0
 }
 

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -34,7 +34,7 @@
     }
 
     prefix=
-    _fzf_complete_docker 'gh '
+    _fzf_complete_gh 'gh '
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 gh **' {
@@ -58,7 +58,7 @@
     }
 
     prefix=
-    _fzf_complete_docker 'TEST1=value1 TEST2=value2 gh '
+    _fzf_complete_gh 'TEST1=value1 TEST2=value2 gh '
 }
 
 @test 'Testing completion: gh pr **' {
@@ -594,7 +594,7 @@
         '8  2nd OPEN PR  2nd-open  OPEN'
     )
 
-    run _fzf_complete_docker-images_post <<< ${(F)input}
+    run _fzf_complete_gh-pr_post <<< ${(F)input}
 
     assert $state equals 0
     assert ${#lines} equals 1

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -564,6 +564,23 @@
     _fzf_complete_gh 'gh pr view '
 }
 
+@test 'Testing completion: gh "" pr view **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'gh "" pr view '
+    }
+
+    prefix=
+    _fzf_complete_gh 'gh "" pr view '
+
+    assert gh mock_times 0
+}
+
 @test 'Testing post: gh-pr' {
     input=(
         '8  2nd OPEN PR  2nd-open  OPEN'

--- a/tests/gh.zunit
+++ b/tests/gh.zunit
@@ -5,14 +5,12 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock gh
-
-    __fzf_extract_command() {
-        echo 'gh'
-    }
+    mock __fzf_extract_command
 }
 
 @teardown {
     unmock gh
+    unmock __fzf_extract_command
 }
 
 @test 'Testing completion: gh **' {
@@ -20,10 +18,19 @@
         fail '_fzf_complete should not be invoked'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh '
+
+        echo 'gh'
+    }
+
     _fzf_path_completion() {
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'gh '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -35,10 +42,19 @@
         fail '_fzf_complete should not be invoked'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 gh '
+
+        echo 'gh'
+    }
+
     _fzf_path_completion() {
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'TEST1=value1 TEST2=value2 gh '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -50,10 +66,18 @@
         fail '_fzf_complete should not be invoked'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr '
+
+        echo 'gh'
+    }
+
     prefix=
     _fzf_complete_gh 'gh pr '
 
     assert $? equals 0
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: gh pr close **' {
@@ -70,6 +94,13 @@
         echo "3\t1st DRAFT PR\t1st-draft\tDRAFT"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr close '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -79,6 +110,7 @@
         assert $5 same_as 'gh pr close '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}"
@@ -106,6 +138,13 @@
         echo "3\t1st DRAFT PR\t1st-draft\tDRAFT"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr merge '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -115,6 +154,7 @@
         assert $5 same_as 'gh pr merge '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}"
@@ -142,6 +182,13 @@
         echo "3\t1st DRAFT PR\t1st-draft\tDRAFT"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr ready '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -151,6 +198,7 @@
         assert $5 same_as 'gh pr ready '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE       ${reset_color}  ${fg[blue]}HEAD     ${reset_color}  ${fg[green]}STATE${reset_color}"
@@ -176,6 +224,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr reopen '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -185,6 +240,7 @@
         assert $5 same_as 'gh pr reopen '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -214,6 +270,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr checkout '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -223,6 +286,7 @@
         assert $5 same_as 'gh pr checkout '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -258,6 +322,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr comment '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -267,6 +338,7 @@
         assert $5 same_as 'gh pr comment '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -302,6 +374,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr diff '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -311,6 +390,7 @@
         assert $5 same_as 'gh pr diff '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -346,6 +426,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr edit '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -355,6 +442,7 @@
         assert $5 same_as 'gh pr edit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -390,6 +478,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr review '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -399,6 +494,7 @@
         assert $5 same_as 'gh pr review '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"
@@ -434,6 +530,13 @@
         echo "1\t1st CLOSED PR\t1st-closed\tCLOSED"
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'gh pr view '
+
+        echo 'gh'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -443,6 +546,7 @@
         assert $5 same_as 'gh pr view '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert gh mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}#${reset_color}  ${reset_color}TITLE        ${reset_color}  ${fg[blue]}HEAD      ${reset_color}  ${fg[green]}STATE ${reset_color}"

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -55,6 +55,21 @@
     _fzf_complete_git 'git '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 git **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'TEST1=value1 TEST2=value2 git '
+    }
+
+    prefix=
+    _fzf_complete_git 'TEST1=value1 TEST2=value2 git '
+}
+
 @test 'Testing completion: git checkout **' {
     _fzf_complete() {
         assert $# equals 4

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -23,6 +23,10 @@
             fi
         done
     }
+
+    __fzf_extract_command() {
+        echo 'git'
+    }
 }
 
 @teardown {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -5152,24 +5152,6 @@
     _fzf_complete_git 'git show '
 }
 
-@test 'Testing completion: git "" show --notes=**' {
-    run git notes add -m 'Note1'
-    run git notes --ref=note add -m 'Note2'
-
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as '--notes='
-        assert $2 same_as 'git "" show '
-    }
-
-    prefix=--notes=
-    _fzf_complete_git 'git "" show '
-}
-
 @test 'Testing completion (alias): git commit --squash **' {
     run git config alias.squash 'commit --squash'
 
@@ -5269,24 +5251,6 @@
 
     prefix=
     _fzf_complete_git 'git commit-cleanup '
-}
-
-@test 'Testing completion (alias): git "" commit **' {
-    run git checkout another-branch
-    run git config alias.commit-all '"" commit -a'
-
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'git commit-all '
-    }
-
-    prefix=
-    _fzf_complete_git 'git commit-all '
 }
 
 @test 'Testing completion (alias): git commit **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -5152,6 +5152,24 @@
     _fzf_complete_git 'git show '
 }
 
+@test 'Testing completion: git "" show --notes=**' {
+    run git notes add -m 'Note1'
+    run git notes --ref=note add -m 'Note2'
+
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as '--notes='
+        assert $2 same_as 'git "" show '
+    }
+
+    prefix=--notes=
+    _fzf_complete_git 'git "" show '
+}
+
 @test 'Testing completion (alias): git commit --squash **' {
     run git config alias.squash 'commit --squash'
 
@@ -5251,6 +5269,24 @@
 
     prefix=
     _fzf_complete_git 'git commit-cleanup '
+}
+
+@test 'Testing completion (alias): git "" commit **' {
+    run git checkout another-branch
+    run git config alias.commit-all '"" commit -a'
+
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'git commit-all '
+    }
+
+    prefix=
+    _fzf_complete_git 'git commit-all '
 }
 
 @test 'Testing completion (alias): git commit **' {

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -2,7 +2,9 @@
 
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
     load _helpers/assertions.zsh
+    mock __fzf_extract_command
 
     pushd tests/_support/git
     DIR=$PWD
@@ -23,13 +25,10 @@
             fi
         done
     }
-
-    __fzf_extract_command() {
-        echo 'git'
-    }
 }
 
 @teardown {
+    (unmock __fzf_extract_command)
     pushd $DIR
 
     {
@@ -41,6 +40,13 @@
 }
 
 @test 'Testing completion: git **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -49,6 +55,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'git '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -56,6 +64,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 git **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 git '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -64,6 +79,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'TEST1=value1 TEST2=value2 git '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -71,6 +88,13 @@
 }
 
 @test 'Testing completion: git checkout **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -79,6 +103,7 @@
         assert $4 same_as 'git checkout '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -98,6 +123,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -111,6 +143,7 @@
         assert $9 same_as 'git checkout -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -140,6 +173,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout -- file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -153,6 +193,7 @@
         assert $9 same_as 'git checkout -- file '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -188,6 +229,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -201,6 +249,7 @@
         assert $9 same_as 'git checkout -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -236,6 +285,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout -- file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -249,6 +305,7 @@
         assert $9 same_as 'git checkout -- file '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -272,6 +329,13 @@
 }
 
 @test 'Testing completion: git checkout another-branch **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -282,6 +346,7 @@
         assert $6 same_as 'git checkout another-branch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -307,6 +372,13 @@
 @test 'Testing completion in subdirectory: git checkout another-branch **' {
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -317,6 +389,7 @@
         assert $6 same_as 'git checkout another-branch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -340,6 +413,13 @@
 }
 
 @test 'Testing completion: git checkout another-branch -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -350,6 +430,7 @@
         assert $6 same_as 'git checkout another-branch -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -375,6 +456,13 @@
 @test 'Testing completion in subdirectory: git checkout another-branch -- **' {
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -385,6 +473,7 @@
         assert $6 same_as 'git checkout another-branch -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -408,6 +497,13 @@
 }
 
 @test 'Testing completion: git checkout another-branch -- file **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch -- file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -418,6 +514,7 @@
         assert $6 same_as 'git checkout another-branch -- file '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -443,6 +540,13 @@
 @test 'Testing completion in subdirectory: git checkout another-branch -- file **' {
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout another-branch -- file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -453,6 +557,7 @@
         assert $6 same_as 'git checkout another-branch -- file '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -476,6 +581,13 @@
 }
 
 @test 'Testing completion: git checkout branch-that-does-not-exist **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout branch-that-does-not-exist '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -486,6 +598,7 @@
         assert $6 same_as 'git checkout branch-that-does-not-exist '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
@@ -497,6 +610,13 @@
 }
 
 @test 'Testing completion: git checkout branch-that-does-not-exist -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout branch-that-does-not-exist -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -507,6 +627,7 @@
         assert $6 same_as 'git checkout branch-that-does-not-exist -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
@@ -518,6 +639,13 @@
 }
 
 @test 'Testing completion: git checkout branch-that-does-not-exist -- file **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout branch-that-does-not-exist -- file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -528,6 +656,7 @@
         assert $6 same_as 'git checkout branch-that-does-not-exist -- file '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
@@ -539,6 +668,13 @@
 }
 
 @test 'Testing completion: git diff **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git diff '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -547,6 +683,7 @@
         assert $4 same_as 'git diff '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -566,6 +703,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git diff -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -579,6 +723,7 @@
         assert $9 same_as 'git diff -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -614,6 +759,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git diff -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -627,6 +779,7 @@
         assert $9 same_as 'git diff -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -650,6 +803,13 @@
 }
 
 @test 'Testing completion: git log **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git log '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -658,6 +818,7 @@
         assert $4 same_as 'git log '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -677,6 +838,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git log -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -687,6 +855,7 @@
         assert $6 same_as 'git log -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -718,6 +887,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git log -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -728,6 +904,7 @@
         assert $6 same_as 'git log -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -751,6 +928,13 @@
 }
 
 @test 'Testing completion: git rebase **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git rebase '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -759,6 +943,7 @@
         assert $4 same_as 'git rebase '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -772,6 +957,13 @@
 }
 
 @test 'Testing completion: git reset **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -780,6 +972,7 @@
         assert $4 same_as 'git reset '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -796,6 +989,13 @@
     echo >> newfile
     run git add newfile
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset another-branch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -806,6 +1006,7 @@
         assert $6 same_as 'git reset another-branch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -833,6 +1034,13 @@
     echo >> newfile
     run git add newfile
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -843,6 +1051,7 @@
         assert $6 same_as 'git reset -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
@@ -860,6 +1069,13 @@
     echo >> newfile
     run git add newfile
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset another-branch -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -870,6 +1086,7 @@
         assert $6 same_as 'git reset another-branch -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -894,6 +1111,13 @@
 }
 
 @test 'Testing completion: git reset --soft -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset --soft -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -901,10 +1125,18 @@
     prefix=
     _fzf_complete_git 'git reset --soft -- '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git reset --hard -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset --hard -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -912,10 +1144,18 @@
     prefix=
     _fzf_complete_git 'git reset --hard -- '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git reset --merge -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset --merge -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -923,10 +1163,18 @@
     prefix=
     _fzf_complete_git 'git reset --merge -- '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git reset --keep -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset --keep -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -934,6 +1182,7 @@
     prefix=
     _fzf_complete_git 'git reset --keep -- '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
@@ -946,6 +1195,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -956,6 +1212,7 @@
         assert $6 same_as 'git reset -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -979,6 +1236,13 @@
 }
 
 @test 'Testing completion: git switch **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git switch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -987,6 +1251,7 @@
         assert $4 same_as 'git switch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -1000,6 +1265,13 @@
 }
 
 @test 'Testing completion: git branch **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git branch -D '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1009,6 +1281,7 @@
         assert $5 same_as 'git branch -D '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -1022,6 +1295,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --cleanup=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1030,6 +1310,7 @@
         assert $4 same_as 'git cherry-pick --cleanup='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -1043,6 +1324,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --cleanup **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick --cleanup '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1051,6 +1339,7 @@
         assert $4 same_as 'git cherry-pick --cleanup '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -1064,6 +1353,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --strategy=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1072,6 +1368,7 @@
         assert $4 same_as 'git cherry-pick --strategy='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -1085,6 +1382,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --strategy **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick --strategy '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1093,6 +1397,7 @@
         assert $4 same_as 'git cherry-pick --strategy '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -1106,6 +1411,13 @@
 }
 
 @test 'Testing completion: git cherry-pick -X **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick -X '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1114,6 +1426,7 @@
         assert $4 same_as 'git cherry-pick -X '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1141,6 +1454,13 @@
 }
 
 @test 'Testing completion: git cherry-pick -X**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1149,6 +1469,7 @@
         assert $4 same_as 'git cherry-pick -X'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1176,6 +1497,13 @@
 }
 
 @test 'Testing completion: git cherry-pick -qX **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick -qX '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1184,6 +1512,7 @@
         assert $4 same_as 'git cherry-pick -qX '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1211,6 +1540,13 @@
 }
 
 @test 'Testing completion: git cherry-pick -qX**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1219,6 +1555,7 @@
         assert $4 same_as 'git cherry-pick -qX'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1246,6 +1583,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --strategy-option=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1254,6 +1598,7 @@
         assert $4 same_as 'git cherry-pick --strategy-option='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1280,6 +1625,13 @@
 }
 
 @test 'Testing completion: git cherry-pick --strategy-option **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick --strategy-option '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -1288,6 +1640,7 @@
         assert $4 same_as 'git cherry-pick --strategy-option '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -1315,6 +1668,13 @@
 }
 
 @test 'Testing completion: git cherry-pick **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git cherry-pick '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1324,6 +1684,7 @@
         assert $5 same_as 'git cherry-pick '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
     }
@@ -1333,6 +1694,13 @@
 }
 
 @test 'Testing completion: git merge **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git merge '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1342,6 +1710,7 @@
         assert $5 same_as 'git merge '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -1355,6 +1724,13 @@
 }
 
 @test 'Testing completion: git revert **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git revert '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1364,6 +1740,7 @@
         assert $5 same_as 'git revert '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -1383,6 +1760,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -1396,6 +1780,7 @@
         assert $9 same_as 'git restore '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1425,6 +1810,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --source=HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1435,6 +1827,7 @@
         assert $6 same_as 'git restore --source=HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1466,6 +1859,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --source=HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1476,6 +1876,7 @@
         assert $6 same_as 'git restore --source=HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1505,6 +1906,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --source HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1515,6 +1923,7 @@
         assert $6 same_as 'git restore --source HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1546,6 +1955,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --source HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1556,6 +1972,7 @@
         assert $6 same_as 'git restore --source HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1585,6 +2002,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -s HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1595,6 +2019,7 @@
         assert $6 same_as 'git restore -s HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1626,6 +2051,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -s HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1636,6 +2068,7 @@
         assert $6 same_as 'git restore -s HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1665,6 +2098,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -sHEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1675,6 +2115,7 @@
         assert $6 same_as 'git restore -sHEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1706,6 +2147,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -sHEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1716,6 +2164,7 @@
         assert $6 same_as 'git restore -sHEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1745,6 +2194,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -qs HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1755,6 +2211,7 @@
         assert $6 same_as 'git restore -qs HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1786,6 +2243,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -qs HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1796,6 +2260,7 @@
         assert $6 same_as 'git restore -qs HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1825,6 +2290,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -qsHEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1835,6 +2307,7 @@
         assert $6 same_as 'git restore -qsHEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1866,6 +2339,13 @@
 
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -qsHEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1876,6 +2356,7 @@
         assert $6 same_as 'git restore -qsHEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1906,6 +2387,13 @@
     echo >> directory2/$'file6\ncontaining\nnewlines'
     run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --staged '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -1919,6 +2407,7 @@
         assert $9 same_as 'git restore --staged '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1948,6 +2437,13 @@
     echo >> directory2/$'file6\ncontaining\nnewlines'
     run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -S '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -1961,6 +2457,7 @@
         assert $9 same_as 'git restore -S '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -1990,6 +2487,13 @@
     echo >> directory2/$'file6\ncontaining\nnewlines'
     run git add file1 ' file3 containing space ' $'directory2/file4\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -qSq '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -2003,6 +2507,7 @@
         assert $9 same_as 'git restore -qSq '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -2025,6 +2530,13 @@
 }
 
 @test 'Testing completion: git restore --source=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2033,6 +2545,7 @@
         assert $4 same_as 'git restore --source='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2046,6 +2559,13 @@
 }
 
 @test 'Testing completion: git restore --source **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore --source '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2054,6 +2574,7 @@
         assert $4 same_as 'git restore --source '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2067,6 +2588,13 @@
 }
 
 @test 'Testing completion: git restore -s **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore -s '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2075,6 +2603,7 @@
         assert $4 same_as 'git restore -s '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2088,6 +2617,13 @@
 }
 
 @test 'Testing completion: git restore -s**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git restore '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2096,6 +2632,7 @@
         assert $4 same_as 'git restore -s'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2109,6 +2646,13 @@
 }
 
 @test 'Testing completion: git commit --fixup=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2117,6 +2661,7 @@
         assert $4 same_as 'git commit --fixup='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2130,6 +2675,13 @@
 }
 
 @test 'Testing completion: git commit --reedit-message=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2138,6 +2690,7 @@
         assert $4 same_as 'git commit --reedit-message='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2151,6 +2704,13 @@
 }
 
 @test 'Testing completion: git commit --reuse-message=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2159,6 +2719,7 @@
         assert $4 same_as 'git commit --reuse-message='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2172,6 +2733,13 @@
 }
 
 @test 'Testing completion: git commit --squash=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2180,6 +2748,7 @@
         assert $4 same_as 'git commit --squash='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2193,6 +2762,13 @@
 }
 
 @test 'Testing completion: git commit -c **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -c '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2201,6 +2777,7 @@
         assert $4 same_as 'git commit -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2214,6 +2791,13 @@
 }
 
 @test 'Testing completion: git commit -c**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2222,6 +2806,7 @@
         assert $4 same_as 'git commit -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2235,6 +2820,13 @@
 }
 
 @test 'Testing completion: git commit -qc **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -qc '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2243,6 +2835,7 @@
         assert $4 same_as 'git commit -qc '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2256,6 +2849,13 @@
 }
 
 @test 'Testing completion: git commit -qc**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2264,6 +2864,7 @@
         assert $4 same_as 'git commit -qc'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2277,6 +2878,13 @@
 }
 
 @test 'Testing completion: git commit -C **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -C '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2285,6 +2893,7 @@
         assert $4 same_as 'git commit -C '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2298,6 +2907,13 @@
 }
 
 @test 'Testing completion: git commit -C**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2306,6 +2922,7 @@
         assert $4 same_as 'git commit -C'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2319,6 +2936,13 @@
 }
 
 @test 'Testing completion: git commit -qC **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -qC '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2327,6 +2951,7 @@
         assert $4 same_as 'git commit -qC '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2340,6 +2965,13 @@
 }
 
 @test 'Testing completion: git commit -qC**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2348,6 +2980,7 @@
         assert $4 same_as 'git commit -qC'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2361,6 +2994,13 @@
 }
 
 @test 'Testing completion: git commit --fixup **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --fixup '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2369,6 +3009,7 @@
         assert $4 same_as 'git commit --fixup '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2382,6 +3023,13 @@
 }
 
 @test 'Testing completion: git commit --reedit-message **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --reedit-message '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2390,6 +3038,7 @@
         assert $4 same_as 'git commit --reedit-message '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2403,6 +3052,13 @@
 }
 
 @test 'Testing completion: git commit --reuse-message **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --reuse-message '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2411,6 +3067,7 @@
         assert $4 same_as 'git commit --reuse-message '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2424,6 +3081,13 @@
 }
 
 @test 'Testing completion: git commit --squash **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --squash '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2432,6 +3096,7 @@
         assert $4 same_as 'git commit --squash '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -2447,6 +3112,13 @@
 @test 'Testing completion: git commit --message=**' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2455,6 +3127,7 @@
         assert $4 same_as 'git commit --message='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2467,6 +3140,13 @@
 @test 'Testing completion: git commit -m **' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -m '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2475,6 +3155,7 @@
         assert $4 same_as 'git commit -m '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2487,6 +3168,13 @@
 @test 'Testing completion: git commit -m**' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2495,6 +3183,7 @@
         assert $4 same_as 'git commit -m'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2507,6 +3196,13 @@
 @test 'Testing completion: git commit -qm **' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -qm '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2515,6 +3211,7 @@
         assert $4 same_as 'git commit -qm '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2527,6 +3224,13 @@
 @test 'Testing completion: git commit -qm**' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2535,6 +3239,7 @@
         assert $4 same_as 'git commit -qm'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2547,6 +3252,13 @@
 @test 'Testing completion: git commit --message **' {
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --message '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2555,6 +3267,7 @@
         assert $4 same_as 'git commit --message '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -2565,6 +3278,13 @@
 }
 
 @test 'Testing completion: git commit --author=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2572,10 +3292,18 @@
     prefix=--author=
     _fzf_complete_git 'git commit '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git commit --date=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2583,10 +3311,18 @@
     prefix=--date=
     _fzf_complete_git 'git commit '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git commit --author **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --author '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2594,10 +3330,18 @@
     prefix=
     _fzf_complete_git 'git commit --author '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git commit --date **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --date '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2605,10 +3349,18 @@
     prefix=
     _fzf_complete_git 'git commit --date '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git commit --file=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2625,9 +3377,18 @@
 
     prefix=--file=
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --template=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2644,9 +3405,18 @@
 
     prefix=--template=
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --pathspec-from-file=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2663,9 +3433,18 @@
 
     prefix=--pathspec-from-file=
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -F **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -F '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2682,9 +3461,18 @@
 
     prefix=
     _fzf_complete_git 'git commit -F '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -F**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2701,9 +3489,18 @@
 
     prefix=-F
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -qF **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -qF '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2720,9 +3517,18 @@
 
     prefix=
     _fzf_complete_git 'git commit -qF '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -qF**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2739,9 +3545,18 @@
 
     prefix=-qF
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -t **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -t '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2758,9 +3573,18 @@
 
     prefix=
     _fzf_complete_git 'git commit -t '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -t**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2777,9 +3601,18 @@
 
     prefix=-t
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -qt **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -qt '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2796,9 +3629,18 @@
 
     prefix=
     _fzf_complete_git 'git commit -qt '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit -qt**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2815,9 +3657,18 @@
 
     prefix=-qt
     _fzf_complete_git 'git commit '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --file **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2834,9 +3685,18 @@
 
     prefix=
     _fzf_complete_git 'git commit --file '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --template **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --template '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2853,9 +3713,18 @@
 
     prefix=
     _fzf_complete_git 'git commit --template '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --pathspec-from-file **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --pathspec-from-file '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2872,9 +3741,18 @@
 
     prefix=
     _fzf_complete_git 'git commit --pathspec-from-file '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: git commit --cleanup=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2883,6 +3761,7 @@
         assert $4 same_as 'git commit --cleanup='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -2896,6 +3775,13 @@
 }
 
 @test 'Testing completion: git commit --cleanup **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit --cleanup '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2904,6 +3790,7 @@
         assert $4 same_as 'git commit --cleanup '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -2917,6 +3804,13 @@
 }
 
 @test 'Testing completion: git commit -u**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2925,6 +3819,7 @@
         assert $4 same_as 'git commit -u'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as no
         assert ${lines[2]} same_as normal
@@ -2936,6 +3831,13 @@
 }
 
 @test 'Testing completion: git commit -qu**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2944,6 +3846,7 @@
         assert $4 same_as 'git commit -qu'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as no
         assert ${lines[2]} same_as normal
@@ -2955,6 +3858,13 @@
 }
 
 @test 'Testing completion: git commit --untracked-files=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -2963,6 +3873,7 @@
         assert $4 same_as 'git commit --untracked-files='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as no
         assert ${lines[2]} same_as normal
@@ -2980,6 +3891,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -2993,6 +3911,7 @@
         assert $9 same_as 'git commit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -3028,6 +3947,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -3041,6 +3967,7 @@
         assert $9 same_as 'git commit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -3070,6 +3997,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -3083,6 +4017,7 @@
         assert $9 same_as 'git commit -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -3118,6 +4053,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -3131,6 +4073,7 @@
         assert $9 same_as 'git commit -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -3160,6 +4103,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git add '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -3173,6 +4123,7 @@
         assert $9 same_as 'git add '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
 
         actual1=(${(0)lines[1]})
@@ -3218,6 +4169,13 @@
 
     cd directory2/directory3
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git add '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -3231,6 +4189,7 @@
         assert $9 same_as 'git add '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 7
 
         actual1=(${(0)lines[1]})
@@ -3275,6 +4234,13 @@
 }
 
 @test 'Testing completion: git fetch --recurse-submodules=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3283,6 +4249,7 @@
         assert $4 same_as 'git fetch --recurse-submodules='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as yes
         assert ${lines[2]} same_as on-demand
@@ -3294,6 +4261,13 @@
 }
 
 @test 'Testing completion: git fetch --recurse-submodules-default=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3302,6 +4276,7 @@
         assert $4 same_as 'git fetch --recurse-submodules-default='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as yes
         assert ${lines[2]} same_as on-demand
@@ -3312,6 +4287,13 @@
 }
 
 @test 'Testing completion: git fetch --recurse-submodules-default **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --recurse-submodules-default '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3320,6 +4302,7 @@
         assert $4 same_as 'git fetch --recurse-submodules-default '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as yes
         assert ${lines[2]} same_as on-demand
@@ -3330,6 +4313,13 @@
 }
 
 @test 'Testing completion: git fetch --shallow-exclude=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3338,6 +4328,7 @@
         assert $4 same_as 'git fetch --shallow-exclude='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -3351,6 +4342,13 @@
 }
 
 @test 'Testing completion: git fetch --shallow-exclude **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --shallow-exclude '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3359,6 +4357,7 @@
         assert $4 same_as 'git fetch --shallow-exclude '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -3372,6 +4371,13 @@
 }
 
 @test 'Testing completion: git fetch --negotiation-tip=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3380,6 +4386,7 @@
         assert $4 same_as 'git fetch --negotiation-tip='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -3393,6 +4400,13 @@
 }
 
 @test 'Testing completion: git fetch --negotiation-tip **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --negotiation-tip '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3401,6 +4415,7 @@
         assert $4 same_as 'git fetch --negotiation-tip '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -3414,6 +4429,13 @@
 }
 
 @test 'Testing completion: git fetch -j**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3421,10 +4443,18 @@
     prefix=-j
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch -j **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch -o '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3432,10 +4462,18 @@
     prefix=
     _fzf_complete_git 'git fetch -o '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --jobs=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --jobs '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3443,10 +4481,18 @@
     prefix=
     _fzf_complete_git 'git fetch --jobs '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --jobs **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --jobs '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3454,10 +4500,18 @@
     prefix=
     _fzf_complete_git 'git fetch --jobs '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch -o **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch -o '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3465,10 +4519,18 @@
     prefix=
     _fzf_complete_git 'git fetch -o '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch -o**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3476,10 +4538,18 @@
     prefix=-o
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch -qo **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch -qo '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3487,10 +4557,18 @@
     prefix=
     _fzf_complete_git 'git fetch -qo '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch -qo**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3498,10 +4576,18 @@
     prefix=-qo
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --depth=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3509,10 +4595,18 @@
     prefix=--depth=
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --depth **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --depth '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3520,10 +4614,18 @@
     prefix=
     _fzf_complete_git 'git fetch --depth '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --deepen=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3531,10 +4633,18 @@
     prefix=--deepen=
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --deepen **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --deepen '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3542,10 +4652,18 @@
     prefix=
     _fzf_complete_git 'git fetch --deepen '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --server-option=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3553,10 +4671,18 @@
     prefix=--server-option=
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --server-option **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --server-option '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3564,10 +4690,18 @@
     prefix=
     _fzf_complete_git 'git fetch --server-option '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --shallow-since=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3575,10 +4709,18 @@
     prefix=--shallow-since=
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --shallow-since **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --shallow-since '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3586,10 +4728,18 @@
     prefix=
     _fzf_complete_git 'git fetch --shallow-since '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --submodule-prefix=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3597,10 +4747,18 @@
     prefix=--submodule-prefix
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --submodule-prefix **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --submodule-prefix '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3608,10 +4766,18 @@
     prefix=
     _fzf_complete_git 'git fetch --submodule-prefix '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --upload-pack=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3619,10 +4785,18 @@
     prefix=--upload-pack
     _fzf_complete_git 'git fetch '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git fetch --upload-pack **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --upload-pack '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -3630,6 +4804,7 @@
     prefix=
     _fzf_complete_git 'git fetch --upload-pack '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
@@ -3641,6 +4816,13 @@
     run git config remotes.group1 'origin upstream'
     run git config remotes.group2 'origin upstream example'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3650,6 +4832,7 @@
         assert $5 same_as 'git fetch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -3665,6 +4848,13 @@
 @test 'Testing completion: git fetch origin **' {
     run git remote add origin ${DIR%/*}/remote.git
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3674,6 +4864,7 @@
         assert $5 same_as 'git fetch origin '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color"
@@ -3693,6 +4884,13 @@
     run git config remotes.group1 'origin upstream'
     run git config remotes.group2 'origin upstream example'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git fetch --multiple origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3702,6 +4900,7 @@
         assert $5 same_as 'git fetch --multiple origin '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -3715,6 +4914,13 @@
 }
 
 @test 'Testing completion: git pull --recurse-submodules=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3723,6 +4929,7 @@
         assert $4 same_as 'git pull --recurse-submodules='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as yes
         assert ${lines[2]} same_as on-demand
@@ -3734,6 +4941,13 @@
 }
 
 @test 'Testing completion: git pull --cleanup=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3742,6 +4956,7 @@
         assert $4 same_as 'git pull --cleanup='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -3755,6 +4970,13 @@
 }
 
 @test 'Testing completion: git pull --cleanup **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --cleanup '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3763,6 +4985,7 @@
         assert $4 same_as 'git pull --cleanup '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -3776,6 +4999,13 @@
 }
 
 @test 'Testing completion: git pull -s **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -s '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3784,6 +5014,7 @@
         assert $4 same_as 'git pull -s '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3797,6 +5028,13 @@
 }
 
 @test 'Testing completion: git pull -s**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3805,6 +5043,7 @@
         assert $4 same_as 'git pull -s'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3818,6 +5057,13 @@
 }
 
 @test 'Testing completion: git pull -qs **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -qs '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3826,6 +5072,7 @@
         assert $4 same_as 'git pull -qs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3839,6 +5086,13 @@
 }
 
 @test 'Testing completion: git pull -qs**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3847,6 +5101,7 @@
         assert $4 same_as 'git pull -qs'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3860,6 +5115,13 @@
 }
 
 @test 'Testing completion: git pull --strategy=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3868,6 +5130,7 @@
         assert $4 same_as 'git pull --strategy='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3881,6 +5144,13 @@
 }
 
 @test 'Testing completion: git pull --strategy **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --strategy '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3889,6 +5159,7 @@
         assert $4 same_as 'git pull --strategy '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as octopus
         assert ${lines[2]} same_as ours
@@ -3902,6 +5173,13 @@
 }
 
 @test 'Testing completion: git pull -X **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -X '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3910,6 +5188,7 @@
         assert $4 same_as 'git pull -X '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -3937,6 +5216,13 @@
 }
 
 @test 'Testing completion: git pull -X**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3945,6 +5231,7 @@
         assert $4 same_as 'git pull -X'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -3972,6 +5259,13 @@
 }
 
 @test 'Testing completion: git pull -qX **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -qX '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3980,6 +5274,7 @@
         assert $4 same_as 'git pull -qX '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -4007,6 +5302,13 @@
 }
 
 @test 'Testing completion: git pull -qX**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4015,6 +5317,7 @@
         assert $4 same_as 'git pull -qX'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -4042,6 +5345,13 @@
 }
 
 @test 'Testing completion: git pull --strategy-option=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4050,6 +5360,7 @@
         assert $4 same_as 'git pull --strategy-option='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -4077,6 +5388,13 @@
 }
 
 @test 'Testing completion: git pull --strategy-option **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --strategy-option '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4085,6 +5403,7 @@
         assert $4 same_as 'git pull --strategy-option '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 19
         assert ${lines[1]} same_as diff-algorithm=histogram
         assert ${lines[2]} same_as diff-algorithm=minimal
@@ -4112,6 +5431,13 @@
 }
 
 @test 'Testing completion: git pull --rebase=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4120,6 +5446,7 @@
         assert $4 same_as 'git pull --rebase='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as false
         assert ${lines[2]} same_as interactive
@@ -4133,6 +5460,13 @@
 }
 
 @test 'Testing completion: git pull --shallow-exclude=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4141,6 +5475,7 @@
         assert $4 same_as 'git pull --shallow-exclude='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4154,6 +5489,13 @@
 }
 
 @test 'Testing completion: git pull --shallow-exclude **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --shallow-exclude '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4162,6 +5504,7 @@
         assert $4 same_as 'git pull --shallow-exclude '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4175,6 +5518,13 @@
 }
 
 @test 'Testing completion: git pull --negotiation-tip=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4183,6 +5533,7 @@
         assert $4 same_as 'git pull --negotiation-tip='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4196,6 +5547,13 @@
 }
 
 @test 'Testing completion: git pull --negotiation-tip **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --negotiation-tip '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4204,6 +5562,7 @@
         assert $4 same_as 'git pull --negotiation-tip '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4217,6 +5576,13 @@
 }
 
 @test 'Testing completion: git pull -o **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -o '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4224,10 +5590,18 @@
     prefix=
     _fzf_complete_git 'git pull -o '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull -o**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4235,10 +5609,18 @@
     prefix=-o
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull -qo **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -qo '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4246,10 +5628,18 @@
     prefix=
     _fzf_complete_git 'git pull -qo '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull -qo**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4257,10 +5647,18 @@
     prefix=-qo
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --date=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4268,10 +5666,18 @@
     prefix=--date=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --date **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --date '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4279,10 +5685,18 @@
     prefix=
     _fzf_complete_git 'git pull --date '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --depth=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4290,10 +5704,18 @@
     prefix=--depth=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --depth **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --depth '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4301,10 +5723,18 @@
     prefix=
     _fzf_complete_git 'git pull --depth '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --deepen=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4312,10 +5742,18 @@
     prefix=--deepen=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --deepen **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --deepen '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4323,10 +5761,18 @@
     prefix=
     _fzf_complete_git 'git pull --deepen '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --log=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4334,10 +5780,18 @@
     prefix=--log=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --server-option=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4345,10 +5799,18 @@
     prefix=--server-option=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --server-option **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --server-option '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4356,10 +5818,18 @@
     prefix=
     _fzf_complete_git 'git pull --server-option '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --shallow-since=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4367,10 +5837,18 @@
     prefix=--shallow-since=
     _fzf_complete_git 'git pull '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git pull --shallow-since **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --shallow-since '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4378,6 +5856,7 @@
     prefix=
     _fzf_complete_git 'git pull --shallow-since '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
@@ -4385,6 +5864,13 @@
     run git remote add origin git@github.com:chitoku-k/fzf-zsh-completions
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull '
+
+        echo 'git'
+    }
 
     _fzf_complete() {
         assert $# equals 4
@@ -4394,6 +5880,7 @@
         assert $4 same_as 'git pull '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4407,6 +5894,13 @@
 @test 'Testing completion: git pull origin **' {
     run git remote add origin ${DIR%/*}/remote.git
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4416,6 +5910,7 @@
         assert $5 same_as 'git pull origin '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color"
@@ -4433,6 +5928,13 @@
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull --cleanup strip --rebase '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4441,6 +5943,7 @@
         assert $4 same_as 'git pull --cleanup strip --rebase '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4454,6 +5957,13 @@
 @test 'Testing completion: git pull origin --cleanup strip --quiet **' {
     run git remote add origin ${DIR%/*}/remote.git
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull origin --cleanup strip --quiet '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4463,6 +5973,7 @@
         assert $5 same_as 'git pull origin --cleanup strip --quiet '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color"
@@ -4480,6 +5991,13 @@
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4488,6 +6006,7 @@
         assert $4 same_as 'git pull -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4501,6 +6020,13 @@
 @test 'Testing completion: git pull -- origin **' {
     run git remote add origin ${DIR%/*}/remote.git
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git pull -- origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4510,6 +6036,7 @@
         assert $5 same_as 'git pull -- origin '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color"
@@ -4523,6 +6050,13 @@
 }
 
 @test 'Testing completion: git push --signed=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4531,6 +6065,7 @@
         assert $4 same_as 'git push --signed='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as false
         assert ${lines[2]} same_as if-asked
@@ -4542,6 +6077,13 @@
 }
 
 @test 'Testing completion: git push --push-option=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4549,10 +6091,18 @@
     prefix=--push-option=
     _fzf_complete_git 'git push '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --push-option **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push --push-option '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4560,10 +6110,18 @@
     prefix=
     _fzf_complete_git 'git push --push-option '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push -o**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4571,10 +6129,18 @@
     prefix=-o
     _fzf_complete_git 'git push '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push -o **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push -o '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4582,10 +6148,18 @@
     prefix=
     _fzf_complete_git 'git push -o '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --exec=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4593,10 +6167,18 @@
     prefix=--exec=
     _fzf_complete_git 'git push '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --exec **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push --exec '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4604,10 +6186,18 @@
     prefix=
     _fzf_complete_git 'git push --exec '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --receive-pack=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4615,10 +6205,18 @@
     prefix=--receive-pack=
     _fzf_complete_git 'git push '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --receive-pack **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push --receive-pack '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -4626,10 +6224,18 @@
     prefix=
     _fzf_complete_git 'git push --receive-pack '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: git push --force-with-lease=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4638,6 +6244,7 @@
         assert $4 same_as 'git push --force-with-lease='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4651,6 +6258,13 @@
 }
 
 @test 'Testing completion: git push --force-with-lease=master:**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4659,6 +6273,7 @@
         assert $4 same_as 'git push --force-with-lease=master:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4676,6 +6291,13 @@
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4684,6 +6306,7 @@
         assert $4 same_as 'git push --repo='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4699,6 +6322,13 @@
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push --repo '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4707,6 +6337,7 @@
         assert $4 same_as 'git push --repo '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4718,6 +6349,13 @@
 }
 
 @test 'Testing completion: git push --recurse-submodules=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4726,6 +6364,7 @@
         assert $4 same_as 'git push --recurse-submodules='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as check
         assert ${lines[2]} same_as no
@@ -4738,6 +6377,13 @@
 }
 
 @test 'Testing completion: git push --recurse-submodules **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push --recurse-submodules '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4746,6 +6392,7 @@
         assert $4 same_as 'git push --recurse-submodules '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as check
         assert ${lines[2]} same_as no
@@ -4762,6 +6409,13 @@
     run git remote add upstream git@example.com:example/fzf-zsh-completions
     run git remote add example example
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4770,6 +6424,7 @@
         assert $4 same_as 'git push '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}example $reset_color  example (fetch)"
         assert ${lines[2]} same_as "${fg[yellow]}origin  $reset_color  git@github.com:chitoku-k/fzf-zsh-completions (fetch)"
@@ -4781,6 +6436,13 @@
 }
 
 @test 'Testing completion: git push origin **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4790,6 +6452,7 @@
         assert $5 same_as 'git push origin '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4805,6 +6468,13 @@
 @test 'Testing completion: git push origin master:**' {
     run git remote add origin ${DIR%/*}/remote.git
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git push origin '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4813,6 +6483,7 @@
         assert $4 same_as 'git push origin master:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color"
@@ -4834,6 +6505,13 @@
     run touch file_outside_tree_object
     run git add file_outside_tree_object
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git rm '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4844,6 +6522,7 @@
         assert $6 same_as 'git rm '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -4878,6 +6557,13 @@
 
     cd directory2
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git rm '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4888,6 +6574,7 @@
         assert $6 same_as 'git rm '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -4912,6 +6599,13 @@
 }
 
 @test 'Testing completion: git show **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4921,6 +6615,7 @@
         assert $5 same_as 'git show '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4934,6 +6629,13 @@
 }
 
 @test 'Testing completion: git show HEAD **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show HEAD '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4943,6 +6645,7 @@
         assert $5 same_as 'git show HEAD '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -4956,6 +6659,13 @@
 }
 
 @test 'Testing completion: git show -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4966,6 +6676,7 @@
         assert $6 same_as 'git show -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
@@ -4979,6 +6690,13 @@
 }
 
 @test 'Testing completion: git show another-branch -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show another-branch -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4989,6 +6707,7 @@
         assert $6 same_as 'git show another-branch -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -5010,6 +6729,13 @@
 }
 
 @test 'Testing completion: git show another-branch:**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5019,6 +6745,7 @@
         assert $5 same_as 'git show another-branch:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -5044,6 +6771,13 @@
 @test 'Testing completion in subdirectory: git show another-branch:**' {
     cd directory1
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5053,6 +6787,7 @@
         assert $5 same_as 'git show another-branch:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -5076,6 +6811,13 @@
 }
 
 @test 'Testing completion: git show another-branch:file1 master another-branch v1:file1 -- **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show another-branch:file1 master another-branch v1:file1 -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5086,6 +6828,7 @@
         assert $6 same_as 'git show another-branch:file1 master another-branch v1:file1 -- '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -5112,6 +6855,13 @@
     run git notes add -m 'Note1'
     run git notes --ref=note add -m 'Note2'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5120,6 +6870,7 @@
         assert $4 same_as 'git show --show-notes='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
 
         assert ${lines[1]} same_as "${fg[yellow]}notes/commits$reset_color  Notes added by 'git notes add'"
@@ -5134,6 +6885,13 @@
     run git notes add -m 'Note1'
     run git notes --ref=note add -m 'Note2'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5142,6 +6900,7 @@
         assert $4 same_as 'git show --notes='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
 
         assert ${lines[1]} same_as "${fg[yellow]}notes/commits$reset_color  Notes added by 'git notes add'"
@@ -5156,6 +6915,13 @@
     run git notes add -m 'Note1'
     run git notes --ref=note add -m 'Note2'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git "" show '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -5164,6 +6930,8 @@
         assert $# equals 2
         assert $1 same_as '--notes='
         assert $2 same_as 'git "" show '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=--notes=
@@ -5173,6 +6941,13 @@
 @test 'Testing completion (alias): git commit --squash **' {
     run git config alias.squash 'commit --squash'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git squash '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5181,6 +6956,7 @@
         assert $4 same_as 'git squash '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -5197,6 +6973,13 @@
     run git config alias.amend 'commit --amend --message'
     run git checkout another-branch
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git amend '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5205,6 +6988,7 @@
         assert $4 same_as 'git amend '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}6088ecf$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}3e209a3$reset_color  1st commit"
@@ -5217,6 +7001,13 @@
 @test 'Testing completion (alias): git commit --date **' {
     run git config alias.commit-date 'commit --date'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit-date '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -5224,11 +7015,19 @@
     prefix=
     _fzf_complete_git 'git commit-date '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion (alias): git commit --pathspec-from-file **' {
     run git config alias.commit-spec 'commit --pathspec-from-file'
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit-spec '
+
+        echo 'git'
+    }
 
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
@@ -5246,10 +7045,19 @@
 
     prefix=
     _fzf_complete_git 'git commit-spec '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion (alias): git commit --cleanup **' {
     run git config alias.commit-cleanup 'commit --cleanup'
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit-cleanup '
+
+        echo 'git'
+    }
 
     _fzf_complete() {
         assert $# equals 4
@@ -5259,6 +7067,7 @@
         assert $4 same_as 'git commit-cleanup '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as strip
         assert ${lines[2]} same_as whitespace
@@ -5275,6 +7084,13 @@
     run git checkout another-branch
     run git config alias.commit-all '"" commit -a'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit-all '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -5283,6 +7099,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'git commit-all '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -5298,6 +7116,13 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit-all '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 9
         assert $1 same_as '--ansi'
@@ -5311,6 +7136,7 @@
         assert $9 same_as 'git commit-all '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         actual1=(${(0)lines[1]})
@@ -5337,6 +7163,13 @@
     run git config alias.foo bar
     run git config alias.bar 'commit --squash'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git foo '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5345,6 +7178,7 @@
         assert $4 same_as 'git foo '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -5362,6 +7196,13 @@
     run git config alias.bar baz
     run git config alias.baz foo
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git foo '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -5370,6 +7211,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'git foo '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -5379,6 +7222,13 @@
 @test 'Testing completion (alias and expansion)' {
     run git config alias.squash 'commit --squash'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '"git"  "squash" '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -5387,6 +7237,7 @@
         assert $4 same_as '"git"  "squash" '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}another-branch$reset_color  ${fg[green]}branch$reset_color   2nd commit"
         assert ${lines[2]} same_as "${fg[yellow]}master        $reset_color  ${fg[green]}branch$reset_color  1st commit"
@@ -5406,7 +7257,16 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git checkout -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
+        assert __fzf_extract_command mock_times 1
+
         fzf_options=($@) run preview ' M  file3 containing space '
         assert $output is_not_empty
 
@@ -5431,7 +7291,16 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git commit -- '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
+        assert __fzf_extract_command mock_times 1
+
         fzf_options=($@) run preview ' M  file3 containing space '
         assert $output is_not_empty
 
@@ -5456,7 +7325,16 @@
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git add '
+
+        echo 'git'
+    }
+
     _fzf_complete() {
+        assert __fzf_extract_command mock_times 1
+
         fzf_options=($@) run preview ' M  file3 containing space '
         assert $output is_not_empty
 

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -13448,23 +13448,6 @@
     _fzf_complete_kubectl 'kubectl top pods '
 }
 
-@test 'Testing completion: kubectl "" top pods **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'kubectl "" top pods '
-    }
-
-    prefix=
-    _fzf_complete_kubectl 'kubectl "" top pods '
-
-    assert kubectl mock_times 0
-}
-
 @test 'Testing post: a resource type without API group' {
     input=(
         'podtemplates                v1           true         PodTemplate'

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -13448,6 +13448,23 @@
     _fzf_complete_kubectl 'kubectl top pods '
 }
 
+@test 'Testing completion: kubectl "" top pods **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl "" top pods '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl "" top pods '
+
+    assert kubectl mock_times 0
+}
+
 @test 'Testing post: a resource type without API group' {
     input=(
         'podtemplates                v1           true         PodTemplate'

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -5,6 +5,10 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock kubectl
+
+    __fzf_extract_command() {
+        echo 'kubectl'
+    }
 }
 
 @teardown {

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -5,13 +5,22 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock kubectl
+    mock __fzf_extract_command
 }
 
 @teardown {
-    unmock kubectl
+    (unmock kubectl)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: kubectl **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -20,6 +29,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -27,6 +38,13 @@
 }
 
 @test 'Testing completion: kubectl --namespace "" **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --namespace "" '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -35,6 +53,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl --namespace "" '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -42,6 +62,13 @@
 }
 
 @test 'Testing completion: kubectl -n "" **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl -n "" '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -50,6 +77,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl -n "" '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -70,6 +99,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -79,6 +115,7 @@
         assert $5 same_as 'kubectl --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -104,6 +141,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --namespace '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -113,6 +157,7 @@
         assert $5 same_as 'kubectl --namespace '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -138,6 +183,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl -n '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -147,6 +199,7 @@
         assert $5 same_as 'kubectl -n '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -172,6 +225,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -181,6 +241,7 @@
         assert $5 same_as 'kubectl -n'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -208,6 +269,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -218,6 +286,7 @@
         assert $6 same_as 'kubectl diff --labels='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -249,6 +318,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff --labels '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -259,6 +335,7 @@
         assert $6 same_as 'kubectl diff --labels '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -290,6 +367,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -300,6 +384,7 @@
         assert $6 same_as 'kubectl diff -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -331,6 +416,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -341,6 +433,7 @@
         assert $6 same_as 'kubectl diff -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -372,6 +465,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -382,6 +482,7 @@
         assert $6 same_as 'kubectl run --labels='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -413,6 +514,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run --labels '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -423,6 +531,7 @@
         assert $6 same_as 'kubectl run --labels '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -454,6 +563,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -464,6 +580,7 @@
         assert $6 same_as 'kubectl run -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -495,6 +612,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -505,6 +629,7 @@
         assert $6 same_as 'kubectl run -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -536,6 +661,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -546,6 +678,7 @@
         assert $6 same_as 'kubectl scale --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -577,6 +710,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -587,6 +727,7 @@
         assert $6 same_as 'kubectl scale --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -618,6 +759,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -628,6 +776,7 @@
         assert $6 same_as 'kubectl scale -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -659,6 +808,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -669,6 +825,7 @@
         assert $6 same_as 'kubectl scale -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -698,6 +855,13 @@
         echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -708,6 +872,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
@@ -733,6 +898,13 @@
         echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -743,6 +915,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
@@ -770,6 +943,13 @@
         echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -780,6 +960,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
@@ -810,6 +991,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -819,6 +1007,7 @@
         assert $5 same_as 'kubectl wait '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -854,6 +1043,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -864,6 +1060,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -897,6 +1094,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -907,6 +1111,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -938,6 +1143,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -948,6 +1160,7 @@
         assert $6 same_as 'kubectl wait pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -979,6 +1192,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -989,6 +1209,7 @@
         assert $6 same_as 'kubectl wait pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1020,6 +1241,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1030,6 +1258,7 @@
         assert $6 same_as 'kubectl wait pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1061,6 +1290,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1071,6 +1307,7 @@
         assert $6 same_as 'kubectl wait pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1104,6 +1341,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1114,6 +1358,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1149,6 +1394,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1159,6 +1411,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1193,6 +1446,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1203,6 +1463,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1238,6 +1499,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1248,6 +1516,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1282,6 +1551,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1291,6 +1567,7 @@
         assert $5 same_as 'kubectl annotate '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -1326,6 +1603,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1335,6 +1619,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1368,6 +1653,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1377,6 +1669,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1408,6 +1701,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1418,6 +1718,7 @@
         assert $6 same_as 'kubectl annotate pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1449,6 +1750,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1459,6 +1767,7 @@
         assert $6 same_as 'kubectl annotate pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1490,6 +1799,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1500,6 +1816,7 @@
         assert $6 same_as 'kubectl annotate pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1531,6 +1848,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1541,6 +1865,7 @@
         assert $6 same_as 'kubectl annotate pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1568,6 +1893,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1579,6 +1911,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1610,6 +1943,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1621,6 +1961,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1658,6 +1999,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1667,6 +2015,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1702,6 +2051,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1711,6 +2067,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1745,6 +2102,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1754,6 +2118,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1789,6 +2154,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1798,6 +2170,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1827,6 +2200,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1838,6 +2218,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1872,6 +2253,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1883,6 +2271,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1916,6 +2305,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1927,6 +2323,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1961,6 +2358,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1972,6 +2376,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1993,6 +2398,13 @@
 }
 
 @test 'Testing completion: kubectl apply --filename=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2009,9 +2421,18 @@
 
     prefix=--filename=
     _fzf_complete_kubectl 'kubectl apply '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply --filename **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply --filename '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2028,9 +2449,18 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl apply --filename '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply -f **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply -f '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2047,9 +2477,18 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl apply -f '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply -f**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -2066,6 +2505,8 @@
 
     prefix=-f
     _fzf_complete_kubectl 'kubectl apply '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply edit-last-applied **' {
@@ -2086,6 +2527,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2095,6 +2543,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2130,6 +2579,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2139,6 +2595,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2172,6 +2629,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2181,6 +2645,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2214,6 +2679,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2223,6 +2695,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2258,6 +2731,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2267,6 +2747,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2301,6 +2782,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2310,6 +2798,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2345,6 +2834,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2354,6 +2850,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2388,6 +2885,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2397,6 +2901,7 @@
         assert $5 same_as 'kubectl apply view-last-applied '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2432,6 +2937,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2442,6 +2954,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2475,6 +2988,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2485,6 +3005,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2516,6 +3037,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2526,6 +3054,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2557,6 +3086,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2567,6 +3103,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2598,6 +3135,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2608,6 +3152,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2639,6 +3184,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2649,6 +3201,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2682,6 +3235,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2692,6 +3252,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2727,6 +3288,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2737,6 +3305,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2771,6 +3340,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2781,6 +3357,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2816,6 +3393,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2826,6 +3410,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2860,6 +3445,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2869,6 +3461,7 @@
         assert $5 same_as 'kubectl autoscale '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2904,6 +3497,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2913,6 +3513,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2946,6 +3547,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2955,6 +3563,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2988,6 +3597,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2997,6 +3613,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3032,6 +3649,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3041,6 +3665,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3075,6 +3700,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3084,6 +3716,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3119,6 +3752,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3128,6 +3768,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3162,6 +3803,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3171,6 +3819,7 @@
         assert $5 same_as 'kubectl edit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -3206,6 +3855,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3215,6 +3871,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3248,6 +3905,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3257,6 +3921,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3290,6 +3955,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3299,6 +3971,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3334,6 +4007,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3343,6 +4023,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3377,6 +4058,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3386,6 +4074,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3421,6 +4110,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3430,6 +4126,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3464,6 +4161,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3473,6 +4177,7 @@
         assert $5 same_as 'kubectl expose '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -3508,6 +4213,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3517,6 +4229,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3550,6 +4263,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3559,6 +4279,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3592,6 +4313,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3601,6 +4329,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3636,6 +4365,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3645,6 +4381,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3679,6 +4416,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3688,6 +4432,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3723,6 +4468,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3732,6 +4484,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3766,6 +4519,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3775,6 +4535,7 @@
         assert $5 same_as 'kubectl patch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -3810,6 +4571,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3819,6 +4587,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3852,6 +4621,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3861,6 +4637,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3894,6 +4671,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3903,6 +4687,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3938,6 +4723,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3947,6 +4739,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3981,6 +4774,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3990,6 +4790,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4025,6 +4826,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4034,6 +4842,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4063,6 +4872,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4072,6 +4888,7 @@
         assert $5 same_as 'kubectl cordon '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -4096,6 +4913,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4106,6 +4930,7 @@
         assert $6 same_as 'kubectl cordon --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4135,6 +4960,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4145,6 +4977,7 @@
         assert $6 same_as 'kubectl cordon --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4174,6 +5007,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4184,6 +5024,7 @@
         assert $6 same_as 'kubectl cordon -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4213,6 +5054,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4223,6 +5071,7 @@
         assert $6 same_as 'kubectl cordon -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4251,6 +5100,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4260,6 +5116,7 @@
         assert $5 same_as 'kubectl drain '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -4284,6 +5141,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4294,6 +5158,7 @@
         assert $6 same_as 'kubectl drain --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4323,6 +5188,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4333,6 +5205,7 @@
         assert $6 same_as 'kubectl drain --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4362,6 +5235,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4372,6 +5252,7 @@
         assert $6 same_as 'kubectl drain -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4401,6 +5282,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4411,6 +5299,7 @@
         assert $6 same_as 'kubectl drain -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4439,6 +5328,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4448,6 +5344,7 @@
         assert $5 same_as 'kubectl uncordon '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -4472,6 +5369,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4482,6 +5386,7 @@
         assert $6 same_as 'kubectl uncordon --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4511,6 +5416,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4521,6 +5433,7 @@
         assert $6 same_as 'kubectl uncordon --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4550,6 +5463,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4560,6 +5480,7 @@
         assert $6 same_as 'kubectl uncordon -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4589,6 +5510,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4599,6 +5527,7 @@
         assert $6 same_as 'kubectl uncordon -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -4615,6 +5544,13 @@
 }
 
 @test 'Testing completion: kubectl create **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -4623,6 +5559,7 @@
         assert $4 same_as 'kubectl create '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 23
         assert ${lines[1]} same_as 'clusterrole'
@@ -4667,6 +5604,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4676,6 +5620,7 @@
         assert $5 same_as 'kubectl create job --from=cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -4699,6 +5644,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4708,6 +5660,7 @@
         assert $5 same_as 'kubectl create job --from=cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -4731,6 +5684,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job --from '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4740,6 +5700,7 @@
         assert $5 same_as 'kubectl create job --from cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -4763,6 +5724,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job --from '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4772,6 +5740,7 @@
         assert $5 same_as 'kubectl create job --from cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -4800,6 +5769,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4809,6 +5785,7 @@
         assert $5 same_as 'kubectl delete '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -4844,6 +5821,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4854,6 +5838,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4887,6 +5872,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4897,6 +5889,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4928,6 +5921,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4938,6 +5938,7 @@
         assert $6 same_as 'kubectl delete pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4969,6 +5970,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4979,6 +5987,7 @@
         assert $6 same_as 'kubectl delete pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5010,6 +6019,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5020,6 +6036,7 @@
         assert $6 same_as 'kubectl delete pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5051,6 +6068,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5061,6 +6085,7 @@
         assert $6 same_as 'kubectl delete pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5094,6 +6119,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5104,6 +6136,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5139,6 +6172,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5149,6 +6189,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5183,6 +6224,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5193,6 +6241,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5228,6 +6277,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5238,6 +6294,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5272,6 +6329,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5281,6 +6345,7 @@
         assert $5 same_as 'kubectl describe '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -5316,6 +6381,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5326,6 +6398,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5359,6 +6432,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5369,6 +6449,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5400,6 +6481,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5410,6 +6498,7 @@
         assert $6 same_as 'kubectl describe pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5441,6 +6530,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5451,6 +6547,7 @@
         assert $6 same_as 'kubectl describe pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5482,6 +6579,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5492,6 +6596,7 @@
         assert $6 same_as 'kubectl describe pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5523,6 +6628,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5533,6 +6645,7 @@
         assert $6 same_as 'kubectl describe pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5566,6 +6679,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5576,6 +6696,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5611,6 +6732,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5621,6 +6749,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5655,6 +6784,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5665,6 +6801,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5700,6 +6837,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5710,6 +6854,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5744,6 +6889,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5753,6 +6905,7 @@
         assert $5 same_as 'kubectl get '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -5788,6 +6941,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5798,6 +6958,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5831,6 +6992,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5841,6 +7009,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -5872,6 +7041,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5882,6 +7058,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5913,6 +7090,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5923,6 +7107,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5956,6 +7141,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5966,6 +7158,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5996,6 +7189,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector=tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6005,6 +7205,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -6032,6 +7233,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6042,6 +7250,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6072,6 +7281,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6082,6 +7298,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6112,6 +7329,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6122,6 +7346,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6149,6 +7374,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6159,6 +7391,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6186,6 +7419,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6195,6 +7435,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6224,6 +7465,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6233,6 +7481,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6262,6 +7511,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6271,6 +7527,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6300,6 +7557,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6309,6 +7573,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6338,6 +7603,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6347,6 +7619,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6376,6 +7649,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6385,6 +7665,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6414,6 +7695,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6424,6 +7712,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6455,6 +7744,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6465,6 +7761,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6498,6 +7795,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6508,6 +7812,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6538,6 +7843,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6547,6 +7859,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -6574,6 +7887,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6584,6 +7904,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6614,6 +7935,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6624,6 +7952,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6654,6 +7983,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6664,6 +8000,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6691,6 +8028,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6701,6 +8045,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6728,6 +8073,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6737,6 +8089,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6766,6 +8119,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6775,6 +8135,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6804,6 +8165,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6813,6 +8181,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6842,6 +8211,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6851,6 +8227,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6880,6 +8257,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6889,6 +8273,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6918,6 +8303,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6927,6 +8319,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6956,6 +8349,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6966,6 +8366,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6997,6 +8398,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7007,6 +8415,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7040,6 +8449,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7050,6 +8466,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7080,6 +8497,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7089,6 +8513,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -7116,6 +8541,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7126,6 +8558,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7156,6 +8589,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7166,6 +8606,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7196,6 +8637,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7206,6 +8654,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7233,6 +8682,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7243,6 +8699,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7270,6 +8727,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7279,6 +8743,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7308,6 +8773,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7317,6 +8789,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7346,6 +8819,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7355,6 +8835,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7384,6 +8865,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7393,6 +8881,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7422,6 +8911,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7431,6 +8927,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7460,6 +8957,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7469,6 +8973,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7498,6 +9003,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7508,6 +9020,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7539,6 +9052,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7549,6 +9069,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7582,6 +9103,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7592,6 +9120,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7622,6 +9151,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -ltier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7631,6 +9167,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -7658,6 +9195,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7668,6 +9212,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7698,6 +9243,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7708,6 +9260,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7738,6 +9291,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7748,6 +9308,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7775,6 +9336,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7785,6 +9353,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7812,6 +9381,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7821,6 +9397,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7850,6 +9427,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7859,6 +9443,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7888,6 +9473,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7897,6 +9489,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7926,6 +9519,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7935,6 +9535,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -7964,6 +9565,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7973,6 +9581,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8002,6 +9611,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8011,6 +9627,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8043,6 +9660,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>            kube-scheduler'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8053,6 +9677,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
@@ -8089,6 +9714,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>            kube-scheduler'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8099,6 +9731,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
@@ -8131,6 +9764,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8141,6 +9781,7 @@
         assert $6 same_as 'kubectl get pods --label-columns='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8169,6 +9810,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8179,6 +9827,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8206,6 +9855,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8216,6 +9872,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8243,6 +9900,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8253,6 +9917,7 @@
         assert $6 same_as 'kubectl get pods --label-columns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8281,6 +9946,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8291,6 +9963,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8318,6 +9991,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8328,6 +10008,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8355,6 +10036,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8365,6 +10053,7 @@
         assert $6 same_as 'kubectl get pods -L '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8393,6 +10082,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8403,6 +10099,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8430,6 +10127,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8440,6 +10144,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8467,6 +10172,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8477,6 +10189,7 @@
         assert $6 same_as 'kubectl get pods -L'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8505,6 +10218,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8515,6 +10235,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8542,6 +10263,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8552,6 +10280,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -8581,6 +10310,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8591,6 +10327,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8626,6 +10363,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8636,6 +10380,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8670,6 +10415,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8680,6 +10432,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8715,6 +10468,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8725,6 +10485,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8759,6 +10520,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8768,6 +10536,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8801,6 +10570,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8810,6 +10586,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8848,6 +10625,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8857,6 +10641,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8891,6 +10676,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8900,6 +10692,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8934,6 +10727,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8943,6 +10743,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8977,6 +10778,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8986,6 +10794,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9020,6 +10829,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9029,6 +10845,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9063,6 +10880,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9072,6 +10896,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9106,6 +10931,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9115,6 +10947,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9149,6 +10982,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9158,6 +10998,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9186,6 +11027,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9195,6 +11043,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9228,6 +11077,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9237,6 +11093,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9269,6 +11126,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9278,6 +11142,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9311,6 +11176,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9320,6 +11192,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9360,6 +11233,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9369,6 +11249,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9408,6 +11289,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9417,6 +11305,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9454,6 +11343,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9463,6 +11359,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9502,6 +11399,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9511,6 +11415,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9548,6 +11453,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9557,6 +11469,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9596,6 +11509,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9605,6 +11525,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9642,6 +11563,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9651,6 +11579,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9690,6 +11619,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9699,6 +11635,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9736,6 +11673,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9745,6 +11689,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9784,6 +11729,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9793,6 +11745,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9830,6 +11783,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9839,6 +11799,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9878,6 +11839,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9887,6 +11855,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9924,6 +11893,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9933,6 +11909,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9972,6 +11949,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9981,6 +11965,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -10018,6 +12003,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10027,6 +12019,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -10066,6 +12059,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10075,6 +12075,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -10105,6 +12106,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl explain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10114,6 +12122,7 @@
         assert $5 same_as 'kubectl explain '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -10149,6 +12158,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10158,6 +12174,7 @@
         assert $5 same_as 'kubectl label '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -10193,6 +12210,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10202,6 +12226,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10235,6 +12260,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10244,6 +12276,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10275,6 +12308,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10285,6 +12325,7 @@
         assert $6 same_as 'kubectl label pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10316,6 +12357,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10326,6 +12374,7 @@
         assert $6 same_as 'kubectl label pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10357,6 +12406,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10367,6 +12423,7 @@
         assert $6 same_as 'kubectl label pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10398,6 +12455,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10408,6 +12472,7 @@
         assert $6 same_as 'kubectl label pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10435,6 +12500,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10445,6 +12517,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10468,6 +12541,13 @@
         echo '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10478,6 +12558,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10507,6 +12588,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10516,6 +12604,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10551,6 +12640,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10560,6 +12656,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10594,6 +12691,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10603,6 +12707,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10638,6 +12743,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10647,6 +12759,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10676,6 +12789,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10686,6 +12806,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10712,6 +12833,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10722,6 +12850,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10747,6 +12876,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10757,6 +12893,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10783,6 +12920,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10793,6 +12937,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10823,6 +12968,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10832,6 +12984,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10865,6 +13018,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs -f '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10874,6 +13034,7 @@
         assert $5 same_as 'kubectl logs -f '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10907,6 +13068,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10916,6 +13084,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10947,6 +13116,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10957,6 +13133,7 @@
         assert $6 same_as 'kubectl logs pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -10988,6 +13165,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10998,6 +13182,7 @@
         assert $6 same_as 'kubectl logs pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11029,6 +13214,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11039,6 +13231,7 @@
         assert $6 same_as 'kubectl logs pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11070,6 +13263,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11080,6 +13280,7 @@
         assert $6 same_as 'kubectl logs pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11118,6 +13319,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11127,6 +13335,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11161,6 +13370,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11170,6 +13386,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11204,6 +13421,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11213,6 +13437,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11247,6 +13472,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11256,6 +13488,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11290,6 +13523,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11299,6 +13539,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11333,6 +13574,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11342,6 +13590,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11376,6 +13625,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11385,6 +13641,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11419,6 +13676,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11428,6 +13692,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11456,6 +13721,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11465,6 +13737,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11498,6 +13771,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11507,6 +13787,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11539,6 +13820,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11548,6 +13836,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11581,6 +13870,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11590,6 +13886,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11630,6 +13927,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11639,6 +13943,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11678,6 +13983,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11687,6 +13999,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11724,6 +14037,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11733,6 +14053,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11772,6 +14093,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11781,6 +14109,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11818,6 +14147,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11827,6 +14163,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11866,6 +14203,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11875,6 +14219,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11912,6 +14257,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11921,6 +14273,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11960,6 +14313,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11969,6 +14329,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12006,6 +14367,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12015,6 +14383,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12054,6 +14423,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12063,6 +14439,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12100,6 +14477,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12109,6 +14493,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12148,6 +14533,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12157,6 +14549,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12194,6 +14587,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12203,6 +14603,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12242,6 +14643,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12251,6 +14659,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12288,6 +14697,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12297,6 +14713,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12336,6 +14753,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12345,6 +14769,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -12372,6 +14797,13 @@
         echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12381,6 +14813,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12408,6 +14841,13 @@
         echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12417,6 +14857,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12443,6 +14884,13 @@
         echo 'kube-system   kube-dns     ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12452,6 +14900,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME         ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
@@ -12478,6 +14927,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12488,6 +14944,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12515,6 +14972,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12525,6 +14989,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12552,6 +15017,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12562,6 +15034,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12589,6 +15062,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12599,6 +15079,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12626,6 +15107,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12636,6 +15124,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12663,6 +15152,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12673,6 +15169,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12699,6 +15196,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12708,6 +15212,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12735,6 +15240,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12744,6 +15256,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12770,6 +15283,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12779,6 +15299,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12806,6 +15327,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12815,6 +15343,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12840,6 +15369,13 @@
         echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12849,6 +15385,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
@@ -12874,6 +15411,13 @@
         echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12883,6 +15427,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
@@ -12910,6 +15455,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12920,6 +15472,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12950,6 +15503,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12960,6 +15520,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -12989,6 +15550,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12999,6 +15567,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13029,6 +15598,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13039,6 +15615,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13068,6 +15645,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13078,6 +15662,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13108,6 +15693,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13118,6 +15710,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13147,6 +15740,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13157,6 +15757,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13187,6 +15788,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13197,6 +15805,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13226,6 +15835,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13236,6 +15852,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13266,6 +15883,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13276,6 +15900,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13305,6 +15930,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13315,6 +15947,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13345,6 +15978,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13355,6 +15995,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -13369,6 +16010,13 @@
 }
 
 @test 'Testing completion: kubectl rollout **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -13377,6 +16025,7 @@
         assert $4 same_as 'kubectl rollout '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as history
@@ -13409,6 +16058,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13418,6 +16074,7 @@
         assert $5 same_as 'kubectl rollout restart '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -13453,6 +16110,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart deployments '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13463,6 +16127,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13496,6 +16161,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13506,6 +16178,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13539,6 +16212,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart deployments '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13549,6 +16229,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13584,6 +16265,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart deployments '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13594,6 +16282,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13628,6 +16317,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13638,6 +16334,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13673,6 +16370,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13683,6 +16387,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13700,6 +16405,13 @@
 }
 
 @test 'Testing completion: kubectl set **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -13708,6 +16420,7 @@
         assert $4 same_as 'kubectl set '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as env
@@ -13740,6 +16453,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13749,6 +16469,7 @@
         assert $5 same_as 'kubectl set env '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -13784,6 +16505,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13793,6 +16521,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13826,6 +16555,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13835,6 +16571,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13866,6 +16603,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13876,6 +16620,7 @@
         assert $6 same_as 'kubectl set env pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13907,6 +16652,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13917,6 +16669,7 @@
         assert $6 same_as 'kubectl set env pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13948,6 +16701,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13958,6 +16718,7 @@
         assert $6 same_as 'kubectl set env pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13989,6 +16750,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13999,6 +16767,7 @@
         assert $6 same_as 'kubectl set env pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -14032,6 +16801,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14041,6 +16817,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14076,6 +16853,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14085,6 +16869,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14119,6 +16904,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14128,6 +16920,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14163,6 +16956,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14172,6 +16972,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14206,6 +17007,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14215,6 +17023,7 @@
         assert $5 same_as 'kubectl set image '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -14250,6 +17059,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14259,6 +17075,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14292,6 +17109,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14301,6 +17125,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14332,6 +17157,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14342,6 +17174,7 @@
         assert $6 same_as 'kubectl set image pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -14373,6 +17206,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14383,6 +17223,7 @@
         assert $6 same_as 'kubectl set image pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -14414,6 +17255,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14424,6 +17272,7 @@
         assert $6 same_as 'kubectl set image pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -14455,6 +17304,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14465,6 +17321,7 @@
         assert $6 same_as 'kubectl set image pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -14503,6 +17360,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14513,6 +17377,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14547,6 +17412,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14557,6 +17429,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14586,6 +17459,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14595,6 +17475,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14630,6 +17511,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14639,6 +17527,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14673,6 +17562,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14682,6 +17578,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14717,6 +17614,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14726,6 +17630,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -14767,6 +17672,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14777,6 +17689,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14816,6 +17729,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14826,6 +17746,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14863,6 +17784,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14873,6 +17801,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14912,6 +17841,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -14922,6 +17858,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -14953,6 +17890,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -14962,6 +17906,7 @@
         assert $5 same_as 'kubectl set resources '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -14997,6 +17942,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15006,6 +17958,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15039,6 +17992,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15048,6 +18008,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15079,6 +18040,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15089,6 +18057,7 @@
         assert $6 same_as 'kubectl set resources pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15120,6 +18089,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15130,6 +18106,7 @@
         assert $6 same_as 'kubectl set resources pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15161,6 +18138,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15171,6 +18155,7 @@
         assert $6 same_as 'kubectl set resources pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15202,6 +18187,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15212,6 +18204,7 @@
         assert $6 same_as 'kubectl set resources pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15245,6 +18238,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15254,6 +18254,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15289,6 +18290,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15298,6 +18306,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15332,6 +18341,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15341,6 +18357,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15376,6 +18393,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15385,6 +18409,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15419,6 +18444,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15428,6 +18460,7 @@
         assert $5 same_as 'kubectl set subject '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -15463,6 +18496,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15472,6 +18512,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15505,6 +18546,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15514,6 +18562,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15545,6 +18594,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15555,6 +18611,7 @@
         assert $6 same_as 'kubectl set subject pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15586,6 +18643,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15596,6 +18660,7 @@
         assert $6 same_as 'kubectl set subject pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15627,6 +18692,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15637,6 +18709,7 @@
         assert $6 same_as 'kubectl set subject pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15668,6 +18741,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15678,6 +18758,7 @@
         assert $6 same_as 'kubectl set subject pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -15711,6 +18792,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15720,6 +18808,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15755,6 +18844,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15764,6 +18860,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15798,6 +18895,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15807,6 +18911,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15842,6 +18947,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -15851,6 +18963,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -15868,6 +18981,13 @@
 }
 
 @test 'Testing completion: kubectl taint **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -15876,6 +18996,7 @@
         assert $4 same_as 'kubectl taint '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 1
         assert ${lines[1]} same_as nodes
@@ -15899,6 +19020,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15909,6 +19037,7 @@
         assert $6 same_as 'kubectl taint --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -15938,6 +19067,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15948,6 +19084,7 @@
         assert $6 same_as 'kubectl taint --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -15977,6 +19114,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -15987,6 +19131,7 @@
         assert $6 same_as 'kubectl taint -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16016,6 +19161,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16026,6 +19178,7 @@
         assert $6 same_as 'kubectl taint -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16054,6 +19207,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -16063,6 +19223,7 @@
         assert $5 same_as 'kubectl taint nodes '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -16087,6 +19248,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16097,6 +19265,7 @@
         assert $6 same_as 'kubectl taint nodes --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16126,6 +19295,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16136,6 +19312,7 @@
         assert $6 same_as 'kubectl taint nodes --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16165,6 +19342,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16175,6 +19359,7 @@
         assert $6 same_as 'kubectl taint nodes -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16204,6 +19389,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16214,6 +19406,7 @@
         assert $6 same_as 'kubectl taint nodes -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16242,6 +19435,13 @@
         echo 'key2 value2 NoExecute'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16252,6 +19452,7 @@
         assert $6 same_as 'kubectl taint nodes minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY ${reset_color}  ${reset_color}VALUE ${reset_color}  EFFECT"
@@ -16264,6 +19465,13 @@
 }
 
 @test 'Testing completion: kubectl top **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -16272,6 +19480,7 @@
         assert $4 same_as 'kubectl top '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 2
         assert ${lines[1]} same_as nodes
@@ -16295,6 +19504,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -16304,6 +19520,7 @@
         assert $5 same_as 'kubectl top nodes '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -16328,6 +19545,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16338,6 +19562,7 @@
         assert $6 same_as 'kubectl top nodes --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16367,6 +19592,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16377,6 +19609,7 @@
         assert $6 same_as 'kubectl top nodes --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16406,6 +19639,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16416,6 +19656,7 @@
         assert $6 same_as 'kubectl top nodes -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16445,6 +19686,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16455,6 +19703,7 @@
         assert $6 same_as 'kubectl top nodes -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -16488,6 +19737,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -16497,6 +19753,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -16528,6 +19785,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16538,6 +19802,7 @@
         assert $6 same_as 'kubectl top pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -16569,6 +19834,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16579,6 +19851,7 @@
         assert $6 same_as 'kubectl top pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -16610,6 +19883,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16620,6 +19900,7 @@
         assert $6 same_as 'kubectl top pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -16651,6 +19932,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -16661,6 +19949,7 @@
         assert $6 same_as 'kubectl top pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -16694,6 +19983,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -16703,6 +19999,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -16738,6 +20035,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -16747,6 +20051,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -16764,6 +20069,13 @@
 }
 
 @test 'Testing completion: kubectl "" top pods **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl "" top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -16772,6 +20084,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl "" top pods '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -5,17 +5,22 @@
     load _helpers/mock.zsh
     load _helpers/assertions.zsh
     mock kubectl
-
-    __fzf_extract_command() {
-        echo 'kubectl'
-    }
+    mock __fzf_extract_command
 }
 
 @teardown {
-    unmock kubectl
+    (unmock kubectl)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: kubectl **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -24,6 +29,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -31,6 +38,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 kubectl **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -39,6 +53,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'TEST1=value1 TEST2=value2 kubectl '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -59,6 +75,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -68,6 +91,7 @@
         assert $5 same_as 'kubectl --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -93,6 +117,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --namespace '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -102,6 +133,7 @@
         assert $5 same_as 'kubectl --namespace '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -127,6 +159,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl -n '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -136,6 +175,7 @@
         assert $5 same_as 'kubectl -n '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -161,6 +201,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -170,6 +217,7 @@
         assert $5 same_as 'kubectl -n'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -197,6 +245,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -207,6 +262,7 @@
         assert $6 same_as 'kubectl diff --labels='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -238,6 +294,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff --labels '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -248,6 +311,7 @@
         assert $6 same_as 'kubectl diff --labels '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -279,6 +343,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -289,6 +360,7 @@
         assert $6 same_as 'kubectl diff -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -320,6 +392,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl diff '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -330,6 +409,7 @@
         assert $6 same_as 'kubectl diff -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -361,6 +441,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -371,6 +458,7 @@
         assert $6 same_as 'kubectl run --labels='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -402,6 +490,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run --labels '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -412,6 +507,7 @@
         assert $6 same_as 'kubectl run --labels '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -443,6 +539,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -453,6 +556,7 @@
         assert $6 same_as 'kubectl run -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -484,6 +588,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl run '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -494,6 +605,7 @@
         assert $6 same_as 'kubectl run -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -525,6 +637,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -535,6 +654,7 @@
         assert $6 same_as 'kubectl scale --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -566,6 +686,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -576,6 +703,7 @@
         assert $6 same_as 'kubectl scale --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -607,6 +735,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -617,6 +752,7 @@
         assert $6 same_as 'kubectl scale -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -648,6 +784,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -658,6 +801,7 @@
         assert $6 same_as 'kubectl scale -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -687,6 +831,13 @@
         echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -697,6 +848,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
@@ -722,6 +874,13 @@
         echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl scale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -732,6 +891,7 @@
         assert $6 same_as 'kubectl scale daemonsets/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
@@ -762,6 +922,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -771,6 +938,7 @@
         assert $5 same_as 'kubectl wait '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -806,6 +974,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -816,6 +991,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -849,6 +1025,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -859,6 +1042,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -890,6 +1074,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -900,6 +1091,7 @@
         assert $6 same_as 'kubectl wait pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -931,6 +1123,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -941,6 +1140,7 @@
         assert $6 same_as 'kubectl wait pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -972,6 +1172,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -982,6 +1189,7 @@
         assert $6 same_as 'kubectl wait pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1013,6 +1221,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1023,6 +1238,7 @@
         assert $6 same_as 'kubectl wait pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1056,6 +1272,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1066,6 +1289,7 @@
         assert $6 same_as 'kubectl wait pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1100,6 +1324,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl wait '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1110,6 +1341,7 @@
         assert $6 same_as 'kubectl wait pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1144,6 +1376,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1153,6 +1392,7 @@
         assert $5 same_as 'kubectl annotate '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -1188,6 +1428,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1197,6 +1444,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1230,6 +1478,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1239,6 +1494,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1270,6 +1526,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1280,6 +1543,7 @@
         assert $6 same_as 'kubectl annotate pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1311,6 +1575,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1321,6 +1592,7 @@
         assert $6 same_as 'kubectl annotate pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1352,6 +1624,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1362,6 +1641,7 @@
         assert $6 same_as 'kubectl annotate pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1393,6 +1673,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -1403,6 +1690,7 @@
         assert $6 same_as 'kubectl annotate pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -1430,6 +1718,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1441,6 +1736,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1472,6 +1768,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1483,6 +1786,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1520,6 +1824,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1529,6 +1840,7 @@
         assert $5 same_as 'kubectl annotate pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1563,6 +1875,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1572,6 +1891,7 @@
         assert $5 same_as 'kubectl annotate pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1601,6 +1921,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1612,6 +1939,7 @@
         assert $7 same_as 'kubectl annotate pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1645,6 +1973,13 @@
         echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl annotate pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -1656,6 +1991,7 @@
         assert $7 same_as 'kubectl annotate pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
 
@@ -1677,6 +2013,13 @@
 }
 
 @test 'Testing completion: kubectl apply --filename=**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1693,9 +2036,18 @@
 
     prefix=--filename=
     _fzf_complete_kubectl 'kubectl apply '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply --filename **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply --filename '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1712,9 +2064,18 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl apply --filename '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply -f **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply -f '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1731,9 +2092,18 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl apply -f '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply -f**' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -1750,6 +2120,8 @@
 
     prefix=-f
     _fzf_complete_kubectl 'kubectl apply '
+
+    assert __fzf_extract_command mock_times 1
 }
 
 @test 'Testing completion: kubectl apply edit-last-applied **' {
@@ -1770,6 +2142,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1779,6 +2158,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -1814,6 +2194,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1823,6 +2210,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1856,6 +2244,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1865,6 +2260,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1898,6 +2294,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1907,6 +2310,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1941,6 +2345,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply edit-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1950,6 +2361,7 @@
         assert $5 same_as 'kubectl apply edit-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -1984,6 +2396,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -1993,6 +2412,7 @@
         assert $5 same_as 'kubectl apply view-last-applied '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2028,6 +2448,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2038,6 +2465,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2071,6 +2499,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2081,6 +2516,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2112,6 +2548,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2122,6 +2565,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2153,6 +2597,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2163,6 +2614,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2194,6 +2646,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2204,6 +2663,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2235,6 +2695,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2245,6 +2712,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -2278,6 +2746,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2288,6 +2763,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2322,6 +2798,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl apply view-last-applied '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -2332,6 +2815,7 @@
         assert $6 same_as 'kubectl apply view-last-applied pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2366,6 +2850,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2375,6 +2866,7 @@
         assert $5 same_as 'kubectl autoscale '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2410,6 +2902,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2419,6 +2918,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2452,6 +2952,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2461,6 +2968,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2494,6 +3002,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2503,6 +3018,7 @@
         assert $5 same_as 'kubectl autoscale pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2537,6 +3053,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl autoscale '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2546,6 +3069,7 @@
         assert $5 same_as 'kubectl autoscale pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2580,6 +3104,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2589,6 +3120,7 @@
         assert $5 same_as 'kubectl edit '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2624,6 +3156,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2633,6 +3172,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2666,6 +3206,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2675,6 +3222,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2708,6 +3256,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2717,6 +3272,7 @@
         assert $5 same_as 'kubectl edit pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2751,6 +3307,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl edit '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2760,6 +3323,7 @@
         assert $5 same_as 'kubectl edit pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2794,6 +3358,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2803,6 +3374,7 @@
         assert $5 same_as 'kubectl expose '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -2838,6 +3410,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2847,6 +3426,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2880,6 +3460,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2889,6 +3476,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2922,6 +3510,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2931,6 +3526,7 @@
         assert $5 same_as 'kubectl expose pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -2965,6 +3561,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl expose '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -2974,6 +3577,7 @@
         assert $5 same_as 'kubectl expose pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3008,6 +3612,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3017,6 +3628,7 @@
         assert $5 same_as 'kubectl patch '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -3052,6 +3664,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3061,6 +3680,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3094,6 +3714,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3103,6 +3730,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3136,6 +3764,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3145,6 +3780,7 @@
         assert $5 same_as 'kubectl patch pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3179,6 +3815,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl patch '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3188,6 +3831,7 @@
         assert $5 same_as 'kubectl patch pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -3217,6 +3861,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3226,6 +3877,7 @@
         assert $5 same_as 'kubectl cordon '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -3250,6 +3902,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3260,6 +3919,7 @@
         assert $6 same_as 'kubectl cordon --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3289,6 +3949,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3299,6 +3966,7 @@
         assert $6 same_as 'kubectl cordon --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3328,6 +3996,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3338,6 +4013,7 @@
         assert $6 same_as 'kubectl cordon -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3367,6 +4043,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl cordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3377,6 +4060,7 @@
         assert $6 same_as 'kubectl cordon -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3405,6 +4089,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3414,6 +4105,7 @@
         assert $5 same_as 'kubectl drain '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -3438,6 +4130,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3448,6 +4147,7 @@
         assert $6 same_as 'kubectl drain --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3477,6 +4177,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3487,6 +4194,7 @@
         assert $6 same_as 'kubectl drain --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3516,6 +4224,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3526,6 +4241,7 @@
         assert $6 same_as 'kubectl drain -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3555,6 +4271,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl drain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3565,6 +4288,7 @@
         assert $6 same_as 'kubectl drain -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3593,6 +4317,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3602,6 +4333,7 @@
         assert $5 same_as 'kubectl uncordon '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -3626,6 +4358,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3636,6 +4375,7 @@
         assert $6 same_as 'kubectl uncordon --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3665,6 +4405,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3675,6 +4422,7 @@
         assert $6 same_as 'kubectl uncordon --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3704,6 +4452,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3714,6 +4469,7 @@
         assert $6 same_as 'kubectl uncordon -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3743,6 +4499,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl uncordon '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -3753,6 +4516,7 @@
         assert $6 same_as 'kubectl uncordon -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -3769,6 +4533,13 @@
 }
 
 @test 'Testing completion: kubectl create **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -3777,6 +4548,7 @@
         assert $4 same_as 'kubectl create '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 23
         assert ${lines[1]} same_as 'clusterrole'
@@ -3821,6 +4593,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3830,6 +4609,7 @@
         assert $5 same_as 'kubectl create job --from=cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -3853,6 +4633,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3862,6 +4649,7 @@
         assert $5 same_as 'kubectl create job --from=cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -3885,6 +4673,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job --from '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3894,6 +4689,7 @@
         assert $5 same_as 'kubectl create job --from cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -3917,6 +4713,13 @@
         echo 'kube-system   descheduler-cronjob   */2 * * * *   False     0        90s             1d    descheduler   k8s.gcr.io/descheduler/descheduler:v0.20.0   <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl create job --from '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3926,6 +4729,7 @@
         assert $5 same_as 'kubectl create job --from cronjob/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                  ${reset_color}SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE   CONTAINERS    IMAGES                                       SELECTOR"
@@ -3954,6 +4758,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -3963,6 +4774,7 @@
         assert $5 same_as 'kubectl delete '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -3998,6 +4810,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4008,6 +4827,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4041,6 +4861,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4051,6 +4878,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4082,6 +4910,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4092,6 +4927,7 @@
         assert $6 same_as 'kubectl delete pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4123,6 +4959,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4133,6 +4976,7 @@
         assert $6 same_as 'kubectl delete pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4164,6 +5008,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4174,6 +5025,7 @@
         assert $6 same_as 'kubectl delete pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4205,6 +5057,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4215,6 +5074,7 @@
         assert $6 same_as 'kubectl delete pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4248,6 +5108,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4258,6 +5125,7 @@
         assert $6 same_as 'kubectl delete pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4292,6 +5160,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl delete '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4302,6 +5177,7 @@
         assert $6 same_as 'kubectl delete pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4336,6 +5212,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4345,6 +5228,7 @@
         assert $5 same_as 'kubectl describe '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -4380,6 +5264,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4390,6 +5281,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4423,6 +5315,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4433,6 +5332,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4464,6 +5364,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4474,6 +5381,7 @@
         assert $6 same_as 'kubectl describe pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4505,6 +5413,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4515,6 +5430,7 @@
         assert $6 same_as 'kubectl describe pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4546,6 +5462,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4556,6 +5479,7 @@
         assert $6 same_as 'kubectl describe pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4587,6 +5511,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4597,6 +5528,7 @@
         assert $6 same_as 'kubectl describe pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4630,6 +5562,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4640,6 +5579,7 @@
         assert $6 same_as 'kubectl describe pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4674,6 +5614,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl describe '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4684,6 +5631,7 @@
         assert $6 same_as 'kubectl describe pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4718,6 +5666,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4727,6 +5682,7 @@
         assert $5 same_as 'kubectl get '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -4762,6 +5718,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4772,6 +5735,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4805,6 +5769,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4815,6 +5786,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -4846,6 +5818,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4856,6 +5835,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4887,6 +5867,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4897,6 +5884,7 @@
         assert $6 same_as 'kubectl get pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -4927,6 +5915,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector=tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -4936,6 +5931,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -4963,6 +5959,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -4973,6 +5976,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5003,6 +6007,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5013,6 +6024,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5043,6 +6055,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5053,6 +6072,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -5080,6 +6100,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5090,6 +6117,7 @@
         assert $6 same_as 'kubectl get pods --selector=tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -5117,6 +6145,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5126,6 +6161,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5155,6 +6191,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5164,6 +6207,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5193,6 +6237,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5202,6 +6253,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5231,6 +6283,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5240,6 +6299,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5269,6 +6329,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5278,6 +6345,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5307,6 +6375,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5316,6 +6391,7 @@
         assert $5 same_as 'kubectl get pods --selector=tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5345,6 +6421,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5355,6 +6438,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5386,6 +6470,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5396,6 +6487,7 @@
         assert $6 same_as 'kubectl get pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5426,6 +6518,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5435,6 +6534,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -5462,6 +6562,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5472,6 +6579,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5502,6 +6610,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5512,6 +6627,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5542,6 +6658,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5552,6 +6675,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -5579,6 +6703,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5589,6 +6720,7 @@
         assert $6 same_as 'kubectl get pods --selector tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -5616,6 +6748,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5625,6 +6764,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5654,6 +6794,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5663,6 +6810,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5692,6 +6840,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5701,6 +6856,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5730,6 +6886,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5739,6 +6902,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5768,6 +6932,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5777,6 +6948,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5806,6 +6978,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5815,6 +6994,7 @@
         assert $5 same_as 'kubectl get pods --selector tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5844,6 +7024,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5854,6 +7041,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5885,6 +7073,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5895,6 +7090,7 @@
         assert $6 same_as 'kubectl get pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -5925,6 +7121,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l tier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -5934,6 +7137,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -5961,6 +7165,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -5971,6 +7182,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6001,6 +7213,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6011,6 +7230,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6041,6 +7261,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6051,6 +7278,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6078,6 +7306,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6088,6 +7323,7 @@
         assert $6 same_as 'kubectl get pods -l tier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6115,6 +7351,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6124,6 +7367,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6153,6 +7397,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6162,6 +7413,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6191,6 +7443,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6200,6 +7459,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6229,6 +7489,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6238,6 +7505,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6267,6 +7535,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6276,6 +7551,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6305,6 +7581,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6314,6 +7597,7 @@
         assert $5 same_as 'kubectl get pods -l tier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6343,6 +7627,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6353,6 +7644,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6384,6 +7676,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6394,6 +7693,7 @@
         assert $6 same_as 'kubectl get pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6424,6 +7724,13 @@
         echo 'kube-system   Active   1d'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -ltier=control-plane '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6433,6 +7740,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane --namespace='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
@@ -6460,6 +7768,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6470,6 +7785,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6500,6 +7816,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6510,6 +7833,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6540,6 +7864,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6550,6 +7881,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6577,6 +7909,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6587,6 +7926,7 @@
         assert $6 same_as 'kubectl get pods -ltier=control-plane,\!'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6614,6 +7954,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6623,6 +7970,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6652,6 +8000,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6661,6 +8016,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6690,6 +8046,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6699,6 +8062,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6728,6 +8092,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6737,6 +8108,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component=='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6766,6 +8138,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6775,6 +8154,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6804,6 +8184,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -6813,6 +8200,7 @@
         assert $5 same_as 'kubectl get pods -ltier=control-plane,component!='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -6845,6 +8233,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>            kube-scheduler'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6855,6 +8250,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
@@ -6891,6 +8287,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>            kube-scheduler'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6901,6 +8304,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES   COMPONENT                 K8S-APP"
@@ -6933,6 +8337,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6943,6 +8354,7 @@
         assert $6 same_as 'kubectl get pods --label-columns='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -6971,6 +8383,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -6981,6 +8400,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7008,6 +8428,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7018,6 +8445,7 @@
         assert $6 same_as 'kubectl get pods --label-columns=tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7045,6 +8473,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7055,6 +8490,7 @@
         assert $6 same_as 'kubectl get pods --label-columns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7083,6 +8519,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7093,6 +8536,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7120,6 +8564,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods --label-columns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7130,6 +8581,7 @@
         assert $6 same_as 'kubectl get pods --label-columns tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7157,6 +8609,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7167,6 +8626,7 @@
         assert $6 same_as 'kubectl get pods -L '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7195,6 +8655,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7205,6 +8672,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7232,6 +8700,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods -L '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7242,6 +8717,7 @@
         assert $6 same_as 'kubectl get pods -L tier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7269,6 +8745,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7279,6 +8762,7 @@
         assert $6 same_as 'kubectl get pods -L'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7307,6 +8791,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7317,6 +8808,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7344,6 +8836,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7354,6 +8853,7 @@
         assert $6 same_as 'kubectl get pods -Ltier,'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUES"
@@ -7383,6 +8883,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7393,6 +8900,7 @@
         assert $6 same_as 'kubectl get pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7427,6 +8935,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -7437,6 +8952,7 @@
         assert $6 same_as 'kubectl get pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7471,6 +8987,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7480,6 +9003,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7513,6 +9037,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7522,6 +9053,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7560,6 +9092,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7569,6 +9108,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7603,6 +9143,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7612,6 +9159,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7646,6 +9194,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7655,6 +9210,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7689,6 +9245,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7698,6 +9261,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7732,6 +9296,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7741,6 +9312,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7775,6 +9347,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7784,6 +9363,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7818,6 +9398,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7827,6 +9414,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7861,6 +9449,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7870,6 +9465,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -7898,6 +9494,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7907,6 +9510,7 @@
         assert $5 same_as 'kubectl exec '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7939,6 +9543,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7948,6 +9559,7 @@
         assert $5 same_as 'kubectl exec pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -7988,6 +9600,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -7997,6 +9616,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8034,6 +9654,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8043,6 +9670,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8080,6 +9708,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8089,6 +9724,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8126,6 +9762,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8135,6 +9778,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8172,6 +9816,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8181,6 +9832,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8218,6 +9870,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8227,6 +9886,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8264,6 +9924,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8273,6 +9940,7 @@
         assert $5 same_as 'kubectl exec etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8310,6 +9978,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl exec pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8319,6 +9994,7 @@
         assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -8349,6 +10025,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl explain '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8358,6 +10041,7 @@
         assert $5 same_as 'kubectl explain '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -8393,6 +10077,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8402,6 +10093,7 @@
         assert $5 same_as 'kubectl label '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -8437,6 +10129,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8446,6 +10145,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8479,6 +10179,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8488,6 +10195,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8519,6 +10227,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8529,6 +10244,7 @@
         assert $6 same_as 'kubectl label pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8560,6 +10276,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8570,6 +10293,7 @@
         assert $6 same_as 'kubectl label pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8601,6 +10325,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8611,6 +10342,7 @@
         assert $6 same_as 'kubectl label pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8642,6 +10374,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8652,6 +10391,7 @@
         assert $6 same_as 'kubectl label pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8679,6 +10419,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8689,6 +10436,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8712,6 +10460,13 @@
         echo '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8722,6 +10477,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8751,6 +10507,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8760,6 +10523,7 @@
         assert $5 same_as 'kubectl label pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8794,6 +10558,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8803,6 +10574,7 @@
         assert $5 same_as 'kubectl label pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8832,6 +10604,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8842,6 +10621,7 @@
         assert $6 same_as 'kubectl label pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8867,6 +10647,13 @@
         echo -n '{"component":"etcd","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl label pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -8877,6 +10664,7 @@
         assert $6 same_as 'kubectl label pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -8907,6 +10695,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8916,6 +10711,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8949,6 +10745,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs -f '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -8958,6 +10761,7 @@
         assert $5 same_as 'kubectl logs -f '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -8991,6 +10795,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9000,6 +10811,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9031,6 +10843,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -9041,6 +10860,7 @@
         assert $6 same_as 'kubectl logs pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -9072,6 +10892,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -9082,6 +10909,7 @@
         assert $6 same_as 'kubectl logs pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -9113,6 +10941,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -9123,6 +10958,7 @@
         assert $6 same_as 'kubectl logs pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -9154,6 +10990,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -9164,6 +11007,7 @@
         assert $6 same_as 'kubectl logs pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -9202,6 +11046,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9211,6 +11062,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9245,6 +11097,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9254,6 +11113,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9288,6 +11148,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9297,6 +11164,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9331,6 +11199,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9340,6 +11215,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9374,6 +11250,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9383,6 +11266,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9417,6 +11301,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9426,6 +11317,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9460,6 +11352,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9469,6 +11368,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9503,6 +11403,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9512,6 +11419,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9540,6 +11448,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9549,6 +11464,7 @@
         assert $5 same_as 'kubectl logs '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9581,6 +11497,13 @@
         echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9590,6 +11513,7 @@
         assert $5 same_as 'kubectl logs pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -9630,6 +11554,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9639,6 +11570,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9676,6 +11608,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9685,6 +11624,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9722,6 +11662,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9731,6 +11678,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9768,6 +11716,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9777,6 +11732,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9814,6 +11770,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9823,6 +11786,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9860,6 +11824,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9869,6 +11840,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9906,6 +11878,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9915,6 +11894,7 @@
         assert $5 same_as 'kubectl logs etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9952,6 +11932,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl logs pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9961,6 +11948,7 @@
         assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -9988,6 +11976,13 @@
         echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -9997,6 +11992,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10024,6 +12020,13 @@
         echo 'kube-system   coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10033,6 +12036,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10059,6 +12063,13 @@
         echo 'kube-system   kube-dns     ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10068,6 +12079,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME         ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
@@ -10094,6 +12106,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10104,6 +12123,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10131,6 +12151,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10141,6 +12168,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10168,6 +12196,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10178,6 +12213,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10205,6 +12241,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10215,6 +12258,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10242,6 +12286,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10252,6 +12303,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10279,6 +12331,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10289,6 +12348,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10315,6 +12375,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10324,6 +12391,7 @@
         assert $5 same_as 'kubectl port-forward '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10350,6 +12418,13 @@
         echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10359,6 +12434,7 @@
         assert $5 same_as 'kubectl port-forward pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10384,6 +12460,13 @@
         echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10393,6 +12476,7 @@
         assert $5 same_as 'kubectl port-forward services/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
@@ -10420,6 +12504,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10430,6 +12521,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10459,6 +12551,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10469,6 +12568,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10498,6 +12598,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10508,6 +12615,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10537,6 +12645,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10547,6 +12662,7 @@
         assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10576,6 +12692,13 @@
         echo ' 9153 TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10586,6 +12709,7 @@
         assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10615,6 +12739,13 @@
         echo '9153  TCP metrics'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl port-forward services/kube-dns '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10625,6 +12756,7 @@
         assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
@@ -10639,6 +12771,13 @@
 }
 
 @test 'Testing completion: kubectl rollout **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -10647,6 +12786,7 @@
         assert $4 same_as 'kubectl rollout '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as history
@@ -10679,6 +12819,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10688,6 +12835,7 @@
         assert $5 same_as 'kubectl rollout restart '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -10723,6 +12871,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart deployments '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10733,6 +12888,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10766,6 +12922,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10776,6 +12939,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10809,6 +12973,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart deployments '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10819,6 +12990,7 @@
         assert $6 same_as 'kubectl rollout restart deployments '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10853,6 +13025,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl rollout restart '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -10863,6 +13042,7 @@
         assert $6 same_as 'kubectl rollout restart deployments/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -10880,6 +13060,13 @@
 }
 
 @test 'Testing completion: kubectl set **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -10888,6 +13075,7 @@
         assert $4 same_as 'kubectl set '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 6
         assert ${lines[1]} same_as env
@@ -10920,6 +13108,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10929,6 +13124,7 @@
         assert $5 same_as 'kubectl set env '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -10964,6 +13160,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -10973,6 +13176,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11006,6 +13210,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11015,6 +13226,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11046,6 +13258,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11056,6 +13275,7 @@
         assert $6 same_as 'kubectl set env pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11087,6 +13307,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11097,6 +13324,7 @@
         assert $6 same_as 'kubectl set env pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11128,6 +13356,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11138,6 +13373,7 @@
         assert $6 same_as 'kubectl set env pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11169,6 +13405,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11179,6 +13422,7 @@
         assert $6 same_as 'kubectl set env pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11212,6 +13456,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11221,6 +13472,7 @@
         assert $5 same_as 'kubectl set env pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11255,6 +13507,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set env '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11264,6 +13523,7 @@
         assert $5 same_as 'kubectl set env pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11298,6 +13558,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11307,6 +13574,7 @@
         assert $5 same_as 'kubectl set image '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -11342,6 +13610,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11351,6 +13626,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11384,6 +13660,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11393,6 +13676,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11424,6 +13708,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11434,6 +13725,7 @@
         assert $6 same_as 'kubectl set image pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11465,6 +13757,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11475,6 +13774,7 @@
         assert $6 same_as 'kubectl set image pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11506,6 +13806,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11516,6 +13823,7 @@
         assert $6 same_as 'kubectl set image pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11547,6 +13855,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11557,6 +13872,7 @@
         assert $6 same_as 'kubectl set image pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -11595,6 +13911,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11605,6 +13928,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11639,6 +13963,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11649,6 +13980,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11678,6 +14010,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11687,6 +14026,7 @@
         assert $5 same_as 'kubectl set image pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11721,6 +14061,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11730,6 +14077,7 @@
         assert $5 same_as 'kubectl set image pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11771,6 +14119,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11781,6 +14136,7 @@
         assert $6 same_as 'kubectl set image pods etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11818,6 +14174,13 @@
         echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set image pods/etcd-minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11828,6 +14191,7 @@
         assert $6 same_as 'kubectl set image pods/etcd-minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
@@ -11858,6 +14222,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11867,6 +14238,7 @@
         assert $5 same_as 'kubectl set resources '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -11902,6 +14274,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11911,6 +14290,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11944,6 +14324,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -11953,6 +14340,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -11984,6 +14372,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -11994,6 +14389,7 @@
         assert $6 same_as 'kubectl set resources pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12025,6 +14421,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12035,6 +14438,7 @@
         assert $6 same_as 'kubectl set resources pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12066,6 +14470,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12076,6 +14487,7 @@
         assert $6 same_as 'kubectl set resources pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12107,6 +14519,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12117,6 +14536,7 @@
         assert $6 same_as 'kubectl set resources pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12150,6 +14570,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12159,6 +14586,7 @@
         assert $5 same_as 'kubectl set resources pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12193,6 +14621,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set resources '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12202,6 +14637,7 @@
         assert $5 same_as 'kubectl set resources pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12236,6 +14672,13 @@
         echo 'roles                     rbac.authorization.k8s.io   true         Role'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12245,6 +14688,7 @@
         assert $5 same_as 'kubectl set subject '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 9
         assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
@@ -12280,6 +14724,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12289,6 +14740,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12322,6 +14774,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12331,6 +14790,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12362,6 +14822,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12372,6 +14839,7 @@
         assert $6 same_as 'kubectl set subject pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12403,6 +14871,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12413,6 +14888,7 @@
         assert $6 same_as 'kubectl set subject pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12444,6 +14920,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12454,6 +14937,7 @@
         assert $6 same_as 'kubectl set subject pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12485,6 +14969,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12495,6 +14986,7 @@
         assert $6 same_as 'kubectl set subject pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -12528,6 +15020,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12537,6 +15036,7 @@
         assert $5 same_as 'kubectl set subject pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12571,6 +15071,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl set subject '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12580,6 +15087,7 @@
         assert $5 same_as 'kubectl set subject pods/'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -12597,6 +15105,13 @@
 }
 
 @test 'Testing completion: kubectl taint **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -12605,6 +15120,7 @@
         assert $4 same_as 'kubectl taint '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 1
         assert ${lines[1]} same_as nodes
@@ -12628,6 +15144,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12638,6 +15161,7 @@
         assert $6 same_as 'kubectl taint --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12667,6 +15191,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12677,6 +15208,7 @@
         assert $6 same_as 'kubectl taint --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12706,6 +15238,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12716,6 +15255,7 @@
         assert $6 same_as 'kubectl taint -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12745,6 +15285,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12755,6 +15302,7 @@
         assert $6 same_as 'kubectl taint -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12783,6 +15331,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -12792,6 +15347,7 @@
         assert $5 same_as 'kubectl taint nodes '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -12816,6 +15372,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12826,6 +15389,7 @@
         assert $6 same_as 'kubectl taint nodes --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12855,6 +15419,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12865,6 +15436,7 @@
         assert $6 same_as 'kubectl taint nodes --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12894,6 +15466,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12904,6 +15483,7 @@
         assert $6 same_as 'kubectl taint nodes -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12933,6 +15513,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12943,6 +15530,7 @@
         assert $6 same_as 'kubectl taint nodes -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -12971,6 +15559,13 @@
         echo 'key2 value2 NoExecute'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl taint nodes minikube '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -12981,6 +15576,7 @@
         assert $6 same_as 'kubectl taint nodes minikube '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}KEY ${reset_color}  ${reset_color}VALUE ${reset_color}  EFFECT"
@@ -12993,6 +15589,13 @@
 }
 
 @test 'Testing completion: kubectl top **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -13001,6 +15604,7 @@
         assert $4 same_as 'kubectl top '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 0
         assert ${#lines} equals 2
         assert ${lines[1]} same_as nodes
@@ -13024,6 +15628,13 @@
         echo 'minikube   Ready    master   20d   v1.19.2   192.0.2.1     <none>        Arch Linux   5.8.14-arch1-1   docker://19.3.13'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13033,6 +15644,7 @@
         assert $5 same_as 'kubectl top nodes '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME"
@@ -13057,6 +15669,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13067,6 +15686,7 @@
         assert $6 same_as 'kubectl top nodes --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -13096,6 +15716,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13106,6 +15733,7 @@
         assert $6 same_as 'kubectl top nodes --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -13135,6 +15763,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13145,6 +15780,7 @@
         assert $6 same_as 'kubectl top nodes -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -13174,6 +15810,13 @@
         echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top nodes '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13184,6 +15827,7 @@
         assert $6 same_as 'kubectl top nodes -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY                                  ${reset_color}  VALUE"
@@ -13217,6 +15861,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13226,6 +15877,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13257,6 +15909,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13267,6 +15926,7 @@
         assert $6 same_as 'kubectl top pods --selector='
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13298,6 +15958,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods --selector '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13308,6 +15975,7 @@
         assert $6 same_as 'kubectl top pods --selector '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13339,6 +16007,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods -l '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13349,6 +16024,7 @@
         assert $6 same_as 'kubectl top pods -l '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13380,6 +16056,13 @@
         echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -13390,6 +16073,7 @@
         assert $6 same_as 'kubectl top pods -l'
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
@@ -13423,6 +16107,13 @@
         echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         assert $# equals 5
         assert $1 same_as '--ansi'
@@ -13432,6 +16123,7 @@
         assert $5 same_as 'kubectl top pods '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert kubectl mock_times 1
         assert ${#lines} equals 7
         assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
@@ -13449,6 +16141,13 @@
 }
 
 @test 'Testing completion: kubectl "" top pods **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl "" top pods '
+
+        echo 'kubectl'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -13457,6 +16156,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'kubectl "" top pods '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -30,6 +30,21 @@
     _fzf_complete_kubectl 'kubectl '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 kubectl **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'TEST1=value1 TEST2=value2 kubectl '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'TEST1=value1 TEST2=value2 kubectl '
+}
+
 @test 'Testing completion: kubectl --namespace=**' {
     kubectl_mock_1() {
         assert $# equals 5

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -84,3 +84,18 @@
     prefix=
     _fzf_complete_npm 'npm run '
 }
+
+@test 'Testing completion: npm "" run **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'npm "" run '
+    }
+
+    prefix=
+    _fzf_complete_npm 'npm "" run '
+}

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -84,18 +84,3 @@
     prefix=
     _fzf_complete_npm 'npm run '
 }
-
-@test 'Testing completion: npm "" run **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'npm "" run '
-    }
-
-    prefix=
-    _fzf_complete_npm 'npm "" run '
-}

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -5,6 +5,10 @@
     load _helpers/assertions.zsh
 
     pushd tests/_support/npm
+
+    __fzf_extract_command() {
+        echo 'npm'
+    }
 }
 
 @test 'Testing completion: npm **' {

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -3,15 +3,25 @@
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
     load _helpers/assertions.zsh
+    load _helpers/mock.zsh
+
+    mock __fzf_extract_command
 
     pushd tests/_support/npm
+}
 
-    __fzf_extract_command() {
-        echo 'npm'
-    }
+@teardown {
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: npm **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'npm '
+
+        echo 'npm'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -20,6 +30,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'npm '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -27,6 +39,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 npm **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 npm '
+
+        echo 'npm'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -35,6 +54,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'TEST1=value1 TEST2=value2 npm '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=
@@ -42,6 +63,13 @@
 }
 
 @test 'Testing completion: npm run **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'npm run '
+
+        echo 'npm'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -52,6 +80,7 @@
         assert $6 same_as 'npm run '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -86,6 +115,13 @@
 }
 
 @test 'Testing completion: npm "" run **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'npm "" run '
+
+        echo 'npm'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -94,6 +130,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'npm "" run '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/npm.zunit
+++ b/tests/npm.zunit
@@ -26,6 +26,21 @@
     _fzf_complete_npm 'npm '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 npm **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'TEST1=value1 TEST2=value2 npm '
+    }
+
+    prefix=
+    _fzf_complete_npm 'TEST1=value1 TEST2=value2 npm '
+}
+
 @test 'Testing completion: npm run **' {
     _fzf_complete() {
         assert $# equals 6

--- a/tests/sudo.zunit
+++ b/tests/sudo.zunit
@@ -36,20 +36,3 @@
 
     assert $LBUFFER same_as 'sudo docker start '
 }
-
-@test 'Testing completion: sudo "" docker start **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'sudo "" docker start '
-    }
-
-    prefix=
-    _fzf_complete_sudo 'sudo "" docker start '
-
-    assert _fzf_complete_docker mock_times 0
-}

--- a/tests/sudo.zunit
+++ b/tests/sudo.zunit
@@ -36,3 +36,20 @@
 
     assert $LBUFFER same_as 'sudo docker start '
 }
+
+@test 'Testing completion: sudo "" docker start **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'sudo "" docker start '
+    }
+
+    prefix=
+    _fzf_complete_sudo 'sudo "" docker start '
+
+    assert _fzf_complete_docker mock_times 0
+}

--- a/tests/systemctl.zunit
+++ b/tests/systemctl.zunit
@@ -94,6 +94,74 @@
     _fzf_complete_systemctl 'systemctl status '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 systemctl status **' {
+    systemctl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'list-units'
+        assert $2 same_as '--full'
+        assert $3 same_as '--no-legend'
+        assert $4 same_as '--no-pager'
+        assert $5 same_as '*'
+
+        echo '-.mount      loaded active mounted Root Mount'
+        echo 'boot.mount   loaded active mounted /boot'
+        echo 'dbus.service loaded active running D-Bus System Message Bus'
+        echo '-.slice      loaded active active  Root Slice'
+        echo 'system.slice loaded active active  System Slice'
+        echo 'user.slice   loaded active active  User and Session Slice'
+        echo 'basic.target loaded active active  Basic System'
+        echo 'dbus.socket  loaded failed running D-Bus System Message Bus Socket'
+    }
+
+    systemctl_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'list-unit-files'
+        assert $2 same_as '--full'
+        assert $3 same_as '--no-legend'
+        assert $4 same_as '--no-pager'
+        assert $5 same_as '*'
+
+        echo '-.mount           generated -'
+        echo 'boot.mount        generated -'
+        echo 'dbus.service      static    -'
+        echo 'ip6tables.service disabled  disabled'
+        echo 'iptables.service  disabled  disabled'
+        echo 'user@.service     static    -'
+        echo 'user.slice        static    -'
+        echo 'basic.target      static    -'
+        echo 'blockdev@.target  static    -'
+        echo 'dbus.socket       static    -'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--preview-window=right:70%:wrap'
+        assert $4 matches '--preview=*'
+        assert $5 same_as '--reverse'
+        assert $6 same_as '--'
+        assert $7 same_as 'TEST1=value1 TEST2=value2 systemctl status '
+
+        run cat
+        assert systemctl mock_times 2
+        assert ${#lines} equals 10
+        assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
+        assert ${lines[2]} same_as "${fg[green]}●${reset_color} -.slice"
+        assert ${lines[3]} same_as "${fg[green]}●${reset_color} basic.target"
+        assert ${lines[4]} same_as "${fg[green]}●${reset_color} boot.mount"
+        assert ${lines[5]} same_as "${fg[green]}●${reset_color} dbus.service"
+        assert ${lines[6]} same_as "${fg[red]}●${reset_color} dbus.socket"
+        assert ${lines[7]} same_as "○ ip6tables.service"
+        assert ${lines[8]} same_as "○ iptables.service"
+        assert ${lines[9]} same_as "${fg[green]}●${reset_color} system.slice"
+        assert ${lines[10]} same_as "${fg[green]}●${reset_color} user.slice"
+    }
+
+    prefix=
+    _fzf_complete_systemctl 'TEST1=value1 TEST2=value2 systemctl status '
+}
+
 @test 'Testing completion: systemctl status --user **' {
     systemctl_mock_1() {
         assert $# equals 6

--- a/tests/systemctl.zunit
+++ b/tests/systemctl.zunit
@@ -6,6 +6,7 @@
     load _helpers/assertions.zsh
     mock systemctl
     mock xargs
+    mock __fzf_extract_command
     FZF_DEFAULT_OPTS=--reverse
 
     preview() {
@@ -15,15 +16,12 @@
             fi
         done
     }
-
-    __fzf_extract_command() {
-        echo 'systemctl'
-    }
 }
 
 @teardown {
-    unmock systemctl
-    unmock xargs
+    (unmock systemctl)
+    (unmock xargs)
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: systemctl status **' {
@@ -65,6 +63,13 @@
         echo 'dbus.socket       static    -'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'systemctl status '
+
+        echo 'systemctl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -76,6 +81,7 @@
         assert $7 same_as 'systemctl status '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert systemctl mock_times 2
         assert ${#lines} equals 10
         assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
@@ -133,6 +139,13 @@
         echo 'dbus.socket       static    -'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 systemctl status '
+
+        echo 'systemctl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -144,6 +157,7 @@
         assert $7 same_as 'TEST1=value1 TEST2=value2 systemctl status '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert systemctl mock_times 2
         assert ${#lines} equals 10
         assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
@@ -194,6 +208,13 @@
         echo 'dbus.socket       static    -'
     }
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'systemctl status --user '
+
+        echo 'systemctl'
+    }
+
     _fzf_complete() {
         assert $# equals 7
         assert $1 same_as '--ansi'
@@ -205,6 +226,7 @@
         assert $7 same_as 'systemctl status --user '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert systemctl mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[green]}●${reset_color} -.mount"
@@ -347,6 +369,13 @@
         echo '      Tasks: 0 (limit: 2367)'
         echo '     Memory: 120.0K'
         echo '     CGroup: /system.slice/boot.mount'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'systemctl status --user '
+
+        echo 'systemctl'
     }
 
     _fzf_complete() {

--- a/tests/systemctl.zunit
+++ b/tests/systemctl.zunit
@@ -15,6 +15,10 @@
             fi
         done
     }
+
+    __fzf_extract_command() {
+        echo 'systemctl'
+    }
 }
 
 @teardown {

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -5,6 +5,10 @@
     load _helpers/assertions.zsh
 
     pushd tests/_support/npm
+
+    __fzf_extract_command() {
+        echo 'yarn'
+    }
 }
 
 @test 'Testing completion: yarn **' {

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -3,15 +3,25 @@
 @setup {
     load ../fzf-zsh-completions.plugin.zsh
     load _helpers/assertions.zsh
+    load _helpers/mock.zsh
+
+    mock __fzf_extract_command
 
     pushd tests/_support/npm
+}
 
-    __fzf_extract_command() {
-        echo 'yarn'
-    }
+@teardown {
+    (unmock __fzf_extract_command)
 }
 
 @test 'Testing completion: yarn **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -22,6 +32,7 @@
         assert $6 same_as 'yarn '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -56,6 +67,13 @@
 }
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 yarn **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'TEST1=value1 TEST2=value2 yarn '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -66,6 +84,7 @@
         assert $6 same_as 'TEST1=value1 TEST2=value2 yarn '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -100,6 +119,13 @@
 }
 
 @test 'Testing completion: yarn run **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn run '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -110,6 +136,7 @@
         assert $6 same_as 'yarn run '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -147,6 +174,13 @@
     popd
     pushd tests/_support/yarn/workspace
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn workspace '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 4
         assert $1 same_as '--ansi'
@@ -155,6 +189,7 @@
         assert $4 same_as 'yarn workspace '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 3
 
         assert ${lines[1]} same_as 'package-a'
@@ -170,6 +205,13 @@
     popd
     pushd tests/_support/yarn/workspace
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn workspace package-a '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -180,6 +222,7 @@
         assert $6 same_as 'yarn workspace package-a '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -218,6 +261,13 @@
     popd
     pushd tests/_support/yarn/workspace
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn workspace package-b '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -228,6 +278,7 @@
         assert $6 same_as 'yarn workspace package-b '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -266,6 +317,13 @@
     popd
     pushd tests/_support/yarn/workspace
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn workspace examples-a '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         assert $# equals 6
         assert $1 same_as '--ansi'
@@ -276,6 +334,7 @@
         assert $6 same_as 'yarn workspace examples-a '
 
         run cat
+        assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 6
 
         actual1=(${(0)lines[1]})
@@ -314,6 +373,13 @@
     popd
     pushd tests/_support/yarn/workspace
 
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn workspace no-workspace '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -321,10 +387,18 @@
     prefix=
     _fzf_complete_yarn 'yarn workspace no-workspace '
 
+    assert __fzf_extract_command mock_times 1
     assert $? equals 0
 }
 
 @test 'Testing completion: yarn "" run **' {
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'yarn "" run '
+
+        echo 'yarn'
+    }
+
     _fzf_complete() {
         fail '_fzf_complete should not be invoked'
     }
@@ -333,6 +407,8 @@
         assert $# equals 2
         assert $1 same_as ''
         assert $2 same_as 'yarn "" run '
+
+        assert __fzf_extract_command mock_times 1
     }
 
     prefix=

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -323,3 +323,18 @@
 
     assert $? equals 0
 }
+
+@test 'Testing completion: yarn "" run **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'yarn "" run '
+    }
+
+    prefix=
+    _fzf_complete_yarn 'yarn "" run '
+}

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -55,6 +55,50 @@
     _fzf_complete_yarn 'yarn '
 }
 
+@test 'Testing completion: TEST1=value1 TEST2=value2 yarn **' {
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--'
+        assert $6 same_as 'TEST1=value1 TEST2=value2 yarn '
+
+        run cat
+        assert ${#lines} equals 6
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'start'
+        assert ${actual1[2]} same_as 'test'
+        assert ${actual1[3]} same_as ' script containing spaces '
+        assert ${actual1[4]} same_as 'script'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'that'
+
+        actual3=(${(0)lines[3]})
+        assert ${#actual3} equals 1
+        assert ${actual3[1]} same_as 'consists'
+
+        actual4=(${(0)lines[4]})
+        assert ${#actual4} equals 1
+        assert ${actual4[1]} same_as 'of'
+
+        actual5=(${(0)lines[5]})
+        assert ${#actual5} equals 1
+        assert ${actual5[1]} same_as 'multiple'
+
+        actual6=(${(0)lines[6]})
+        assert ${actual6[1]} same_as 'lines'
+    }
+
+    prefix=
+    _fzf_complete_yarn 'TEST1=value1 TEST2=value2 yarn '
+}
+
 @test 'Testing completion: yarn run **' {
     _fzf_complete() {
         assert $# equals 6

--- a/tests/yarn.zunit
+++ b/tests/yarn.zunit
@@ -323,18 +323,3 @@
 
     assert $? equals 0
 }
-
-@test 'Testing completion: yarn "" run **' {
-    _fzf_complete() {
-        fail '_fzf_complete should not be invoked'
-    }
-
-    _fzf_path_completion() {
-        assert $# equals 2
-        assert $1 same_as ''
-        assert $2 same_as 'yarn "" run '
-    }
-
-    prefix=
-    _fzf_complete_yarn 'yarn "" run '
-}


### PR DESCRIPTION
This closes #138.

The arguments whose env is trimmed are passed to the function parsing arguments.
https://github.com/chitoku-k/fzf-zsh-completions/blob/3a90f2a89f37cab22a1d24f0f34a1152d9327fe0/src/completers/systemctl.zsh#L22