### PR TITLE
Show files with according to argument of --source when `git restore --source <tree> **`

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -421,8 +421,9 @@ _fzf_complete_git() {
         _fzf_complete_git_parse_completing_option
 
         if [[ -z $completing_option ]]; then
-            if _fzf_complete_parse_option_arguments '-s' '--source' "${(F)git_options_argument_required}" "${arguments[@]}" > /dev/null; then
-                _fzf_complete_git-files_index '' '--multi' "$@"
+            local restore_source=()
+            if restore_source=($(_fzf_complete_parse_option_arguments '-s' '--source' "${(F)git_options_argument_required}" "${arguments[@]}")); then
+                treeish=${restore_source[-1]#(-s|--source=)} _fzf_complete_git-files_index '' '--multi' "$@"
                 return
             fi
 

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1854,16 +1854,10 @@
     _fzf_complete_git 'git restore '
 }
 
-@test 'Testing completion: git restore --source=HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore --source=another-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore --source=HEAD '
+        assert $1 same_as 'git restore --source=another-branch '
 
         echo 'git'
     }
@@ -1875,7 +1869,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore --source=HEAD '
+        assert $6 same_as 'git restore --source=another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -1898,21 +1892,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore --source=HEAD '
+    _fzf_complete_git 'git restore --source=another-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore --source=HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore --source=another-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore --source=HEAD '
+        assert $1 same_as 'git restore --source=another-branch '
 
         echo 'git'
     }
@@ -1924,7 +1912,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore --source=HEAD '
+        assert $6 same_as 'git restore --source=another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -1947,19 +1935,13 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore --source=HEAD '
+    _fzf_complete_git 'git restore --source=another-branch '
 }
 
-@test 'Testing completion: git restore --source HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore --source another-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore --source HEAD '
+        assert $1 same_as 'git restore --source another-branch '
 
         echo 'git'
     }
@@ -1971,7 +1953,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore --source HEAD '
+        assert $6 same_as 'git restore --source another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -1994,21 +1976,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore --source HEAD '
+    _fzf_complete_git 'git restore --source another-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore --source HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore --source another-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore --source HEAD '
+        assert $1 same_as 'git restore --source another-branch '
 
         echo 'git'
     }
@@ -2020,7 +1996,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore --source HEAD '
+        assert $6 same_as 'git restore --source another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2043,19 +2019,13 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore --source HEAD '
+    _fzf_complete_git 'git restore --source another-branch '
 }
 
-@test 'Testing completion: git restore -s HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore -s another-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -s HEAD '
+        assert $1 same_as 'git restore -s another-branch '
 
         echo 'git'
     }
@@ -2067,7 +2037,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -s HEAD '
+        assert $6 same_as 'git restore -s another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2090,21 +2060,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -s HEAD '
+    _fzf_complete_git 'git restore -s another-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore -s HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore -s another-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -s HEAD '
+        assert $1 same_as 'git restore -s another-branch '
 
         echo 'git'
     }
@@ -2116,7 +2080,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -s HEAD '
+        assert $6 same_as 'git restore -s another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2139,19 +2103,13 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -s HEAD '
+    _fzf_complete_git 'git restore -s another-branch '
 }
 
-@test 'Testing completion: git restore -sHEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore -sanother-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -sHEAD '
+        assert $1 same_as 'git restore -sanother-branch '
 
         echo 'git'
     }
@@ -2163,7 +2121,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -sHEAD '
+        assert $6 same_as 'git restore -sanother-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2186,21 +2144,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -sHEAD '
+    _fzf_complete_git 'git restore -sanother-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore -sHEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore -sanother-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -sHEAD '
+        assert $1 same_as 'git restore -sanother-branch '
 
         echo 'git'
     }
@@ -2212,7 +2164,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -sHEAD '
+        assert $6 same_as 'git restore -sanother-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2235,19 +2187,13 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -sHEAD '
+    _fzf_complete_git 'git restore -sanother-branch '
 }
 
-@test 'Testing completion: git restore -qs HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore -qs another-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -qs HEAD '
+        assert $1 same_as 'git restore -qs another-branch '
 
         echo 'git'
     }
@@ -2259,7 +2205,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -qs HEAD '
+        assert $6 same_as 'git restore -qs another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2282,21 +2228,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -qs HEAD '
+    _fzf_complete_git 'git restore -qs another-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore -qs HEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore -qs another-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -qs HEAD '
+        assert $1 same_as 'git restore -qs another-branch '
 
         echo 'git'
     }
@@ -2308,7 +2248,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -qs HEAD '
+        assert $6 same_as 'git restore -qs another-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2331,19 +2271,13 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -qs HEAD '
+    _fzf_complete_git 'git restore -qs another-branch '
 }
 
-@test 'Testing completion: git restore -qsHEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion: git restore -qsanother-branch **' {
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -qsHEAD '
+        assert $1 same_as 'git restore -qsanother-branch '
 
         echo 'git'
     }
@@ -2355,7 +2289,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -qsHEAD '
+        assert $6 same_as 'git restore -qsanother-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2378,21 +2312,15 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -qsHEAD '
+    _fzf_complete_git 'git restore -qsanother-branch '
 }
 
-@test 'Testing completion in subdirectory: git restore -qsHEAD **' {
-    run git checkout another-branch
-    echo >> ' file3 containing space '
-    echo >> directory2/$'file4\ncontaining\nnewlines'
-    echo >> ' file5 containing space '
-    echo >> directory2/$'file6\ncontaining\nnewlines'
-
+@test 'Testing completion in subdirectory: git restore -qsanother-branch **' {
     cd directory1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'git restore -qsHEAD '
+        assert $1 same_as 'git restore -qsanother-branch '
 
         echo 'git'
     }
@@ -2404,7 +2332,7 @@
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
         assert $5 same_as '--'
-        assert $6 same_as 'git restore -qsHEAD '
+        assert $6 same_as 'git restore -qsanother-branch '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -2427,7 +2355,7 @@
     }
 
     prefix=
-    _fzf_complete_git 'git restore -qsHEAD '
+    _fzf_complete_git 'git restore -qsanother-branch '
 }
 
 @test 'Testing completion: git restore --staged **' {


### PR DESCRIPTION
The files in `HEAD` had been shown until now, but the ones in `<tree>` will be shown.