### PR TITLE
Show runtime version before testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zsh
       - name: Run unit tests
-        run: tests/test.zsh --tap tests/*.zunit
+        run: |
+          node --version
+          php --version
+          tests/test.zsh --tap tests/*.zunit


### PR DESCRIPTION
In order to make the tests on macos-latest be more stable, this PR tries to eliminate the time to potentially initialize language runtimes like Node.js and PHP by just printing their versions before beginning the tests with timeout being set to 10 seconds.

The following screenshot shows it took ~7s for a runner on GitHub Actions to complete `node --version` and so as `php --version`.

![image](https://user-images.githubusercontent.com/6535425/124755078-e2852680-df65-11eb-876a-91dc72af701a.png)