### PR TITLE
Fix a bug where empty string was inserted when resource selection canceled

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -956,7 +956,7 @@ _fzf_complete_kubectl-resources_post() {
             }
         }
         END {
-            if (resource_suffix == "") {
+            if (NR > 0 && resource_suffix == "") {
                 printf "\n"
             }
         }


### PR DESCRIPTION
Follows up for #201 