### PR TITLE
Fix an empty namespace causing parse failure in kubectl

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -101,18 +101,17 @@ _fzf_complete_kubectl() {
     )
     local kubectl_options_argument_optional=()
 
-
     for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
         if [[ $inherit_option = --* ]]; then
             for arg in "$@" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "${(F)kubectl_options_argument_required}" "$arg"); then
-                    kubectl_arguments+=($inherit_values)
+                    kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
                 fi
             done
         else
             for arg in "$@" "$RBUFFER"; do
                 if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "${(F)kubectl_options_argument_required}" "$arg"); then
-                    kubectl_arguments+=($inherit_values)
+                    kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
                 fi
             done
         fi
@@ -173,16 +172,16 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-annotations '--multi' $@
+            _fzf_complete_kubectl-annotations '--multi' "$@"
             return
         fi
     fi
@@ -217,15 +216,15 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]] && [[ ${#subcommands[@]} = 2 ]]; then
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
                 if [[ ${subcommands[2]} = 'edit-last-applied' ]]; then
-                    _fzf_complete_kubectl-resource-names '' $@
+                    _fzf_complete_kubectl-resource-names '' "$@"
                 elif [[ ${subcommands[2]} = 'view-last-applied' ]]; then
-                    _fzf_complete_kubectl-resource-names '--multi' $@
+                    _fzf_complete_kubectl-resource-names '--multi' "$@"
                 fi
             fi
             return
@@ -275,11 +274,11 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-resource-names '' $@
+            _fzf_complete_kubectl-resource-names '' "$@"
             return
         fi
     fi
@@ -305,7 +304,7 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ -z $completing_option ]]; then
-            _fzf_complete_kubectl-resource-names '' $@
+            _fzf_complete_kubectl-resource-names '' "$@"
             return
         fi
     fi
@@ -406,13 +405,13 @@ _fzf_complete_kubectl() {
                 prefix=${prefix##*/}
                 prefix_option=${prefix_option##*/}cronjob/
                 resource=cronjob
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
         fi
 
         if [[ -z $completing_option ]]; then
-            _fzf_complete_constants '' "${(F)set_subcommands}" $@
+            _fzf_complete_constants '' "${(F)set_subcommands}" "$@"
             return
         fi
     fi
@@ -455,11 +454,11 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-resource-names '--multi' $@
+            _fzf_complete_kubectl-resource-names '--multi' "$@"
             return
         fi
 
@@ -470,7 +469,7 @@ _fzf_complete_kubectl() {
                 prefix=${prefix#$label_columns}
             fi
 
-            _fzf_complete_kubectl-label-columns '--multi' $@
+            _fzf_complete_kubectl-label-columns '--multi' "$@"
             return
         fi
     fi
@@ -499,12 +498,12 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ -z $completing_option ]]; then
-            _fzf_complete_kubectl-resource-names '' $@
+            _fzf_complete_kubectl-resource-names '' "$@"
             return
         fi
 
         if [[ $completing_option =~ '^(-c|--container)$' ]]; then
-            _fzf_complete_kubectl-containers '' $@
+            _fzf_complete_kubectl-containers '' "$@"
             return
         fi
     fi
@@ -522,7 +521,7 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ -z $completing_option ]]; then
-            _fzf_complete_kubectl-resources '' $@
+            _fzf_complete_kubectl-resources '' "$@"
             return
         fi
     fi
@@ -555,16 +554,16 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-labels '--multi' $@
+            _fzf_complete_kubectl-labels '--multi' "$@"
             return
         fi
     fi
@@ -598,12 +597,12 @@ _fzf_complete_kubectl() {
         fi
 
         if [[ -z $completing_option ]]; then
-            _fzf_complete_kubectl-resource-names '' $@
+            _fzf_complete_kubectl-resource-names '' "$@"
             return
         fi
 
         if [[ $completing_option =~ '^(-c|--container)$' ]]; then
-            _fzf_complete_kubectl-containers '' $@
+            _fzf_complete_kubectl-containers '' "$@"
             return
         fi
     fi
@@ -630,13 +629,13 @@ _fzf_complete_kubectl() {
 
         if [[ -z $completing_option ]]; then
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
 
             prefix_option=${prefix/:*/:}
             prefix=${prefix#$prefix_option}
-            _fzf_complete_kubectl-ports '--multi' $@
+            _fzf_complete_kubectl-ports '--multi' "$@"
             return
         fi
     fi
@@ -654,16 +653,16 @@ _fzf_complete_kubectl() {
         if [[ -z $completing_option ]]; then
             if [[ ${#subcommands[@]} != 2 ]]; then
                 local rollout_subcommands=(history pause restart resume status undo)
-                _fzf_complete_constants '' "${(F)rollout_subcommands}" $@
+                _fzf_complete_constants '' "${(F)rollout_subcommands}" "$@"
                 return
             fi
 
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-resource-names '--multi' $@
+            _fzf_complete_kubectl-resource-names '--multi' "$@"
             return
         fi
     fi
@@ -707,22 +706,22 @@ _fzf_complete_kubectl() {
         if [[ -z $completing_option ]]; then
             if [[ ${#subcommands[@]} != 2 ]]; then
                 local set_subcommands=(env image resources selector serviceaccount subject)
-                _fzf_complete_constants '' "${(F)set_subcommands}" $@
+                _fzf_complete_constants '' "${(F)set_subcommands}" "$@"
                 return
             fi
 
             if [[ -z $resource ]]; then
-                _fzf_complete_kubectl-resources '' $@
+                _fzf_complete_kubectl-resources '' "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
 
             if [[ ${subcommands[2]} = 'image' ]]; then
-                _fzf_complete_kubectl-containers '--multi' $@
+                _fzf_complete_kubectl-containers '--multi' "$@"
                 return
             fi
             return
@@ -752,16 +751,16 @@ _fzf_complete_kubectl() {
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
                 local taint_resources=(nodes)
-                _fzf_complete_constants '' "${(F)taint_resources}" $@
+                _fzf_complete_constants '' "${(F)taint_resources}" "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
 
-            _fzf_complete_kubectl-taints '--multi' $@
+            _fzf_complete_kubectl-taints '--multi' "$@"
             return
         fi
     fi
@@ -785,12 +784,12 @@ _fzf_complete_kubectl() {
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
                 local top_resources=(nodes pods)
-                _fzf_complete_constants '' "${(F)top_resources}" $@
+                _fzf_complete_constants '' "${(F)top_resources}" "$@"
                 return
             fi
 
             if [[ -z $name ]]; then
-                _fzf_complete_kubectl-resource-names '' $@
+                _fzf_complete_kubectl-resource-names '' "$@"
                 return
             fi
             return
@@ -839,11 +838,15 @@ _fzf_complete_kubectl() {
     fi
 
     if [[ $completing_option =~ '^(-n|--namespace)$' ]]; then
-        kubectl_arguments=${kubectl_arguments:#\'-l*}
-        kubectl_arguments=${kubectl_arguments:#\'--selector*}
+        kubectl_arguments[${kubectl_arguments[(i)-l]},${kubectl_arguments[(i)-l]}+1]=()
+        kubectl_arguments[${kubectl_arguments[(i)--selector]},${kubectl_arguments[(i)--selector]}+1]=()
+        kubectl_arguments=("${(@)kubectl_arguments:#-l*}")
+        kubectl_arguments=("${(@)kubectl_arguments:#--selector*}")
+        kubectl_arguments=("${(@)kubectl_arguments:#-n}")
+        kubectl_arguments=("${(@)kubectl_arguments:#--namespace=}")
 
         resource=namespaces
-        _fzf_complete_kubectl-resource-names '' $@
+        _fzf_complete_kubectl-resource-names '' "$@"
         return
     fi
 
@@ -864,17 +867,17 @@ _fzf_complete_kubectl() {
             local selector=${prefix%=*}=
             prefix_option=$prefix_option$selector
             prefix=${prefix#$selector}
-            _fzf_complete_kubectl-selectors '' $@
+            _fzf_complete_kubectl-selectors '' "$@"
             return
         fi
 
-        _fzf_complete_kubectl-selectors '--multi' $@
+        _fzf_complete_kubectl-selectors '--multi' "$@"
         return
     fi
 
     if [[ $completing_option =~ '^(-f|--filename)$' ]]; then
         if [[ $last_argument =~ '(-[^-]*f|--filename)$' ]]; then
-            __fzf_generic_path_completion "$prefix" $@ _fzf_compgen_path '' '' ' '
+            __fzf_generic_path_completion "$prefix" "$@" _fzf_compgen_path '' '' ' '
             return
         fi
 
@@ -882,15 +885,15 @@ _fzf_complete_kubectl() {
         return
     fi
 
-    _fzf_path_completion "$prefix" $@
+    _fzf_path_completion "$prefix" "$@"
 }
 
 _fzf_complete_kubectl-resources() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@ < <(
-        kubectl api-resources --cached --verbs=get ${(Q)${(z)kubectl_arguments}} |
+    _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(
+        kubectl api-resources --cached --verbs=get "${kubectl_arguments[@]}" |
         _fzf_complete_colorize $fg[yellow]
     )
 }
@@ -924,7 +927,7 @@ _fzf_complete_kubectl-resource-names() {
     fi
 
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
-        local result=$(kubectl get "$resource" -o wide ${(Q)${(z)kubectl_arguments}} 2> /dev/null)
+        local result=$(kubectl get "$resource" -o wide "${kubectl_arguments[@]}" 2> /dev/null)
         if [[ $result = NAMESPACE\ * ]]; then
             _fzf_complete_colorize $fg[green] $fg[yellow] | awk '{ print SUBSEP $0 }'
         else
@@ -962,8 +965,8 @@ _fzf_complete_kubectl-containers() {
 
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
         echo NAME IMAGE
-        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{range ..initContainers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
-        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{range ..containers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
+        kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..initContainers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
+        kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range ..containers[*]}{.name} {.image}{"\n"}{end}' 2> /dev/null
     } | _fzf_complete_tabularize $fg[yellow])
 }
 
@@ -981,7 +984,7 @@ _fzf_complete_kubectl-ports() {
     shift
 
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
-        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='PORT PROTOCOL NAME{"\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\n"}{end}' 2> /dev/null |
+        kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='PORT PROTOCOL NAME{"\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\n"}{end}' 2> /dev/null |
         awk '{ print $1, $2, $3 }' |
         _fzf_complete_tabularize $fg[yellow] $reset_color
     )
@@ -996,7 +999,7 @@ _fzf_complete_kubectl-annotations() {
     shift
 
     _fzf_complete --ansi --read0 --print0 --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <({
-        kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
+        kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.annotations}' | jq -jr 'to_entries | map("\(.key)=\(.value)") | join("\u0000")'
     } 2> /dev/null)
 }
 
@@ -1021,7 +1024,7 @@ _fzf_complete_kubectl-labels() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUE
-            kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.metadata.labels}' |
+            kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{.metadata.labels}' |
                 jq -r 'to_entries[] | "\(.key) \(.value)"'
         } 2> /dev/null)
     )
@@ -1063,7 +1066,7 @@ _fzf_complete_kubectl-selectors() {
                 echo KEY VALUE
             fi
 
-            kubectl get "${resource:-all}" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.items[*].metadata.labels}' |
+            kubectl get "${resource:-all}" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
                 if [[ $prefix_option = *! ]]; then
                     jq --slurp -r 'map(to_entries[]) | group_by(.key) | map("\(first | .key) \(map(.value) | unique | join(", "))")[]'
                 elif [[ $prefix_option = *= ]] && [[ -n $selector ]]; then
@@ -1101,7 +1104,7 @@ _fzf_complete_kubectl-label-columns() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUES
-            kubectl get "$resource" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{.items[*].metadata.labels}' |
+            kubectl get "$resource" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
                 jq --slurp -r 'map(to_entries[]) | group_by(.key) | map("\(first | .key) \(map(.value) | unique | join(", "))")[]'
         } 2> /dev/null)
     )
@@ -1118,7 +1121,7 @@ _fzf_complete_kubectl-taints() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- $@$prefix_option < <(
         _fzf_complete_tabularize $fg[yellow] $reset_color < <(
             echo KEY VALUE EFFECT
-            kubectl get "$resource" "$name" ${(Q)${(z)kubectl_arguments}} -o jsonpath='{range .spec.taints[*]}{.key} {.value} {.effect}{"\n"}{end}' 2> /dev/null
+            kubectl get "$resource" "$name" "${kubectl_arguments[@]}" -o jsonpath='{range .spec.taints[*]}{.key} {.value} {.effect}{"\n"}{end}' 2> /dev/null
         )
     )
 }

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -26,6 +26,36 @@
     _fzf_complete_kubectl 'kubectl '
 }
 
+@test 'Testing completion: kubectl --namespace "" **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl --namespace "" '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl --namespace "" '
+}
+
+@test 'Testing completion: kubectl -n "" **' {
+    _fzf_complete() {
+        fail '_fzf_complete should not be invoked'
+    }
+
+    _fzf_path_completion() {
+        assert $# equals 2
+        assert $1 same_as ''
+        assert $2 same_as 'kubectl -n "" '
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl -n "" '
+}
+
 @test 'Testing completion: kubectl --namespace=**' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -725,6 +755,43 @@
     _fzf_complete_kubectl 'kubectl scale '
 }
 
+@test 'Testing completion: kubectl scale daemonsets/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'daemonsets'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                    READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR'
+        echo 'default       test-0000000000-00000   1/1     1            1           1d    web          nginx:latest                    app=test'
+        echo 'kube-system   kube-proxy-00000        2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl scale daemonsets/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                    ${reset_color}READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS   IMAGES                          SELECTOR"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000   ${reset_color}1/1     1            1           1d    web          nginx:latest                    app=test"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000        ${reset_color}2/2     2            2           1d    kube-proxy   k8s.gcr.io/kube-proxy:v1.20.5   k8s-app=kube-proxy"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=daemonsets/
+    _fzf_complete_kubectl 'kubectl scale '
+}
+
 @test 'Testing completion: kubectl wait **' {
     kubectl_mock_1() {
         assert $# equals 3
@@ -1063,6 +1130,51 @@
     _fzf_complete_kubectl 'kubectl wait pods '
 }
 
+@test 'Testing completion: kubectl wait pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl wait pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl wait pods '
+}
+
 @test 'Testing completion: kubectl wait pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -1103,6 +1215,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl wait '
+}
+
+@test 'Testing completion: kubectl wait pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl wait pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl wait '
 }
@@ -1526,6 +1683,50 @@
     _fzf_complete_kubectl 'kubectl annotate pods '
 }
 
+@test 'Testing completion: kubectl annotate pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods '
+}
+
 @test 'Testing completion: kubectl annotate pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -1565,6 +1766,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl annotate '
+}
+
+@test 'Testing completion: kubectl annotate pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl annotate pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl annotate '
 }
@@ -1613,6 +1858,51 @@
     _fzf_complete_kubectl 'kubectl annotate pods etcd-minikube '
 }
 
+@test 'Testing completion: kubectl annotate pods etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods etcd-minikube '
+}
+
 @test 'Testing completion: kubectl annotate pods/etcd-minikube ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -1653,6 +1943,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl annotate pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl annotate pods/etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={.metadata.annotations}'
