### PR TITLE
Fix some of issues related to the mock

### DIFF
--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -3,8 +3,6 @@ _zunit_assert_mock_times() {
     local count=$2
     shift 2
 
-    : ${mock_dir:=${funcsourcetrace[1]:P:h:h}/_support/mock}
-
     local len=$(cat -- $mock_dir/${target}_mock_times)
     if [[ $len != $count ]]; then
         echo "'$target' is called $len time(s)"

--- a/tests/_helpers/assertions.zsh
+++ b/tests/_helpers/assertions.zsh
@@ -3,7 +3,9 @@ _zunit_assert_mock_times() {
     local count=$2
     shift 2
 
-    local len=$(cat -- ${target}_mock_times)
+    : ${mock_dir:=${funcsourcetrace[1]:P:h:h}/_support/mock}
+
+    local len=$(cat -- $mock_dir/${target}_mock_times)
     if [[ $len != $count ]]; then
         echo "'$target' is called $len time(s)"
         exit 1
@@ -12,9 +14,10 @@ _zunit_assert_mock_times() {
     local i
     for (( i = 1; i <= len; i++ )); do
         local mock=${target}_mock_$i
-        if [[ -e ${mock}_fail ]]; then
-            echo "$mock: $(cat -- ${mock}_fail)"
-            rm -f -- ${mock}_fail
+        local mock_failfile=$mock_dir/${mock}_fail
+        if [[ -e $mock_failfile ]]; then
+            echo "$mock: $(cat -- $mock_failfile)"
+            rm -f -- $mock_failfile
             exit 1
         fi
     done

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -5,7 +5,6 @@ mock() {
     shift
 
     local mock_timesfile=$mock_dir/${target}_mock_times
-
     echo 0 > $mock_timesfile
 
     $target() {

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -10,7 +10,7 @@ mock() {
         local mock_failfile=${target}_mock_${mock_times}_fail
         echo $mock_times > ${target}_mock_times
 
-        if ${target}_mock_$mock_times $@ &> $mock_failfile; then
+        if ${target}_mock_$mock_times "$@" &> $mock_failfile; then
             cat -- $mock_failfile
             rm -- $mock_failfile
         fi

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -30,7 +30,6 @@ unmock() {
         unfunction $target
     fi
 
-    : ${mock_dir:=${funcsourcetrace[1]:P:h:h}/_support/mock}
     local mock_timesfile=$mock_dir/${target}_mock_times
     local mock_failfile=$mock_dir/${mock}_fail
 

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -1,8 +1,9 @@
+typeset -g mock_dir=${funcsourcetrace[1]:P:h:h}/_support/mock
+
 mock() {
     local target=$1
     shift
 
-    typeset -g mock_dir=${funcsourcetrace[1]:P:h:h}/_support/mock
     local mock_timesfile=$mock_dir/${target}_mock_times
 
     echo 0 > $mock_timesfile

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -2,13 +2,17 @@ mock() {
     local target=$1
     shift
 
-    echo 0 > ${target}_mock_times
+    typeset -g mock_dir=${funcsourcetrace[1]:P:h:h}/_support/mock
+    local mock_timesfile=$mock_dir/${target}_mock_times
+
+    echo 0 > $mock_timesfile
 
     $target() {
         local target=${funcstack[1]}
-        local mock_times=$(($(cat -- ${target}_mock_times) + 1))
-        local mock_failfile=${target}_mock_${mock_times}_fail
-        echo $mock_times > ${target}_mock_times
+        local mock_timesfile=$mock_dir/${target}_mock_times
+        local mock_times=$(($(cat -- $mock_timesfile) + 1))
+        local mock_failfile=$mock_dir/${target}_mock_${mock_times}_fail
+        echo $mock_times > $mock_timesfile
 
         if ${target}_mock_$mock_times "$@" &> $mock_failfile; then
             cat -- $mock_failfile
@@ -25,14 +29,18 @@ unmock() {
         unfunction $target
     fi
 
+    : ${mock_dir:=${funcsourcetrace[1]:P:h:h}/_support/mock}
+    local mock_timesfile=$mock_dir/${target}_mock_times
+    local mock_failfile=$mock_dir/${mock}_fail
+
     local i
-    local len=$(cat -- ${target}_mock_times)
+    local len=$(cat -- $mock_timesfile)
     for (( i = 1; i <= len; i++ )); do
         local mock=${target}_mock_$i
-        if [[ -e ${mock}_fail ]]; then
-            echo "$mock: $(cat -- ${mock}_fail)"
+        if [[ -e $mock_failfile ]]; then
+            echo "$mock: $(cat -- $mock_failfile)"
         fi
     done
 
-    rm -f -- ${target}_mock_times ${target}_mock_*_fail(N)
+    rm -f -- $mock_timesfile $mock_dir/${target}_mock_*_fail(N)
 }


### PR DESCRIPTION
This PR fixes two issues. One is that the issue where empty strings were removed (related to #146). The other is the issue related to the place of the mock files. The place of the mock files affected the completion using files in a working directory like `git`. In the case of `git`, they were shown in the completion, but this was unexpected. Setting the directory where they are saved resolves this issue.