### PR TITLE
Determine options based on subcommand and determine subcommand based on known global options in kubectl

### DIFF
--- a/src/completers/docker.zsh
+++ b/src/completers/docker.zsh
@@ -49,7 +49,7 @@ _fzf_complete_docker() {
 
     if [[ $subcommand = 'inspect' ]]; then
         local inspect_type
-        inspect_type=($(_fzf_complete_parse_option_arguments '' '--type' '' $arguments || :))
+        inspect_type=($(_fzf_complete_parse_option_arguments '' '--type' '--type' "${arguments[@]}" || :))
         inspect_type=${${${(Q)inspect_type}[-1]}#--type=}
 
         case $inspect_type in

--- a/src/completers/env.zsh
+++ b/src/completers/env.zsh
@@ -3,8 +3,8 @@
 _fzf_complete_env() {
     setopt local_options no_aliases
     local arguments=("${(Q)${(z)@}[@]}")
-    arguments=($(_fzf_complete_trim_env "${${(q)arguments[2,-1][@]}}"))
-    local cmd=${(Q)arguments[1]}
+    arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "${arguments[2,-1]}")"}[@]}")
+    local cmd=${arguments[1]}
 
     if (( $+functions[_fzf_complete_$cmd] )); then
         LBUFFER=${LBUFFER/env /}

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -62,7 +62,7 @@ _fzf_complete_git() {
     local resolved_commands=()
 
     while true; do
-        local resolved=$(_fzf_complete_git_resolve_alias "${(q)arguments[@]}")
+        local resolved=$(_fzf_complete_git_resolve_alias "${arguments[@]}")
         if [[ -z $resolved ]]; then
             break
         fi
@@ -130,7 +130,7 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") || [[ -n $treeish ]]; then
+                if treeish=$(_fzf_complete_parse_argument 3 1 "${(F)git_options_argument_required}" "${arguments[1, ${arguments[(i)--]} - 1][@]}") || [[ -n $treeish ]]; then
                     _fzf_complete_git-files_index '' '--multi' "$@"
                     return
                 fi
@@ -266,7 +266,7 @@ _fzf_complete_git() {
 
             *)
                 local treeish
-                if ! treeish=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}") &&
+                if ! treeish=$(_fzf_complete_parse_argument 3 1 "${(F)git_options_argument_required}" "${arguments[1, ${arguments[(i)--]} - 1][@]}") &&
                     [[ -z $treeish ]] &&
                     [[ -z ${arguments[(r)--]} ]]; then
 
@@ -274,7 +274,7 @@ _fzf_complete_git() {
                     return
                 fi
 
-                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' "${(q)arguments[@]}" > /dev/null; then
+                if _fzf_complete_parse_option '' '--soft --hard --merge --keep' '' "${arguments[@]}" > /dev/null; then
                     return
                 fi
 
@@ -385,7 +385,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if [[ $@ =~ '--multiple' ]] || ! repository=$(_fzf_complete_parse_argument 3 1 "${(F)git_options_argument_required}" "${arguments[@]}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '--multi' "$@"
                     return
                 fi
@@ -473,7 +473,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_parse_argument 3 1 "${(F)git_options_argument_required}" "${arguments[@]}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' "$@"
                     return
                 fi
@@ -528,7 +528,7 @@ _fzf_complete_git() {
 
             *)
                 local repository
-                if ! repository=$(_fzf_complete_parse_argument 3 1 "${${(q)arguments[@]}}" "${(F)git_options_argument_required}") && [[ -z $repository ]]; then
+                if ! repository=$(_fzf_complete_parse_argument 3 1 "${(F)git_options_argument_required}" "${arguments[@]}") && [[ -z $repository ]]; then
                     _fzf_complete_git-repositories '' "$@"
                     return
                 fi
@@ -675,7 +675,7 @@ _fzf_complete_git() {
                 fi
 
                 if [[ -n ${arguments[(r)--]} ]]; then
-                    local args=($(_fzf_complete_parse_argument 3 0 "${${(q)arguments[1, ${arguments[(i)--]} - 1][@]}}" "${(F)git_options_argument_required}"))
+                    local args=($(_fzf_complete_parse_argument 3 0 "${(F)git_options_argument_required}" "${arguments[1, ${arguments[(i)--]} - 1][@]}"))
                     treeish=${args:#*:*}
                     _fzf_complete_git-show-files '--multi' "$@"
                     return

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -6,6 +6,7 @@ colors
 _fzf_complete_kubectl() {
     setopt local_options no_aliases
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
+    local options_and_subcommand=()
     local kubectl_arguments=()
     local last_argument=${arguments[-1]}
     local prefix_option completing_option arg subcommands namespace resource name
@@ -100,7 +101,24 @@ _fzf_complete_kubectl() {
         --v
         --vmodule
     )
-    local kubectl_options_argument_optional=()
+    local kubectl_options_argument_optional=(
+        --add-dir-header
+        --alsologtostderr
+        --disable-root-cgroup-stats
+        --docker-only
+        --docker-tls
+        --enable-load-reader
+        --insecure-skip-tls-verify
+        --log-cadvisor-usage
+        --logtostderr
+        --match-server-version
+        --one-output
+        --skip-headers
+        --skip-log-headers
+        --storage-driver-secure
+        --version
+        --warnings-as-errors
+    )
 
     for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
         if [[ $inherit_option = --* ]]; then
@@ -118,31 +136,19 @@ _fzf_complete_kubectl() {
         fi
     done
 
-    subcommands=($(_fzf_complete_parse_argument 2 1 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
+    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_kubectl_parse_global_options_and_subcommand "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_optional}")"}[@]}")
+    subcommands=("${options_and_subcommand[-1]}")
+    arguments=(
+        "${arguments[1,1][@]}"
+        "${subcommands[1,1][@]}"
+        "${options_and_subcommand[1,-2][@]}"
+        "${arguments[${#options_and_subcommand}+2,-1][@]}"
+    )
+
     namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "$@$RBUFFER" || :)
 
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
         subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-    else
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-    fi
-
-    if [[ $resource = */* ]]; then
-        name=${resource#*/}
-        resource=${resource%/*}
-    elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-        resource=${prefix%/*}
-        prefix_option=${prefix%/*}/
-        prefix=${prefix#$prefix_option}
-    elif [[ ${subcommands[1]} =~ '^(cordon|drain|uncordon)$' ]]; then
-        resource=nodes
-    elif [[ ${subcommands[1]} = 'run' ]]; then
-        resource=pods
-    elif [[ ${subcommands[1]} = 'scale' ]]; then
-        resource=deployments,replicaset,replicationcontrollers,statefulset
     fi
 
     if [[ ${subcommands[1]} = 'annotate' ]]; then
@@ -161,6 +167,18 @@ _fzf_complete_kubectl() {
             --selector
             --template
         )
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -205,6 +223,18 @@ _fzf_complete_kubectl() {
             --template
             --timeout
         )
+
+        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -264,6 +294,18 @@ _fzf_complete_kubectl() {
             --type
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -294,6 +336,20 @@ _fzf_complete_kubectl() {
             --skip-wait-for-delete-timeout
             --timeout
         )
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        else
+            resource=nodes
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -392,6 +448,18 @@ _fzf_complete_kubectl() {
             'serviceaccount'
         )
 
+        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -444,6 +512,20 @@ _fzf_complete_kubectl() {
             --timeout
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        elif [[ ${subcommands[1]} = 'scale' ]]; then
+            resource=deployments,replicaset,replicationcontrollers,statefulset
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -484,6 +566,18 @@ _fzf_complete_kubectl() {
             --pod-running-timeout
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
@@ -511,6 +605,18 @@ _fzf_complete_kubectl() {
 
     if [[ ${subcommands[1]} = 'explain' ]]; then
         kubectl_options_argument_required+=(--api-version)
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -543,6 +649,18 @@ _fzf_complete_kubectl() {
             --selector
             --template
         )
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -583,6 +701,18 @@ _fzf_complete_kubectl() {
             --tail
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
@@ -614,6 +744,18 @@ _fzf_complete_kubectl() {
             --pod-running-timeout
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
@@ -642,6 +784,18 @@ _fzf_complete_kubectl() {
     fi
 
     if [[ ${subcommands[1]} = 'rollout' ]]; then
+        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -695,6 +849,18 @@ _fzf_complete_kubectl() {
             --template
         )
 
+        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -740,6 +906,18 @@ _fzf_complete_kubectl() {
             --template
         )
 
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
+
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
                 prefix_option=$completing_option=
@@ -772,6 +950,18 @@ _fzf_complete_kubectl() {
             --selector
             --sort-by
         )
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -827,6 +1017,20 @@ _fzf_complete_kubectl() {
             --template
             --timeout
         )
+
+        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+
+        if [[ $resource = */* ]]; then
+            name=${resource#*/}
+            resource=${resource%/*}
+        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+            resource=${prefix%/*}
+            prefix_option=${prefix%/*}/
+            prefix=${prefix#$prefix_option}
+        elif [[ ${subcommands[1]} = 'run' ]]; then
+            resource=pods
+        fi
 
         if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
             if [[ $completing_option = --* ]]; then
@@ -1293,4 +1497,46 @@ _fzf_complete_kubectl-taints() {
 
 _fzf_complete_kubectl-taints_post() {
     awk '{ printf "%s%s=%s:%s", (NR > 1 ? "\n" : ""), $1, $2, $3 }'
+}
+
+_fzf_complete_kubectl_parse_global_options_and_subcommand() {
+    local start_index=2
+    local arguments=("${(Q)${(z)1}[@]}")
+    local options_argument_optional=(${(z)2})
+    shift 2
+
+    local i
+    local parsing_argument parsing_subcommand
+    local command_arguments=()
+    for i in {$start_index..${#arguments}}; do
+        if [[ -n $parsing_argument ]]; then
+            parsing_argument=
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        if [[ ${arguments[$i]} = -[A-Za-z0-9] ]] || [[ ${arguments[$i]} = --[A-Za-z0-9-](#c1,) ]]; then
+            if [[ ${options_argument_optional[(r)$arguments[$i]]} = ${arguments[$i]} ]]; then
+                parsing_argument=
+            else
+                parsing_argument=1
+            fi
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        if [[ ${arguments[$i]} = -(#c1,2)* ]]; then
+            parsing_argument=
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        parsing_subcommand=1
+        command_arguments+=("${arguments[$i]}")
+        break
+    done
+
+    if [[ -n $parsing_subcommand ]]; then
+        echo ${(q)command_arguments}
+    fi
 }

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -9,9 +9,8 @@ _fzf_complete_kubectl() {
     local options_and_subcommand=()
     local kubectl_arguments=()
     local last_argument=${arguments[-1]}
-    local prefix_option completing_option arg subcommands namespace resource name
+    local prefix_option completing_option subcommands namespace resource name
 
-    local inherit_option inherit_values
     local kubectl_inherited_options_argument_required=(
         --as
         --as-group
@@ -120,23 +119,7 @@ _fzf_complete_kubectl() {
         --warnings-as-errors
     )
 
-    for inherit_option in ${kubectl_inherited_options_argument_required[@]} ${kubectl_inherited_options[@]}; do
-        if [[ $inherit_option = --* ]]; then
-            for arg in "$arguments" "$RBUFFER"; do
-                if inherit_values=$(_fzf_complete_parse_option_arguments '' "$inherit_option" "${(F)kubectl_options_argument_required}" "$arg"); then
-                    kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
-                fi
-            done
-        else
-            for arg in "$arguments" "$RBUFFER"; do
-                if inherit_values=$(_fzf_complete_parse_option_arguments "$inherit_option" '' "${(F)kubectl_options_argument_required}" "$arg"); then
-                    kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
-                fi
-            done
-        fi
-    done
-
-    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_kubectl_parse_global_options_and_subcommand "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_optional}")"}[@]}")
+    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_kubectl_parse_global_options_and_subcommand "${(F)kubectl_options_argument_optional}" "${arguments[@]}")"}[@]}")
     subcommands=("${options_and_subcommand[-1]}")
     arguments=(
         "${arguments[1,1][@]}"
@@ -145,10 +128,8 @@ _fzf_complete_kubectl() {
         "${arguments[${#options_and_subcommand}+2,-1][@]}"
     )
 
-    namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "$@$RBUFFER" || :)
-
     if [[ ${subcommands[1]} =~ '^(apply|create|rollout|set)$' ]]; then
-        subcommands+=($(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :))
+        subcommands+=($(_fzf_complete_parse_argument 2 2 "${(F)kubectl_options_argument_required}" "${arguments[@]}" || :))
     fi
 
     if [[ ${subcommands[1]} = 'annotate' ]]; then
@@ -168,26 +149,9 @@ _fzf_complete_kubectl() {
             --template
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
@@ -224,26 +188,9 @@ _fzf_complete_kubectl() {
             --timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 3
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]] && [[ ${#subcommands[@]} = 2 ]]; then
             if [[ -z $resource ]]; then
@@ -294,26 +241,9 @@ _fzf_complete_kubectl() {
             --type
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
@@ -337,27 +267,12 @@ _fzf_complete_kubectl() {
             --timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        else
+        if [[ -z $resource ]]; then
             resource=nodes
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
         fi
 
         if [[ -z $completing_option ]]; then
@@ -448,26 +363,9 @@ _fzf_complete_kubectl() {
             'serviceaccount'
         )
 
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 3
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ ${subcommands[2]} = 'job' ]]; then
             if [[ $completing_option = '--from' ]]; then
@@ -512,27 +410,12 @@ _fzf_complete_kubectl() {
             --timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        elif [[ ${subcommands[1]} = 'scale' ]]; then
+        if [[ -z $resource ]] && [[ ${subcommands[1]} = 'scale' ]]; then
             resource=deployments,replicaset,replicationcontrollers,statefulset
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
         fi
 
         if [[ -z $completing_option ]]; then
@@ -566,31 +449,15 @@ _fzf_complete_kubectl() {
             --pod-running-timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
 
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
         fi
 
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             _fzf_complete_kubectl-resource-names '' "$@"
@@ -606,26 +473,9 @@ _fzf_complete_kubectl() {
     if [[ ${subcommands[1]} = 'explain' ]]; then
         kubectl_options_argument_required+=(--api-version)
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             _fzf_complete_kubectl-resources '' "$@"
@@ -650,26 +500,9 @@ _fzf_complete_kubectl() {
             --template
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
@@ -701,31 +534,15 @@ _fzf_complete_kubectl() {
             --tail
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
 
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
         fi
 
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             _fzf_complete_kubectl-resource-names '' "$@"
@@ -744,31 +561,15 @@ _fzf_complete_kubectl() {
             --pod-running-timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
 
         if [[ -z $name ]] && [[ -z $prefix_option ]]; then
             name=$resource
             resource=pods
         fi
 
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $name ]]; then
@@ -784,26 +585,9 @@ _fzf_complete_kubectl() {
     fi
 
     if [[ ${subcommands[1]} = 'rollout' ]]; then
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 3
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ ${#subcommands[@]} != 2 ]]; then
@@ -849,26 +633,9 @@ _fzf_complete_kubectl() {
             --template
         )
 
-        resource=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 4 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 3
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ ${#subcommands[@]} != 2 ]]; then
@@ -906,26 +673,9 @@ _fzf_complete_kubectl() {
             --template
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
@@ -951,26 +701,9 @@ _fzf_complete_kubectl() {
             --sort-by
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
-        fi
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
         if [[ -z $completing_option ]]; then
             if [[ -z $resource ]]; then
@@ -1018,27 +751,12 @@ _fzf_complete_kubectl() {
             --timeout
         )
 
-        resource=$(_fzf_complete_parse_argument 2 2 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
-        name=$(_fzf_complete_parse_argument 2 3 "${${(q)arguments[@]}}" "${(F)kubectl_options_argument_required}" || :)
+        _fzf_complete_kubectl_parse_resource_and_name 2
+        _fzf_complete_kubectl_parse_completing_option
+        _fzf_complete_kubectl_parse_kubectl_arguments
 
-        if [[ $resource = */* ]]; then
-            name=${resource#*/}
-            resource=${resource%/*}
-        elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
-            resource=${prefix%/*}
-            prefix_option=${prefix%/*}/
-            prefix=${prefix#$prefix_option}
-        elif [[ ${subcommands[1]} = 'run' ]]; then
+        if [[ -z $resource ]] && [[ ${subcommands[1]} = 'run' ]]; then
             resource=pods
-        fi
-
-        if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
-            if [[ $completing_option = --* ]]; then
-                prefix_option=$completing_option=
-            else
-                prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
-            fi
-            prefix=${prefix#$prefix_option}
         fi
     fi
 
@@ -1132,7 +850,7 @@ _fzf_complete_kubectl-resource-names() {
     local fzf_options=$1
     shift
 
-    if [[ -z $namespace ]]; then
+    if [[ ${+namespace} = 0 ]]; then
         kubectl_arguments+=(--all-namespaces)
     fi
 
@@ -1248,7 +966,7 @@ _fzf_complete_kubectl-selectors() {
     local fzf_options=$1
     shift
 
-    if [[ -z $namespace ]]; then
+    if [[ ${+namespace} = 0 ]]; then
         kubectl_arguments+=(--all-namespaces)
     fi
 
@@ -1302,7 +1020,7 @@ _fzf_complete_kubectl-field-selectors() {
     local fzf_options=$1
     shift
 
-    if [[ -z $namespace ]]; then
+    if [[ ${+namespace} = 0 ]]; then
         kubectl_arguments+=(--all-namespaces)
     fi
 
@@ -1461,7 +1179,7 @@ _fzf_complete_kubectl-label-columns() {
     local fzf_options=$1
     shift
 
-    if [[ -z $namespace ]]; then
+    if [[ ${+namespace} = 0 ]]; then
         kubectl_arguments+=(--all-namespaces)
     fi
 
@@ -1499,15 +1217,64 @@ _fzf_complete_kubectl-taints_post() {
     awk '{ printf "%s%s=%s:%s", (NR > 1 ? "\n" : ""), $1, $2, $3 }'
 }
 
-_fzf_complete_kubectl_parse_global_options_and_subcommand() {
-    local start_index=2
-    local arguments=("${(Q)${(z)1}[@]}")
-    local options_argument_optional=(${(z)2})
-    shift 2
+_fzf_complete_kubectl_parse_resource_and_name() {
+    local resource_index=$1
+    local name_index=$((resource_index + 1))
+    shift
 
-    local i
-    local parsing_argument parsing_subcommand
+    resource=$(_fzf_complete_parse_argument 2 "$resource_index" "${(F)kubectl_options_argument_required}" "${arguments[@]}" || :)
+    name=$(_fzf_complete_parse_argument 2 "$name_index" "${(F)kubectl_options_argument_required}" "${arguments[@]}" || :)
+
+    if ! namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "${(Q)${(z)RBUFFER}[@]}") && \
+        ! namespace=$(_fzf_complete_parse_option_arguments '-n' '--namespace' "${(F)kubectl_options_argument_required}" "${arguments[@]}"); then
+        unset namespace
+    fi
+
+    if [[ $resource = */* ]]; then
+        name=${resource#*/}
+        resource=${resource%/*}
+    elif [[ -z $resource ]] && [[ $prefix != -* ]] && [[ $prefix = */* ]]; then
+        resource=${prefix%/*}
+        prefix_option=${prefix%/*}/
+        prefix=${prefix#$prefix_option}
+    fi
+}
+
+_fzf_complete_kubectl_parse_completing_option() {
+    if completing_option=$(_fzf_complete_parse_completing_option "$prefix" "$last_argument" "${(F)kubectl_options_argument_required}" "${(F)kubectl_options_argument_optional}"); then
+        if [[ $completing_option = --* ]]; then
+            prefix_option=$completing_option=
+        else
+            prefix_option=${prefix%%${completing_option[-1]}*}${completing_option[-1]}
+        fi
+        prefix=${prefix#$prefix_option}
+    fi
+}
+
+_fzf_complete_kubectl_parse_kubectl_arguments() {
+    local arg inherit_values
+    local all_options=($kubectl_inherited_options_argument_required $kubectl_inherited_options)
+    local shorts=(${all_options:#--*})
+    local longs=(${all_options:#-[a-zA-Z0-9]})
+
+    if inherit_values=$(_fzf_complete_parse_option_arguments "$shorts" "$longs" "${(F)kubectl_options_argument_required}" "${arguments[@]}"); then
+        kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
+    fi
+
+    if inherit_values=$(_fzf_complete_parse_option_arguments "$shorts" "$longs" "${(F)kubectl_options_argument_required}" "${(Q)${(z)RBUFFER}[@]}"); then
+        kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
+    fi
+}
+
+_fzf_complete_kubectl_parse_global_options_and_subcommand() {
+    local options_argument_optional=(${(z)1})
+    shift
+
+    local i parsing_argument parsing_subcommand
     local command_arguments=()
+    local start_index=2
+    local arguments=("$@")
+
     for i in {$start_index..${#arguments}}; do
         if [[ -n $parsing_argument ]]; then
             parsing_argument=

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -1252,7 +1252,7 @@ _fzf_complete_kubectl_parse_completing_option() {
 }
 
 _fzf_complete_kubectl_parse_kubectl_arguments() {
-    local arg inherit_values
+    local inherit_values
     local all_options=($kubectl_inherited_options_argument_required $kubectl_inherited_options)
     local shorts=(${all_options:#--*})
     local longs=(${all_options:#-[a-zA-Z0-9]})

--- a/src/completers/systemctl.zsh
+++ b/src/completers/systemctl.zsh
@@ -20,7 +20,7 @@ _fzf_complete_systemctl-units() {
 
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$@")"}[@]}")
     local systemctl_options=(--full --no-legend --no-pager)
-    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${${(q)arguments[@]}}")) || :
+    systemctl_options+=($(_fzf_complete_parse_option '' '--user --system' '' "${arguments[@]}")) || :
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)${_fzf_complete_preview_systemctl_status/\$SYSTEMCTL_OPTIONS/$systemctl_options}}} ${(Q)${(Z+n+)FZF_DEFAULT_OPTS}} -- "$@" < \
         <({

--- a/src/completers/yarn.zsh
+++ b/src/completers/yarn.zsh
@@ -7,7 +7,7 @@ _fzf_complete_yarn() {
 
     if [[ $subcommand = 'workspace' ]]; then
         local workspace
-        if ! workspace=$(_fzf_complete_parse_argument 3 1 "$arguments" '') && [[ -z $workspace ]]; then
+        if ! workspace=$(_fzf_complete_parse_argument 3 1 '' "${arguments[@]}") && [[ -z $workspace ]]; then
             _fzf_complete_yarn-workspace '' "$@"
             return
         fi

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -47,6 +47,10 @@ _fzf_complete_parse_completing_option() {
     current=$last_argument
 
     while [[ -n $current ]]; do
+        if [[ -n ${options_argument_required[(r)${current[1,2]}]} ]] && (( ${#current} > 2 )); then
+            break
+        fi
+
         if [[ -n ${options_argument_required[(r)$current]} ]]; then
             completing_option=$current
             completing_option_source=last_argument

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -133,7 +133,7 @@ _fzf_complete_parse_option() {
 
         if [[ ${arguments[$i]} = -- ]]; then
             break
-        elif [[ ${arguments[$i]} = -[A-Za-z0-9]* ]]; then
+        elif [[ ${arguments[$i]} = -[^-]* ]]; then
             for j in {$start_index..${#arguments[$i]}}; do
                 if [[ ${options_argument_required[(r)-${arguments[$i][$j]}]} = -${arguments[$i][$j]} ]]; then
                     if [[ $j = ${#arguments[$i]} ]]; then
@@ -152,7 +152,7 @@ _fzf_complete_parse_option() {
                     result+=(-${arguments[$i][$j]})
                 fi
             done
-        elif [[ ${arguments[$i]} = --[A-Za-z0-9]* ]]; then
+        elif [[ ${arguments[$i]} = --[^-]* ]]; then
             if [[ ${options_argument_required[(r)${arguments[$i]}]} = ${arguments[$i]} ]]; then
                 parsing_argument=1
             elif [[ ${longs[(r)${arguments[$i]%%=*}]} = ${arguments[$i]%%=*} ]]; then

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -253,6 +253,214 @@
     _fzf_complete_kubectl 'kubectl '
 }
 
+@test 'Testing completion: kubectl --output=yaml get **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --output=yaml get '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --output=yaml get '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl --output=yaml get '
+}
+
+@test 'Testing completion: kubectl --output yaml get **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --output yaml get '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --output yaml get '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl --output yaml get '
+}
+
+@test 'Testing completion: kubectl -o yaml get **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl -o yaml get '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl -o yaml get '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl -o yaml get '
+}
+
+@test 'Testing completion: kubectl -oyaml get **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl -oyaml get '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl -oyaml get '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl -oyaml get '
+}
+
 @test 'Testing completion: kubectl diff --labels=**' {
     kubectl_mock_1() {
         assert $# equals 5
@@ -6921,6 +7129,214 @@
 
     prefix=
     _fzf_complete_kubectl 'kubectl get '
+}
+
+@test 'Testing completion: kubectl get --output=yaml **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get --output=yaml '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get --output=yaml '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get --output=yaml '
+}
+
+@test 'Testing completion: kubectl get --output yaml **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get --output yaml '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get --output yaml '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get --output yaml '
+}
+
+@test 'Testing completion: kubectl get -o yaml **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get -o yaml '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get -o yaml '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get -o yaml '
+}
+
+@test 'Testing completion: kubectl get -oyaml **' {
+    kubectl_mock_1() {
+        assert $# equals 3
+        assert $1 same_as 'api-resources'
+        assert $2 same_as '--cached'
+        assert $3 same_as '--verbs=get'
+
+        echo 'NAME         SHORTNAMES   APIGROUP                    NAMESPACED   KIND'
+        echo 'configmaps   cm                                       true         ConfigMap'
+        echo 'namespaces   ns                                       false        Namespace'
+        echo 'nodes        no                                       false        Node'
+        echo 'pods         po                                       true         Pod'
+        echo 'secrets                                               true         Secret'
+        echo 'services     svc                                      true         Service'
+        echo 'ingresses    ing          extensions                  true         Ingress'
+        echo 'roles                     rbac.authorization.k8s.io   true         Role'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl get -oyaml '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl get -oyaml '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 9
+        assert ${lines[1]} same_as "${fg[yellow]}NAME         ${reset_color}SHORTNAMES   APIGROUP                    NAMESPACED   KIND"
+        assert ${lines[2]} same_as "${fg[yellow]}configmaps   ${reset_color}cm                                       true         ConfigMap"
+        assert ${lines[3]} same_as "${fg[yellow]}namespaces   ${reset_color}ns                                       false        Namespace"
+        assert ${lines[4]} same_as "${fg[yellow]}nodes        ${reset_color}no                                       false        Node"
+        assert ${lines[5]} same_as "${fg[yellow]}pods         ${reset_color}po                                       true         Pod"
+        assert ${lines[6]} same_as "${fg[yellow]}secrets      ${reset_color}                                         true         Secret"
+        assert ${lines[7]} same_as "${fg[yellow]}services     ${reset_color}svc                                      true         Service"
+        assert ${lines[8]} same_as "${fg[yellow]}ingresses    ${reset_color}ing          extensions                  true         Ingress"
+        assert ${lines[9]} same_as "${fg[yellow]}roles        ${reset_color}             rbac.authorization.k8s.io   true         Role"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl get -oyaml '
 }
 
 @test 'Testing completion: kubectl get pods **' {


### PR DESCRIPTION
Fixes #147

## _fzf_complete_parse_completing_option

- Fixes a bug where it did not take account of the options that require arguments in `$last_argument`. For example, the following case was incorrectly handled as if it is completing `-l` option (`yaml` is an argument for `-o` option.)
  ```zsh
  _fzf_complete_parse_completing_option '' '-oyaml' '-o -l' ''
  # Incorrect behaviour => -l
  # Correct behaviour =>
  ```

## _fzf_complete_parse_argument

- Changes the order of parameters

## _fzf_complete_parse_option

- Fixes a bug where it did not take account of the options that require arguments. For example, the following case was incorrectly handled as if `-A` option is given (`-AFILE` is an argument for `-f` option.)
  ```zsh
  _fzf_complete_parse_option '-A' '--all-namespaces' '-f --file' kubectl get pods -f -AFILE
  # Incorrect behaviour => -A
  # Correct behaviour => 
  ```

## _fzf_complete_parse_option_arguments

- Supports multiple short/long options to parse out.
- Fixes a bug where it did not take account of the options that require arguments. For example, the following case was incorrectly handled as if `-o` option is given (`-oFILE` is an argument for `-f` option.)
  ```zsh
  _fzf_complete_parse_option_arguments '-o' '--output' '-f --file -o --output' kubectl get pods -f -oFILE POD
  # Incorrect behaviour => '-oFILE'
  # Correct behaviour =>
  ```