+
+        echo -n '{"cni.projectcalico.org/podIP":"10.0.0.1/32","cni.projectcalico.org/podIPs":"10.0.0.1/32","kubectl.kubernetes.io/restartedAt":"2020-10-01T00:00:00Z","note":"line\\\\nbreaks"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 7
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--tiebreak=index'
+        assert $5 same_as '--multi'
+        assert $6 same_as '--'
+        assert $7 same_as 'kubectl annotate pods/etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 2
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as 'cni.projectcalico.org/podIP=10.0.0.1/32'
+        assert ${actual1[2]} same_as 'cni.projectcalico.org/podIPs=10.0.0.1/32'
+        assert ${actual1[3]} same_as 'kubectl.kubernetes.io/restartedAt=2020-10-01T00:00:00Z'
+        assert ${actual1[4]} same_as 'note=line'
+
+        actual2=(${(0)lines[2]})
+        assert ${#actual2} equals 1
+        assert ${actual2[1]} same_as 'breaks'
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl annotate pods/etcd-minikube '
 }
@@ -1904,6 +2239,50 @@
     _fzf_complete_kubectl 'kubectl apply edit-last-applied pods '
 }
 
+@test 'Testing completion: kubectl apply edit-last-applied pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl apply edit-last-applied pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl apply edit-last-applied pods '
+}
+
 @test 'Testing completion: kubectl apply edit-last-applied pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -1943,6 +2322,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl apply edit-last-applied '
