### PR TITLE
Fix a bug where completion isn't correctly shown when the command used to display it is aliased.

### DIFF
--- a/src/completers/composer.zsh
+++ b/src/completers/composer.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_composer() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 

--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -4,6 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_docker() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_env() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)@}[@]}")
     arguments=($(_fzf_complete_trim_env "${${(q)arguments[2,-1][@]}}"))
     local cmd=${(Q)arguments[1]}

--- a/src/completers/gh.zsh
+++ b/src/completers/gh.zsh
@@ -4,6 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_gh() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local gh_command=${arguments[2]}
     local gh_subcommand=${arguments[3]}

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -57,7 +57,7 @@ PREVIEW_OPTIONS
 )
 
 _fzf_complete_git() {
-    setopt local_options extended_glob
+    setopt local_options extended_glob no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local resolved_commands=()
 

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,6 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local kubectl_arguments=()
     local last_argument=${arguments[-1]}

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_make() {
+    setopt local_options no_aliases
     _fzf_complete_make-target '' "$@"
 }
 

--- a/src/completers/npm.zsh
+++ b/src/completers/npm.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_npm() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 

--- a/src/completers/sudo.zsh
+++ b/src/completers/sudo.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_sudo() {
+    setopt local_options no_aliases
     local args=("${(Q)${(z)@}[@]}")
     local subcommand=${args:1:1}
 

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -14,6 +14,7 @@ _fzf_complete_systemctl() {
 }
 
 _fzf_complete_systemctl-units() {
+    setopt local_options no_aliases
     local fzf_options=$1
     shift
 

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -1,6 +1,7 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_yarn() {
+    setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local subcommand=${arguments[2]}
 


### PR DESCRIPTION
For example, when `git status` is aliased into `git`, which is bizarre, displaying the completion with git commit **<Tab> uses `git status status --porcelain=v1 -z ${(Z+n+)git_options}` for the command getting its items, so it was broken.