### PR TITLE
Extend timouts on CI depending on runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+            timeout: 10
+          - os: macos-latest
+            timeout: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -24,6 +26,4 @@ jobs:
           sudo apt-get install -y zsh
       - name: Run unit tests
         run: |
-          node --version
-          php --version
-          tests/test.zsh --tap tests/*.zunit
+          tests/test.zsh --tap --time-limit=${{ matrix.timeout }} tests/*.zunit


### PR DESCRIPTION
macOS runners have been pretty problematic in their degraded performance quite often so I made up my mind to extend timeouts depending on runners.