+}
+
+@test 'Testing completion: kubectl apply edit-last-applied pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl apply edit-last-applied pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl apply edit-last-applied '
 }
@@ -2285,6 +2708,51 @@
     _fzf_complete_kubectl 'kubectl apply view-last-applied pods '
 }
 
+@test 'Testing completion: kubectl apply view-last-applied pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl apply view-last-applied pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl apply view-last-applied pods '
+}
+
 @test 'Testing completion: kubectl apply view-last-applied pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -2325,6 +2793,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl apply view-last-applied '
+}
+
+@test 'Testing completion: kubectl apply view-last-applied pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl apply view-last-applied pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl apply view-last-applied '
 }
@@ -2500,6 +3013,50 @@
     _fzf_complete_kubectl 'kubectl autoscale pods '
 }
 
+@test 'Testing completion: kubectl autoscale pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl autoscale pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl autoscale pods '
+}
+
 @test 'Testing completion: kubectl autoscale pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -2539,6 +3096,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl autoscale '
+}
+
+@test 'Testing completion: kubectl autoscale pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl autoscale pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl autoscale '
 }
@@ -2714,6 +3315,50 @@
     _fzf_complete_kubectl 'kubectl edit pods '
 }
 
+@test 'Testing completion: kubectl edit pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl edit pods '
+}
+
 @test 'Testing completion: kubectl edit pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -2753,6 +3398,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl edit '
+}
+
+@test 'Testing completion: kubectl edit pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl edit pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl edit '
 }
@@ -2928,6 +3617,50 @@
     _fzf_complete_kubectl 'kubectl expose pods '
 }
 
+@test 'Testing completion: kubectl expose pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl expose pods '
+}
+
 @test 'Testing completion: kubectl expose pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -2967,6 +3700,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl expose '
+}
+
+@test 'Testing completion: kubectl expose pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl expose pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl expose '
 }
@@ -3142,6 +3919,50 @@
     _fzf_complete_kubectl 'kubectl patch pods '
 }
 
+@test 'Testing completion: kubectl patch pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl patch pods '
+}
+
 @test 'Testing completion: kubectl patch pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -3181,6 +4002,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl patch '
+}
+
+@test 'Testing completion: kubectl patch pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl patch pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl patch '
 }
@@ -4255,6 +5120,51 @@
     _fzf_complete_kubectl 'kubectl delete pods '
 }
 
+@test 'Testing completion: kubectl delete pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl delete pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl delete pods '
+}
+
 @test 'Testing completion: kubectl delete pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -4295,6 +5205,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl delete '
+}
+
+@test 'Testing completion: kubectl delete pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl delete pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl delete '
 }
@@ -4637,6 +5592,51 @@
     _fzf_complete_kubectl 'kubectl describe pods '
 }
 
+@test 'Testing completion: kubectl describe pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl describe pods '
+}
+
 @test 'Testing completion: kubectl describe pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -4677,6 +5677,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl describe '
+}
+
+@test 'Testing completion: kubectl describe pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl describe pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl describe '
 }
@@ -4890,6 +5935,49 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=--selector=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods --selector=** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--namespace'
+        assert $4 same_as ''
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"k8s-app":"kube-proxy"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector='
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
+        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=--selector=
     _fzf_complete_kubectl 'kubectl get pods '
 }
@@ -5393,6 +6481,49 @@
     _fzf_complete_kubectl 'kubectl get pods --selector '
 }
 
+@test 'Testing completion: kubectl get pods --selector ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--namespace'
+        assert $4 same_as ''
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"k8s-app":"kube-proxy"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods --selector '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
+        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl get pods --selector '
+}
+
 @test 'Testing completion: kubectl get pods --selector tier=control-plane --namespace=**' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -5892,6 +7023,49 @@
     _fzf_complete_kubectl 'kubectl get pods -l '
 }
 
+@test 'Testing completion: kubectl get pods -l ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--namespace'
+        assert $4 same_as ''
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"k8s-app":"kube-proxy"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -l '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
+        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl get pods -l '
+}
+
 @test 'Testing completion: kubectl get pods -l tier=control-plane --namespace=**' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -6387,6 +7561,49 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=-l
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
+@test 'Testing completion: kubectl get pods -l** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '--namespace'
+        assert $4 same_as ''
+        assert $5 same_as '-o'
+        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo -n '{"k8s-app":"kube-proxy"}'
+        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods -l'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}component${reset_color}  kube-apiserver"
+        assert ${lines[4]} same_as "${fg[yellow]}component${reset_color}  kube-controller-manager"
+        assert ${lines[5]} same_as "${fg[yellow]}component${reset_color}  kube-scheduler"
+        assert ${lines[6]} same_as "${fg[yellow]}k8s-app  ${reset_color}  kube-proxy"
+        assert ${lines[7]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=-l
     _fzf_complete_kubectl 'kubectl get pods '
 }
@@ -7390,6 +8607,51 @@
     _fzf_complete_kubectl 'kubectl get pods '
 }
 
+@test 'Testing completion: kubectl get pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl get pods '
+}
+
 @test 'Testing completion: kubectl get pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -7430,6 +8692,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl get '
+}
+
+@test 'Testing completion: kubectl get pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl get pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl get '
 }
@@ -7903,6 +9210,48 @@
     _fzf_complete_kubectl 'kubectl exec '
 }
 
+@test 'Testing completion: kubectl exec ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec '
+}
+
 @test 'Testing completion: kubectl exec pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -7940,6 +9289,48 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl exec '
+}
+
+@test 'Testing completion: kubectl exec pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl exec '
 }
@@ -7990,6 +9381,54 @@
     _fzf_complete_kubectl 'kubectl exec etcd-minikube '
 }
 
+@test 'Testing completion: kubectl exec etcd-minikube --container=** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container='
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
 @test 'Testing completion: kubectl exec pods/etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8032,6 +9471,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container=** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container='
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=--container=
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
@@ -8082,6 +9569,54 @@
     _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
 }
 
+@test 'Testing completion: kubectl exec etcd-minikube --container ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube --container '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube --container '
+}
+
 @test 'Testing completion: kubectl exec pods/etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8124,6 +9659,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube --container ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube --container '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube --container '
 }
@@ -8174,6 +9757,54 @@
     _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
 }
 
+@test 'Testing completion: kubectl exec etcd-minikube -c ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube -c '
+}
+
 @test 'Testing completion: kubectl exec pods/etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8216,6 +9847,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube -c '
 }
@@ -8266,6 +9945,54 @@
     _fzf_complete_kubectl 'kubectl exec etcd-minikube '
 }
 
+@test 'Testing completion: kubectl exec etcd-minikube -c** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec etcd-minikube -c'
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec etcd-minikube '
+}
+
 @test 'Testing completion: kubectl exec pods/etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8308,6 +10035,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl exec pods/etcd-minikube -c** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl exec pods/etcd-minikube -c'
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=-c
     _fzf_complete_kubectl 'kubectl exec pods/etcd-minikube '
 }
@@ -8757,6 +10532,50 @@
     _fzf_complete_kubectl 'kubectl label pods '
 }
 
+@test 'Testing completion: kubectl label pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods '
+}
+
 @test 'Testing completion: kubectl label pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -8800,6 +10619,50 @@
     _fzf_complete_kubectl 'kubectl label '
 }
 
+@test 'Testing completion: kubectl label pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl label pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl label '
+}
+
 @test 'Testing completion: kubectl label pods etcd-minikube ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8835,6 +10698,42 @@
     _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
 }
 
+@test 'Testing completion: kubectl label pods etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods etcd-minikube '
+}
+
 @test 'Testing completion: kubectl label pods/etcd-minikube ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -8866,6 +10765,42 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl label pods/etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={.metadata.labels}'
+
+        echo -n '{"component":"etcd","tier":"control-plane"}'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl label pods/etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}KEY      ${reset_color}  VALUE"
+        assert ${lines[2]} same_as "${fg[yellow]}component${reset_color}  etcd"
+        assert ${lines[3]} same_as "${fg[yellow]}tier     ${reset_color}  control-plane"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl label pods/etcd-minikube '
 }
@@ -9545,6 +11480,48 @@
     _fzf_complete_kubectl 'kubectl logs '
 }
 
+@test 'Testing completion: kubectl logs ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs '
+}
+
 @test 'Testing completion: kubectl logs pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -9582,6 +11559,48 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl logs '
+}
+
+@test 'Testing completion: kubectl logs pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 6
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl logs '
 }
@@ -9632,6 +11651,54 @@
     _fzf_complete_kubectl 'kubectl logs etcd-minikube '
 }
 
+@test 'Testing completion: kubectl logs etcd-minikube --container=** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container='
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
 @test 'Testing completion: kubectl logs pods/etcd-minikube --container=** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -9674,6 +11741,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=--container=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container=** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container='
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=--container=
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
@@ -9724,6 +11839,54 @@
     _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
 }
 
+@test 'Testing completion: kubectl logs etcd-minikube --container ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube --container '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube --container '
+}
+
 @test 'Testing completion: kubectl logs pods/etcd-minikube --container ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -9766,6 +11929,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube --container ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube --container '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube --container '
 }
@@ -9816,6 +12027,54 @@
     _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
 }
 
+@test 'Testing completion: kubectl logs etcd-minikube -c ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube -c '
+}
+
 @test 'Testing completion: kubectl logs pods/etcd-minikube -c ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -9858,6 +12117,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube -c '
 }
@@ -9908,6 +12215,54 @@
     _fzf_complete_kubectl 'kubectl logs etcd-minikube '
 }
 
+@test 'Testing completion: kubectl logs etcd-minikube -c** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs etcd-minikube -c'
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs etcd-minikube '
+}
+
 @test 'Testing completion: kubectl logs pods/etcd-minikube -c** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -9950,6 +12305,54 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=-c
+    _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
+}
+
+@test 'Testing completion: kubectl logs pods/etcd-minikube -c** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl logs pods/etcd-minikube -c'
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=-c
     _fzf_complete_kubectl 'kubectl logs pods/etcd-minikube '
 }
@@ -10317,6 +12720,42 @@
     _fzf_complete_kubectl 'kubectl port-forward '
 }
 
+@test 'Testing completion: kubectl port-forward ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
 @test 'Testing completion: kubectl port-forward pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -10352,6 +12791,42 @@
     _fzf_complete_kubectl 'kubectl port-forward '
 }
 
+@test 'Testing completion: kubectl port-forward pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME                      READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'coredns-000000000-00000   1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'coredns-000000000-00001   1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME                      ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "${fg[yellow]}coredns-000000000-00000   ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "${fg[yellow]}coredns-000000000-00001   ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
 @test 'Testing completion: kubectl port-forward services/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -10381,6 +12856,40 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=services/
+    _fzf_complete_kubectl 'kubectl port-forward '
+}
+
+@test 'Testing completion: kubectl port-forward services/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAME       TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR'
+        echo 'kube-dns   ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl port-forward services/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 2
+        assert ${lines[1]} same_as "${fg[yellow]}NAME       ${reset_color}TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE   SELECTOR"
+        assert ${lines[2]} same_as "${fg[yellow]}kube-dns   ${reset_color}ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   1d    k8s-app=kube-dns"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=services/
     _fzf_complete_kubectl 'kubectl port-forward '
 }
@@ -10424,6 +12933,46 @@
     _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
 }
 
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
+}
+
 @test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -10459,6 +13008,46 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
 }
@@ -10502,6 +13091,46 @@
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
 
+@test 'Testing completion: kubectl port-forward services/kube-dns ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward services/kube-dns '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
 @test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -10537,6 +13166,46 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
+}
+
+@test 'Testing completion: kubectl port-forward coredns-000000000-00000 53:** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward coredns-000000000-00000 53:'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=53:
     _fzf_complete_kubectl 'kubectl port-forward coredns-000000000-00000 '
 }
@@ -10580,6 +13249,46 @@
     _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
 }
 
+@test 'Testing completion: kubectl port-forward pods/coredns-000000000-00000 53:** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'coredns-000000000-00000'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo ' 53 UDP dns'
+        echo ' 53 TCP dns-tcp'
+        echo ' 9153 TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward pods/coredns-000000000-00000 53:'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward pods/coredns-000000000-00000 '
+}
+
 @test 'Testing completion: kubectl port-forward services/kube-dns 53:** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -10615,6 +13324,46 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=53:
+    _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
+}
+
+@test 'Testing completion: kubectl port-forward services/kube-dns 53:** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'services'
+        assert $3 same_as 'kube-dns'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath=PORT PROTOCOL NAME{"\\n"}{range ..ports[*]}{.targetPort} {.containerPort} {.protocol} {.name}{"\\n"}{end}'
+
+        echo 'PORT PROTOCOL NAME'
+        echo '53  UDP dns'
+        echo '53  TCP dns-tcp'
+        echo '9153  TCP metrics'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl port-forward services/kube-dns 53:'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}PORT$reset_color  ${reset_color}PROTOCOL$reset_color  NAME"
+        assert ${lines[2]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}UDP     $reset_color  dns"
+        assert ${lines[3]} same_as "${fg[yellow]}53  $reset_color  ${reset_color}TCP     $reset_color  dns-tcp"
+        assert ${lines[4]} same_as "${fg[yellow]}9153$reset_color  ${reset_color}TCP     $reset_color  metrics"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=53:
     _fzf_complete_kubectl 'kubectl port-forward services/kube-dns '
 }
@@ -10816,6 +13565,51 @@
     _fzf_complete_kubectl 'kubectl rollout restart deployments '
 }
 
+@test 'Testing completion: kubectl rollout restart deployments ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl rollout restart deployments '
+}
+
 @test 'Testing completion: kubectl rollout restart deployments/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -10856,6 +13650,51 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=deployments/
+    _fzf_complete_kubectl 'kubectl rollout restart '
+}
+
+@test 'Testing completion: kubectl rollout restart deployments/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'deployments'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl rollout restart deployments/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=deployments/
     _fzf_complete_kubectl 'kubectl rollout restart '
 }
@@ -11218,6 +14057,50 @@
     _fzf_complete_kubectl 'kubectl set env pods '
 }
 
+@test 'Testing completion: kubectl set env pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set env pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set env pods '
+}
+
 @test 'Testing completion: kubectl set env pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -11257,6 +14140,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set env '
+}
+
+@test 'Testing completion: kubectl set env pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set env pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl set env '
 }
@@ -11684,6 +14611,50 @@
     _fzf_complete_kubectl 'kubectl set image pods '
 }
 
+@test 'Testing completion: kubectl set image pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods '
+}
+
 @test 'Testing completion: kubectl set image pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -11723,6 +14694,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set image '
+}
+
+@test 'Testing completion: kubectl set image pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set image pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl set image '
 }
@@ -11774,6 +14789,55 @@
     _fzf_complete_kubectl 'kubectl set image pods etcd-minikube '
 }
 
+@test 'Testing completion: kubectl set image pods etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods etcd-minikube '
+}
+
 @test 'Testing completion: kubectl set image pods/etcd-minikube ** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 6
@@ -11820,6 +14884,56 @@
     prefix=
     _fzf_complete_kubectl 'kubectl set image pods/etcd-minikube '
 }
+
+@test 'Testing completion: kubectl set image pods/etcd-minikube ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..initContainers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'initcontainer busybox:musl'
+    }
+
+    kubectl_mock_2() {
+        assert $# equals 7
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as 'etcd-minikube'
+        assert $4 same_as '--namespace'
+        assert $5 same_as ''
+        assert $6 same_as '-o'
+        assert $7 same_as 'jsonpath={range ..containers[*]}{.name} {.image}{"\\n"}{end}'
+
+        echo 'etcd k8s.gcr.io/etcd:3.4.13-0'
+    }
+
+    _fzf_complete() {
+        assert $# equals 6
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--'
+        assert $6 same_as 'kubectl set image pods/etcd-minikube '
+
+        run cat
+        assert kubectl mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}  IMAGE"
+        assert ${lines[2]} same_as "${fg[yellow]}initcontainer${reset_color}  busybox:musl"
+        assert ${lines[3]} same_as "${fg[yellow]}etcd         ${reset_color}  k8s.gcr.io/etcd:3.4.13-0"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set image pods/etcd-minikube '
+}
+
 
 @test 'Testing completion: kubectl set resources **' {
     kubectl_mock_1() {
@@ -12156,6 +15270,50 @@
     _fzf_complete_kubectl 'kubectl set resources pods '
 }
 
+@test 'Testing completion: kubectl set resources pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set resources pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set resources pods '
+}
+
 @test 'Testing completion: kubectl set resources pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -12195,6 +15353,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set resources '
+}
+
+@test 'Testing completion: kubectl set resources pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set resources pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl set resources '
 }
@@ -12534,6 +15736,50 @@
     _fzf_complete_kubectl 'kubectl set subject pods '
 }
 
+@test 'Testing completion: kubectl set subject pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set subject pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
+    prefix=
+    _fzf_complete_kubectl 'kubectl set subject pods '
+}
+
 @test 'Testing completion: kubectl set subject pods/** --namespace=kube-system' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -12573,6 +15819,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=pods/
+    _fzf_complete_kubectl 'kubectl set subject '
+}
+
+@test 'Testing completion: kubectl set subject pods/** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl set subject pods/'
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=pods/
     _fzf_complete_kubectl 'kubectl set subject '
 }
@@ -13425,6 +16715,50 @@
     }
 
     RBUFFER=' --namespace=kube-system'
+    prefix=
+    _fzf_complete_kubectl 'kubectl top pods '
+}
+
+@test 'Testing completion: kubectl top pods ** --namespace ""' {
+    kubectl_mock_1() {
+        assert $# equals 6
+        assert $1 same_as 'get'
+        assert $2 same_as 'pods'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--namespace'
+        assert $6 same_as ''
+
+        echo 'NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES'
+        echo 'default       test-0000000000-00000              1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>'
+        echo 'kube-system   etcd-minikube                      1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>'
+        echo 'kube-system   kube-apiserver-minikube            1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>'
+        echo 'kube-system   kube-controller-manager-minikube   1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>'
+        echo 'kube-system   kube-proxy-00000                   1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>'
+        echo 'kube-system   kube-scheduler-minikube            1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl top pods '
+
+        run cat
+        assert kubectl mock_times 1
+        assert ${#lines} equals 7
+        assert ${lines[1]} same_as "\x1c${fg[green]}NAMESPACE     $reset_color${fg[yellow]}NAME                               ${reset_color}READY   STATUS    RESTARTS   AGE   IP         NODE       NOMINATED NODE   READINESS GATES"
+        assert ${lines[2]} same_as "\x1c${fg[green]}default       $reset_color${fg[yellow]}test-0000000000-00000              ${reset_color}1/1     Running   0          1d    10.0.0.1   minikube   <none>           <none>"
+        assert ${lines[3]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}etcd-minikube                      ${reset_color}1/1     Running   0          1d    10.0.0.2   minikube   <none>           <none>"
+        assert ${lines[4]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-apiserver-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.3   minikube   <none>           <none>"
+        assert ${lines[5]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-controller-manager-minikube   ${reset_color}1/1     Running   0          1d    10.0.0.4   minikube   <none>           <none>"
+        assert ${lines[6]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-proxy-00000                   ${reset_color}1/1     Running   0          1d    10.0.0.5   minikube   <none>           <none>"
+        assert ${lines[7]} same_as "\x1c${fg[green]}kube-system   $reset_color${fg[yellow]}kube-scheduler-minikube            ${reset_color}1/1     Running   0          1d    10.0.0.6   minikube   <none>           <none>"
+    }
+
+    RBUFFER=' --namespace ""'
     prefix=
     _fzf_complete_kubectl 'kubectl top pods '
 }


### PR DESCRIPTION
This PR fixes a bug in the completions for kubectl where it failed to parse if an empty namespace is given to either a long option without equal-sign (`--namespace ""`) or a short option without use of stacking (`-n ""`).