### PR TITLE
Detect cf version when completing

### DIFF
--- a/tests/cf.zunit
+++ b/tests/cf.zunit
@@ -93,6 +93,13 @@
 @test 'Testing completion: cf app **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -121,7 +128,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -135,6 +142,13 @@
 
 @test 'Testing completion: TEST1=value1 TEST2=value2 cf app **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -167,7 +181,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -184,6 +198,13 @@
 
 @test 'Testing completion: cf d **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -213,7 +234,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -227,6 +248,13 @@
 
 @test 'Testing completion: cf delete **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -256,7 +284,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -270,6 +298,13 @@
 
 @test 'Testing completion: cf disable-ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -299,7 +334,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -313,6 +348,13 @@
 
 @test 'Testing completion: cf e **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -342,7 +384,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -356,6 +398,13 @@
 
 @test 'Testing completion: cf enable-ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -385,7 +434,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -399,6 +448,13 @@
 
 @test 'Testing completion: cf env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -428,7 +484,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -442,6 +498,13 @@
 
 @test 'Testing completion: cf events **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -471,7 +534,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -485,6 +548,13 @@
 
 @test 'Testing completion: cf get-health-check **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -514,7 +584,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -528,6 +598,13 @@
 
 @test 'Testing completion: cf logs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -557,7 +634,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -571,6 +648,13 @@
 
 @test 'Testing completion: cf rename **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -600,7 +684,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -614,6 +698,13 @@
 
 @test 'Testing completion: cf restage **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -643,7 +734,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -657,6 +748,13 @@
 
 @test 'Testing completion: cf restart **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -686,7 +784,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -700,6 +798,13 @@
 
 @test 'Testing completion: cf rg **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -729,7 +834,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -743,6 +848,13 @@
 
 @test 'Testing completion: cf rs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -772,7 +884,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -786,6 +898,13 @@
 
 @test 'Testing completion: cf sp **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -815,7 +934,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -829,6 +948,13 @@
 
 @test 'Testing completion: cf ssh-enabled **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -858,7 +984,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -872,6 +998,13 @@
 
 @test 'Testing completion: cf st **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -901,7 +1034,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -915,6 +1048,13 @@
 
 @test 'Testing completion: cf start **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -944,7 +1084,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -958,6 +1098,13 @@
 
 @test 'Testing completion: cf stop **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -987,7 +1134,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1001,6 +1148,13 @@
 
 @test 'Testing completion: cf tasks **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1030,7 +1184,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1044,6 +1198,13 @@
 
 @test 'Testing completion: cf v3-delete **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1073,7 +1234,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1087,6 +1248,13 @@
 
 @test 'Testing completion: cf v3-droplets **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1116,7 +1284,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1130,6 +1298,13 @@
 
 @test 'Testing completion: cf v3-env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1159,7 +1334,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1173,6 +1348,13 @@
 
 @test 'Testing completion: cf v3-get-health-check **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1202,7 +1384,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1216,6 +1398,13 @@
 
 @test 'Testing completion: cf v3-packages **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1245,7 +1434,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1259,6 +1448,13 @@
 
 @test 'Testing completion: cf v3-restart **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1288,7 +1484,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1302,6 +1498,13 @@
 
 @test 'Testing completion: cf v3-start **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1331,7 +1534,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1345,6 +1548,13 @@
 
 @test 'Testing completion: cf v3-stop **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1374,7 +1584,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1388,6 +1598,13 @@
 
 @test 'Testing completion: cf add-network-policy **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1417,7 +1634,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1431,6 +1648,13 @@
 
 @test 'Testing completion: cf add-network-policy --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1460,7 +1684,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1474,6 +1698,13 @@
 
 @test 'Testing completion: cf add-network-policy --destination-app **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -1503,7 +1734,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -1517,6 +1748,13 @@
 
 @test 'Testing completion: cf add-network-policy -o org-01 -s space-01 --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -1525,7 +1763,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
@@ -1566,7 +1804,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -1675,7 +1913,7 @@
         }'
     }
 
-    cf_mock_4() {
+    cf_mock_5() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -1754,7 +1992,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 4
+        assert cf mock_times 5
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -1768,6 +2006,13 @@
 
 @test 'Testing completion: cf add-network-policy -s space-01 --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'space'
         assert $2 same_as '--guid'
@@ -1776,7 +2021,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -1885,7 +2130,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -1964,7 +2209,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -1978,6 +2223,13 @@
 
 @test 'Testing completion: cf add-network-policy -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -2006,7 +2258,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -2020,6 +2272,13 @@
 
 @test 'Testing completion: cf add-network-policy -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -2028,7 +2287,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -2095,7 +2354,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -2153,7 +2412,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -2167,6 +2426,13 @@
 
 @test 'Testing completion: cf add-network-policy -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -2195,7 +2461,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -2209,6 +2475,13 @@
 
 @test 'Testing completion: cf add-network-policy -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -2237,7 +2510,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -2251,6 +2524,13 @@
 
 @test 'Testing completion: cf add-network-policy -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -2259,7 +2539,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -2326,7 +2606,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -2384,7 +2664,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -2398,6 +2678,13 @@
 
 @test 'Testing completion: cf add-network-policy -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -2426,7 +2713,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -2440,6 +2727,13 @@
 
 @test 'Testing completion: cf remove-network-policy **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'network-policies'
 
@@ -2467,7 +2761,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}source   ${reset_color}destination   protocol   ports       destination space   destination org"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}app-02        tcp        8080        space-01            org-01"
@@ -2480,6 +2774,13 @@
 
 @test 'Testing completion: cf remove-network-policy --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -2509,7 +2810,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -2523,6 +2824,13 @@
 
 @test 'Testing completion: cf remove-network-policy --destination-app **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -2552,7 +2860,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -2566,6 +2874,13 @@
 
 @test 'Testing completion: cf remove-network-policy -o org-01 -s space-01 --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -2574,7 +2889,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
@@ -2615,7 +2930,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -2724,7 +3039,7 @@
         }'
     }
 
-    cf_mock_4() {
+    cf_mock_5() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -2803,7 +3118,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 4
+        assert cf mock_times 5
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -2817,6 +3132,13 @@
 
 @test 'Testing completion: cf remove-network-policy -s space-01 --destination-app=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'space'
         assert $2 same_as '--guid'
@@ -2825,7 +3147,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -2934,7 +3256,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -3013,7 +3335,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -3027,6 +3349,13 @@
 
 @test 'Testing completion: cf remove-network-policy -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -3055,7 +3384,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -3069,6 +3398,13 @@
 
 @test 'Testing completion: cf remove-network-policy -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -3077,7 +3413,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -3144,7 +3480,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -3202,7 +3538,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -3216,6 +3552,13 @@
 
 @test 'Testing completion: cf remove-network-policy -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -3244,7 +3587,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -3258,6 +3601,13 @@
 
 @test 'Testing completion: cf remove-network-policy -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -3286,7 +3636,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -3300,6 +3650,13 @@
 
 @test 'Testing completion: cf remove-network-policy -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -3308,7 +3665,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -3375,7 +3732,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -3433,7 +3790,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -3447,6 +3804,13 @@
 
 @test 'Testing completion: cf remove-network-policy -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -3475,7 +3839,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -3489,6 +3853,13 @@
 
 @test 'Testing completion: cf bind-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3518,7 +3889,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3532,6 +3903,13 @@
 
 @test 'Testing completion: cf bind-service app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -3562,7 +3940,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -3578,6 +3956,13 @@
 
 @test 'Testing completion: cf bs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3607,7 +3992,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3621,6 +4006,13 @@
 
 @test 'Testing completion: cf bs app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -3651,7 +4043,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -3667,6 +4059,13 @@
 
 @test 'Testing completion: cf unbind-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3696,7 +4095,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3710,6 +4109,13 @@
 
 @test 'Testing completion: cf unbind-service app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -3740,7 +4146,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -3756,6 +4162,13 @@
 
 @test 'Testing completion: cf ub **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3785,7 +4198,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3799,6 +4212,13 @@
 
 @test 'Testing completion: cf ub app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -3829,7 +4249,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -3845,6 +4265,13 @@
 
 @test 'Testing completion: cf copy-source **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3874,7 +4301,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3888,6 +4315,13 @@
 
 @test 'Testing completion: cf copy-source app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -3917,7 +4351,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -3931,6 +4365,13 @@
 
 @test 'Testing completion: cf copy-source -o org-01 -s space-01 app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -3939,7 +4380,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
@@ -3980,7 +4421,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -4089,7 +4530,7 @@
         }'
     }
 
-    cf_mock_4() {
+    cf_mock_5() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -4168,7 +4609,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 4
+        assert cf mock_times 5
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -4182,494 +4623,19 @@
 
 @test 'Testing completion: cf copy-source -s space-01 app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'space'
         assert $2 same_as '--guid'
         assert $3 same_as 'space-01'
 
         echo '00000000-0000-0000-0000-000000000000'
-    }
-
-    cf_mock_2() {
-        assert $# equals 2
-        assert $1 same_as 'curl'
-        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
-
-        echo '{
-           "total_results": 3,
-           "total_pages": 2,
-           "prev_url": null,
-           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
-           "resources": [
-              {
-                 "metadata": {
-                    "guid": "00000000-0000-0000-0000-000000000000",
-                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "app-01",
-                    "production": false,
-                    "space_guid": "00000000-0000-0000-0000-000000000000",
-                    "stack_guid": "00000000-0000-0000-0000-000000000000",
-                    "buildpack": null,
-                    "detected_buildpack": null,
-                    "environment_json": null,
-                    "memory": 1024,
-                    "instances": 3,
-                    "disk_quota": 1024,
-                    "state": "STARTED",
-                    "version": "00000000-0000-0000-0000-000000000000",
-                    "command": null,
-                    "console": false,
-                    "debug": null,
-                    "staging_task_id": null,
-                    "package_state": "PENDING",
-                    "health_check_type": "port",
-                    "health_check_timeout": null,
-                    "staging_failed_reason": null,
-                    "staging_failed_description": null,
-                    "diego": false,
-                    "docker_image": null,
-                    "docker_credentials": {
-                      "username": null,
-                      "password": null
-                    },
-                    "package_updated_at": "2021-01-01T00:00:00Z",
-                    "detected_start_command": "",
-                    "enable_ssh": true,
-                    "ports": null,
-                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
-                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
-                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
-                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
-                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
-                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
-                 }
-              },
-              {
-                 "metadata": {
-                    "guid": "11111111-1111-1111-1111-111111111111",
-                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "app-02",
-                    "production": false,
-                    "space_guid": "00000000-0000-0000-0000-000000000000",
-                    "stack_guid": "00000000-0000-0000-0000-000000000000",
-                    "buildpack": null,
-                    "detected_buildpack": null,
-                    "environment_json": null,
-                    "memory": 512,
-                    "instances": 2,
-                    "disk_quota": 1024,
-                    "state": "STARTED",
-                    "version": "00000000-0000-0000-0000-000000000000",
-                    "command": null,
-                    "console": false,
-                    "debug": null,
-                    "staging_task_id": null,
-                    "package_state": "PENDING",
-                    "health_check_type": "port",
-                    "health_check_timeout": null,
-                    "staging_failed_reason": null,
-                    "staging_failed_description": null,
-                    "diego": false,
-                    "docker_image": null,
-                    "docker_credentials": {
-                      "username": null,
-                      "password": null
-                    },
-                    "package_updated_at": "2021-01-01T00:00:00Z",
-                    "detected_start_command": "",
-                    "enable_ssh": true,
-                    "ports": null,
-                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
-                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
-                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
-                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
-                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
-                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
-                 }
-              }
-           ]
-        }'
-    }
-
-    cf_mock_3() {
-        assert $# equals 2
-        assert $1 same_as 'curl'
-        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
-
-        echo '{
-           "total_results": 3,
-           "total_pages": 2,
-           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
-           "next_url": null,
-           "resources": [
-              {
-                 "metadata": {
-                    "guid": "22222222-2222-2222-2222-222222222222",
-                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "app-03",
-                    "production": false,
-                    "space_guid": "00000000-0000-0000-0000-000000000000",
-                    "stack_guid": "00000000-0000-0000-0000-000000000000",
-                    "buildpack": null,
-                    "detected_buildpack": null,
-                    "environment_json": null,
-                    "memory": 256,
-                    "instances": 1,
-                    "disk_quota": 1024,
-                    "state": "STOPPED",
-                    "version": "00000000-0000-0000-0000-000000000000",
-                    "command": null,
-                    "console": false,
-                    "debug": null,
-                    "staging_task_id": null,
-                    "package_state": "PENDING",
-                    "health_check_type": "port",
-                    "health_check_timeout": null,
-                    "staging_failed_reason": null,
-                    "staging_failed_description": null,
-                    "diego": false,
-                    "docker_image": null,
-                    "docker_credentials": {
-                      "username": null,
-                      "password": null
-                    },
-                    "package_updated_at": "2021-01-01T00:00:00Z",
-                    "detected_start_command": "",
-                    "enable_ssh": true,
-                    "ports": null,
-                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
-                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
-                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
-                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
-                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
-                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
-                 }
-              }
-           ]
-        }'
-    }
-
-    __fzf_extract_command_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'cf copy-source -s space-01 app-01 '
-
-        echo 'cf'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'cf copy-source -s space-01 app-01 '
-
-        run cat
-        assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
-        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
-        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
-        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
-    }
-
-    prefix=
-    _fzf_complete_cf 'cf copy-source -s space-01 app-01 '
-}
-
-@test 'Testing completion: cf copy-source -o **' {
-    cf_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'orgs'
-
-        echo 'Getting orgs as user-01...'
-        echo ''
-        echo 'name'
-        echo 'org-01'
-        echo 'org-02'
-        echo 'org-03'
-    }
-
-    __fzf_extract_command_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'cf copy-source -o '
-
-        echo 'cf'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'cf copy-source -o '
-
-        run cat
-        assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
-        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
-        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
-        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
-    }
-
-    prefix=
-    _fzf_complete_cf 'cf copy-source -o '
-}
-
-@test 'Testing completion: cf copy-source -o org-01 -s **' {
-    cf_mock_1() {
-        assert $# equals 3
-        assert $1 same_as 'org'
-        assert $2 same_as '--guid'
-        assert $3 same_as 'org-01'
-
-        echo '00000000-0000-0000-0000-000000000000'
-    }
-
-    cf_mock_2() {
-        assert $# equals 2
-        assert $1 same_as 'curl'
-        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
-
-        echo '{
-           "total_results": 3,
-           "total_pages": 2,
-           "prev_url": null,
-           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
-           "resources": [
-              {
-                 "metadata": {
-                    "guid": "00000000-0000-0000-0000-000000000000",
-                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "space-01",
-                    "organization_guid": "00000000-0000-0000-0000-000000000000",
-                    "space_quota_definition_guid": null,
-                    "allow_ssh": true,
-                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
-                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
-                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
-                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
-                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
-                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
-                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
-                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
-                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
-                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
-                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
-                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
-                 }
-              },
-              {
-                 "metadata": {
-                    "guid": "11111111-1111-1111-1111-111111111111",
-                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "space-02",
-                    "organization_guid": "00000000-0000-0000-0000-000000000000",
-                    "space_quota_definition_guid": null,
-                    "allow_ssh": true,
-                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
-                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
-                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
-                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
-                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
-                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
-                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
-                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
-                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
-                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
-                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
-                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
-                 }
-              }
-           ]
-        }'
-    }
-
-    cf_mock_3() {
-        assert $# equals 2
-        assert $1 same_as 'curl'
-        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
-
-        echo '{
-           "total_results": 3,
-           "total_pages": 2,
-           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
-           "next_url": null,
-           "resources": [
-              {
-                 "metadata": {
-                    "guid": "22222222-2222-2222-2222-222222222222",
-                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "space-03",
-                    "organization_guid": "00000000-0000-0000-0000-000000000000",
-                    "space_quota_definition_guid": null,
-                    "allow_ssh": true,
-                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
-                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
-                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
-                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
-                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
-                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
-                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
-                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
-                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
-                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
-                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
-                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
-                 }
-              }
-           ]
-        }'
-    }
-
-    __fzf_extract_command_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'cf copy-source -o org-01 -s '
-
-        echo 'cf'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'cf copy-source -o org-01 -s '
-
-        run cat
-        assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
-        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
-        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
-        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
-    }
-
-    prefix=
-    _fzf_complete_cf 'cf copy-source -o org-01 -s '
-}
-
-@test 'Testing completion: cf copy-source -s **' {
-    cf_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'spaces'
-
-        echo 'Getting spaces in org org-01 as user-01...'
-        echo ''
-        echo 'name'
-        echo 'space-01'
-        echo 'space-02'
-        echo 'space-03'
-    }
-
-    __fzf_extract_command_mock_1() {
-        assert $# equals 1
-        assert $1 same_as 'cf copy-source -s '
-
-        echo 'cf'
-    }
-
-    _fzf_complete() {
-        assert $# equals 5
-        assert $1 same_as '--ansi'
-        assert $2 same_as '--tiebreak=index'
-        assert $3 same_as '--header-lines=1'
-        assert $4 same_as '--'
-        assert $5 same_as 'cf copy-source -s '
-
-        run cat
-        assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
-        assert ${#lines} equals 4
-        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
-        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
-        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
-        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
-    }
-
-    prefix=
-    _fzf_complete_cf 'cf copy-source -s '
-}
-
-@test 'Testing completion: cf copy-source -oorg-01 -sspace-01 app-01 **' {
-    cf_mock_1() {
-        assert $# equals 3
-        assert $1 same_as 'org'
-        assert $2 same_as '--guid'
-        assert $3 same_as 'org-01'
-
-        echo '00000000-0000-0000-0000-000000000000'
-    }
-
-    cf_mock_2() {
-        assert $# equals 2
-        assert $1 same_as 'curl'
-        assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
-
-        echo '{
-           "total_results": 1,
-           "total_pages": 1,
-           "prev_url": null,
-           "next_url": null,
-           "resources": [
-              {
-                 "metadata": {
-                    "guid": "00000000-0000-0000-0000-000000000000",
-                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
-                    "created_at": "2021-01-01T00:00:00Z",
-                    "updated_at": "2021-01-01T00:00:00Z"
-                 },
-                 "entity": {
-                    "name": "space-01",
-                    "organization_guid": "00000000-0000-0000-0000-000000000000",
-                    "space_quota_definition_guid": null,
-                    "allow_ssh": true,
-                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
-                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
-                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
-                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
-                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
-                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
-                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
-                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
-                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
-                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
-                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
-                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
-                 }
-              }
-           ]
-        }'
     }
 
     cf_mock_3() {
@@ -4845,7 +4811,7 @@
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
-        assert $1 same_as 'cf copy-source -oorg-01 -sspace-01 app-01 '
+        assert $1 same_as 'cf copy-source -s space-01 app-01 '
 
         echo 'cf'
     }
@@ -4856,7 +4822,7 @@
         assert $2 same_as '--tiebreak=index'
         assert $3 same_as '--header-lines=1'
         assert $4 same_as '--'
-        assert $5 same_as 'cf copy-source -oorg-01 -sspace-01 app-01 '
+        assert $5 same_as 'cf copy-source -s space-01 app-01 '
 
         run cat
         assert __fzf_extract_command mock_times 1
@@ -4869,20 +4835,320 @@
     }
 
     prefix=
-    _fzf_complete_cf 'cf copy-source -oorg-01 -sspace-01 app-01 '
+    _fzf_complete_cf 'cf copy-source -s space-01 app-01 '
 }
 
-@test 'Testing completion: cf copy-source -sspace-01 app-01 **' {
+@test 'Testing completion: cf copy-source -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'orgs'
+
+        echo 'Getting orgs as user-01...'
+        echo ''
+        echo 'name'
+        echo 'org-01'
+        echo 'org-02'
+        echo 'org-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf copy-source -o '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf copy-source -o '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf copy-source -o '
+}
+
+@test 'Testing completion: cf copy-source -o org-01 -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
-        assert $1 same_as 'space'
+        assert $1 same_as 'org'
         assert $2 same_as '--guid'
-        assert $3 same_as 'space-01'
+        assert $3 same_as 'org-01'
 
         echo '00000000-0000-0000-0000-000000000000'
     }
 
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-02",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
+                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
+                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
+                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
+                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
+                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
+                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
+                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
+                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
+                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-03",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
+                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
+                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
+                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
+                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
+                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
+                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
+                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
+                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
+                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf copy-source -o org-01 -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf copy-source -o org-01 -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf copy-source -o org-01 -s '
+}
+
+@test 'Testing completion: cf copy-source -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
     cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'spaces'
+
+        echo 'Getting spaces in org org-01 as user-01...'
+        echo ''
+        echo 'name'
+        echo 'space-01'
+        echo 'space-02'
+        echo 'space-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf copy-source -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf copy-source -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf copy-source -s '
+}
+
+@test 'Testing completion: cf copy-source -oorg-01 -sspace-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
+
+        echo '{
+           "total_results": 1,
+           "total_pages": 1,
+           "prev_url": null,
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
@@ -4991,7 +5257,224 @@
         }'
     }
 
+    cf_mock_5() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-03",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 256,
+                    "instances": 1,
+                    "disk_quota": 1024,
+                    "state": "STOPPED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
+                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
+                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
+                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf copy-source -oorg-01 -sspace-01 app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf copy-source -oorg-01 -sspace-01 app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 5
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf copy-source -oorg-01 -sspace-01 app-01 '
+}
+
+@test 'Testing completion: cf copy-source -sspace-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'space'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'space-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
     cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-01",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 1024,
+                    "instances": 3,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
+                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
+                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
+                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-02",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 512,
+                    "instances": 2,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
+                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
+                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
+                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
@@ -5070,7 +5553,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
@@ -5084,6 +5567,13 @@
 
 @test 'Testing completion: cf copy-source -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -5112,7 +5602,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -5126,6 +5616,13 @@
 
 @test 'Testing completion: cf copy-source -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -5134,7 +5631,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -5201,7 +5698,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -5259,7 +5756,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -5273,6 +5770,13 @@
 
 @test 'Testing completion: cf copy-source -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -5301,7 +5805,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -5315,6 +5819,13 @@
 
 @test 'Testing completion: cf create-app-manifest **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -5344,7 +5855,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5415,6 +5926,13 @@
 @test 'Testing completion: cf f **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -5443,7 +5961,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5457,6 +5975,13 @@
 
 @test 'Testing completion: cf f app-01 -i **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -5496,7 +6021,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -5510,6 +6035,13 @@
 
 @test 'Testing completion: cf f app-01 -i**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -5549,7 +6081,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -5563,6 +6095,13 @@
 
 @test 'Testing completion: cf files **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -5592,7 +6131,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5606,6 +6145,13 @@
 
 @test 'Testing completion: cf files app-01 -i **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -5645,7 +6191,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -5659,6 +6205,13 @@
 
 @test 'Testing completion: cf files app-01 -i**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -5698,7 +6251,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -5712,6 +6265,13 @@
 
 @test 'Testing completion: cf map-route **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -5741,7 +6301,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5755,6 +6315,13 @@
 
 @test 'Testing completion: cf map-route app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -5800,7 +6367,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -5832,6 +6399,13 @@
 @test 'Testing completion: cf unmap-route **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -5860,7 +6434,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5874,6 +6448,13 @@
 
 @test 'Testing completion: cf unmap-route app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -5919,7 +6500,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -5951,6 +6532,13 @@
 @test 'Testing completion: cf p **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -5979,7 +6567,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -5993,6 +6581,13 @@
 
 @test 'Testing completion: cf p -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -6022,7 +6617,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -6037,6 +6632,13 @@
 
 @test 'Testing completion: cf p -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -6066,7 +6668,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -6081,6 +6683,13 @@
 
 @test 'Testing completion: cf p -d **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -6110,7 +6719,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -6126,6 +6735,13 @@
 
 @test 'Testing completion: cf p -d**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -6155,7 +6771,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -6171,6 +6787,13 @@
 
 @test 'Testing completion: cf p -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -6199,7 +6822,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -6212,6 +6835,13 @@
 
 @test 'Testing completion: cf p -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -6240,7 +6870,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -6278,6 +6908,13 @@
 @test 'Testing completion: cf push **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -6306,7 +6943,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6320,6 +6957,13 @@
 
 @test 'Testing completion: cf push -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -6349,7 +6993,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -6364,6 +7008,13 @@
 
 @test 'Testing completion: cf push -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -6393,7 +7044,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -6408,6 +7059,13 @@
 
 @test 'Testing completion: cf push -d **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -6437,7 +7095,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -6453,6 +7111,13 @@
 
 @test 'Testing completion: cf push -d**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -6482,7 +7147,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -6498,6 +7163,13 @@
 
 @test 'Testing completion: cf push -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -6526,7 +7198,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -6539,6 +7211,13 @@
 
 @test 'Testing completion: cf push -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -6567,7 +7246,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -6605,6 +7284,13 @@
 @test 'Testing completion: cf restart-app-instance **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -6633,7 +7319,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6647,6 +7333,13 @@
 
 @test 'Testing completion: cf restart-app-instance app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -6686,7 +7379,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -6700,6 +7393,13 @@
 
 @test 'Testing completion: cf v3-restart-app-instance **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -6729,7 +7429,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6743,6 +7443,13 @@
 
 @test 'Testing completion: cf v3-restart-app-instance app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -6782,7 +7489,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -6796,6 +7503,13 @@
 
 @test 'Testing completion: cf rt **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -6825,7 +7539,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6839,6 +7553,13 @@
 
 @test 'Testing completion: cf run-task **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -6868,7 +7589,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6882,6 +7603,13 @@
 
 @test 'Testing completion: cf se **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -6911,7 +7639,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -6925,6 +7653,13 @@
 
 @test 'Testing completion: cf se app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -6933,7 +7668,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -6997,7 +7732,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7011,6 +7746,13 @@
 
 @test 'Testing completion: cf set-env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7040,7 +7782,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7054,6 +7796,13 @@
 
 @test 'Testing completion: cf set-env app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -7062,7 +7811,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -7126,7 +7875,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7140,6 +7889,13 @@
 
 @test 'Testing completion: cf ue **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7169,7 +7925,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7183,6 +7939,13 @@
 
 @test 'Testing completion: cf ue app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -7191,7 +7954,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -7255,7 +8018,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7269,6 +8032,13 @@
 
 @test 'Testing completion: cf unset-env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7298,7 +8068,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7312,6 +8082,13 @@
 
 @test 'Testing completion: cf unset-env app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -7320,7 +8097,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -7384,7 +8161,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7398,6 +8175,13 @@
 
 @test 'Testing completion: cf v3-set-env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7427,7 +8211,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7441,6 +8225,13 @@
 
 @test 'Testing completion: cf v3-set-env app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -7449,7 +8240,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -7513,7 +8304,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7527,6 +8318,13 @@
 
 @test 'Testing completion: cf v3-unset-env **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7556,7 +8354,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7570,6 +8368,13 @@
 
 @test 'Testing completion: cf v3-unset-env app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'app'
         assert $2 same_as '--guid'
@@ -7578,7 +8383,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/apps/00000000-0000-0000-0000-000000000000/env'
@@ -7642,7 +8447,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 2
+        assert cf mock_times 3
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}  value"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}  value-01"
@@ -7656,6 +8461,13 @@
 
 @test 'Testing completion: cf scale **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7685,7 +8497,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7699,6 +8511,13 @@
 
 @test 'Testing completion: cf v3-scale **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7728,7 +8547,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7742,6 +8561,13 @@
 
 @test 'Testing completion: cf set-health-check **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7771,7 +8597,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7785,6 +8611,13 @@
 
 @test 'Testing completion: cf v3-set-health-check **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7814,7 +8647,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7828,6 +8661,13 @@
 
 @test 'Testing completion: cf ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -7857,7 +8697,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -7871,6 +8711,13 @@
 
 @test 'Testing completion: cf ssh app-01 --app-instance-index=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -7910,7 +8757,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -7924,6 +8771,13 @@
 
 @test 'Testing completion: cf ssh app-01 --app-instance-index **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -7963,7 +8817,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -7977,6 +8831,13 @@
 
 @test 'Testing completion: cf ssh app-01 -i **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8016,7 +8877,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8030,6 +8891,13 @@
 
 @test 'Testing completion: cf ssh app-01 -i**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8069,7 +8937,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8083,6 +8951,13 @@
 
 @test 'Testing completion: cf v3-ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -8112,7 +8987,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -8126,6 +9001,13 @@
 
 @test 'Testing completion: cf v3-ssh app-01 --app-instance-index=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8165,7 +9047,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8179,6 +9061,13 @@
 
 @test 'Testing completion: cf v3-ssh app-01 --app-instance-index **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8218,7 +9107,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8232,6 +9121,13 @@
 
 @test 'Testing completion: cf v3-ssh app-01 -i **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8271,7 +9167,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8285,6 +9181,13 @@
 
 @test 'Testing completion: cf v3-ssh app-01 -i**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'app'
         assert $2 same_as 'app-01'
@@ -8324,7 +9227,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
@@ -8338,6 +9241,13 @@
 
 @test 'Testing completion: cf v3-create-package **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -8367,7 +9277,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -8438,6 +9348,13 @@
 @test 'Testing completion: cf v3-set-droplet **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'apps'
 
         echo 'Getting apps in org org-01 / space space-01 as user-01...'
@@ -8466,7 +9383,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -8480,6 +9397,13 @@
 
 @test 'Testing completion: cf v3-delete **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -8509,7 +9433,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -8548,6 +9472,13 @@
 @test 'Testing completion: cf create-buildpack buildpack-01 /path/to/buildpack **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'buildpacks'
 
         echo 'Getting buildpacks...'
@@ -8576,7 +9507,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -8592,6 +9523,13 @@
 
 @test 'Testing completion: cf delete-buildpack **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -8621,7 +9559,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -8636,6 +9574,13 @@
 
 @test 'Testing completion: cf delete-buildpack -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8664,7 +9609,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8677,6 +9622,13 @@
 
 @test 'Testing completion: cf delete-buildpack -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8705,7 +9657,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8718,6 +9670,13 @@
 
 @test 'Testing completion: cf rename-buildpack **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -8747,7 +9706,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -8762,6 +9721,13 @@
 
 @test 'Testing completion: cf rename-buildpack -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8790,7 +9756,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8803,6 +9769,13 @@
 
 @test 'Testing completion: cf rename-buildpack -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8831,7 +9804,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8844,6 +9817,13 @@
 
 @test 'Testing completion: cf update-buildpack **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -8873,7 +9853,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -8888,6 +9868,13 @@
 
 @test 'Testing completion: cf update-buildpack --assign-stack=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8916,7 +9903,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8929,6 +9916,13 @@
 
 @test 'Testing completion: cf update-buildpack --assign-stack **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8957,7 +9951,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -8970,6 +9964,13 @@
 
 @test 'Testing completion: cf update-buildpack -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -8998,7 +9999,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -9011,6 +10012,13 @@
 
 @test 'Testing completion: cf update-buildpack -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -9039,7 +10047,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -9052,6 +10060,13 @@
 
 @test 'Testing completion: cf update-buildpack -i **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -9081,7 +10096,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -9097,6 +10112,13 @@
 
 @test 'Testing completion: cf update-buildpack -i**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'buildpacks'
 
@@ -9126,7 +10148,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 5
         assert ${lines[1]} same_as "${fg[yellow]}buildpack          ${reset_color}position   enabled   locked   filename                                  stack"
         assert ${lines[2]} same_as "${fg[yellow]}binary_buildpack   ${reset_color}1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3"
@@ -9199,6 +10221,13 @@
 @test 'Testing completion: cf delete-domain **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'domains'
 
         echo 'Getting domains in org org-01 as user-01...'
@@ -9227,7 +10256,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -9243,6 +10272,13 @@
 
 @test 'Testing completion: cf delete-shared-domain **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -9272,7 +10308,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -9288,6 +10324,13 @@
 
 @test 'Testing completion: cf bind-route-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -9333,7 +10376,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -9365,6 +10408,13 @@
 @test 'Testing completion: cf bind-route-service example.com **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'services'
 
         echo 'Getting services in org org-01 / space space-01 as user-01...'
@@ -9394,7 +10444,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -9410,6 +10460,13 @@
 
 @test 'Testing completion: cf brs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -9455,7 +10512,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -9487,6 +10544,13 @@
 @test 'Testing completion: cf brs example.com **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'services'
 
         echo 'Getting services in org org-01 / space space-01 as user-01...'
@@ -9516,7 +10580,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -9532,6 +10596,13 @@
 
 @test 'Testing completion: cf unbind-route-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -9577,7 +10648,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -9609,6 +10680,13 @@
 @test 'Testing completion: cf unbind-route-service example.com **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'services'
 
         echo 'Getting services in org org-01 / space space-01 as user-01...'
@@ -9638,7 +10716,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -9654,6 +10732,13 @@
 
 @test 'Testing completion: cf urs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -9699,7 +10784,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -9731,6 +10816,13 @@
 @test 'Testing completion: cf urs example.com **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'services'
 
         echo 'Getting services in org org-01 / space space-01 as user-01...'
@@ -9760,7 +10852,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -9776,6 +10868,13 @@
 
 @test 'Testing completion: cf check-route host-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -9805,7 +10904,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -9821,6 +10920,13 @@
 
 @test 'Testing completion: cf delete-route **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'routes'
 
@@ -9866,7 +10972,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 21
         assert ${lines[1]} same_as "${fg[green]}space      ${reset_color}${fg[yellow]}host      ${reset_color}${fg[blue]}domain                    ${reset_color}port   path   type   apps     service"
         assert ${lines[2]} same_as "${fg[green]}space-01   ${reset_color}${fg[yellow]}app       ${reset_color}${fg[blue]}example.com               ${reset_color}                     app-01"
@@ -9898,6 +11004,13 @@
 @test 'Testing completion: cf disable-feature-flag **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'feature-flags'
 
         echo 'Retrieving status of all flagged features as user-01...'
@@ -9925,7 +11038,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}features                   ${reset_color}state"
         assert ${lines[2]} same_as "${fg[yellow]}app_scaling                ${reset_color}enabled"
@@ -9939,6 +11052,13 @@
 
 @test 'Testing completion: cf enable-feature-flag **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'feature-flags'
 
@@ -9967,7 +11087,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}features                   ${reset_color}state"
         assert ${lines[2]} same_as "${fg[yellow]}app_scaling                ${reset_color}enabled"
@@ -9981,6 +11101,13 @@
 
 @test 'Testing completion: cf feature-flag **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'feature-flags'
 
@@ -10009,7 +11136,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}features                   ${reset_color}state"
         assert ${lines[2]} same_as "${fg[yellow]}app_scaling                ${reset_color}enabled"
@@ -10023,6 +11150,13 @@
 
 @test 'Testing completion: cf delete-isolation-segment **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'isolation-segments'
 
@@ -10051,7 +11185,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                   ${reset_color}orgs"
         assert ${lines[2]} same_as "${fg[yellow]}shared                 ${reset_color}"
@@ -10064,6 +11198,13 @@
 
 @test 'Testing completion: cf m -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10094,7 +11235,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10107,6 +11248,13 @@
 
 @test 'Testing completion: cf m -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10137,7 +11285,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10150,6 +11298,13 @@
 
 @test 'Testing completion: cf marketplace -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10180,7 +11335,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10193,6 +11348,13 @@
 
 @test 'Testing completion: cf marketplace -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10223,7 +11385,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10236,6 +11398,13 @@
 
 @test 'Testing completion: cf create-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10266,7 +11435,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10279,6 +11448,13 @@
 
 @test 'Testing completion: cf create-service service-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -10309,7 +11485,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -10322,6 +11498,13 @@
 
 @test 'Testing completion: cf create-service -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10349,7 +11532,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10362,6 +11545,13 @@
 
 @test 'Testing completion: cf create-service -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10389,7 +11579,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10402,6 +11592,13 @@
 
 @test 'Testing completion: cf cs **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10432,7 +11629,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10445,6 +11642,13 @@
 
 @test 'Testing completion: cf cs service-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -10475,7 +11679,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -10488,6 +11692,13 @@
 
 @test 'Testing completion: cf cs -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10515,7 +11726,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10528,6 +11739,13 @@
 
 @test 'Testing completion: cf cs -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10555,7 +11773,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10568,6 +11786,13 @@
 
 @test 'Testing completion: cf disable-service-access **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10598,7 +11823,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10611,6 +11836,13 @@
 
 @test 'Testing completion: cf disable-service-access -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10638,7 +11870,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10651,6 +11883,13 @@
 
 @test 'Testing completion: cf disable-service-access -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10678,7 +11917,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10691,6 +11930,13 @@
 
 @test 'Testing completion: cf disable-service-access -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -10719,7 +11965,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -10733,6 +11979,13 @@
 
 @test 'Testing completion: cf disable-service-access -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -10761,7 +12014,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -10775,6 +12028,13 @@
 
 @test 'Testing completion: cf disable-service-access service-01 -p **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -10805,7 +12065,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -10818,6 +12078,13 @@
 
 @test 'Testing completion: cf disable-service-access service-01 -p**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -10848,7 +12115,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -10861,6 +12128,13 @@
 
 @test 'Testing completion: cf enable-service-access **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -10891,7 +12165,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -10904,6 +12178,13 @@
 
 @test 'Testing completion: cf enable-service-access -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10931,7 +12212,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10944,6 +12225,13 @@
 
 @test 'Testing completion: cf enable-service-access -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -10971,7 +12259,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -10984,6 +12272,13 @@
 
 @test 'Testing completion: cf enable-service-access -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11012,7 +12307,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11026,6 +12321,13 @@
 
 @test 'Testing completion: cf enable-service-access -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11054,7 +12356,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11068,6 +12370,13 @@
 
 @test 'Testing completion: cf enable-service-access service-01 -p **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -11098,7 +12407,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -11111,6 +12420,13 @@
 
 @test 'Testing completion: cf enable-service-access service-01 -p**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -11141,7 +12457,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -11154,6 +12470,13 @@
 
 @test 'Testing completion: cf purge-service-offering **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -11184,7 +12507,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -11197,6 +12520,13 @@
 
 @test 'Testing completion: cf purge-service-offering -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -11224,7 +12554,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -11237,6 +12567,13 @@
 
 @test 'Testing completion: cf purge-service-offering -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -11264,7 +12601,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -11277,6 +12614,13 @@
 
 @test 'Testing completion: cf service-access -b **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -11304,7 +12648,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -11317,6 +12661,13 @@
 
 @test 'Testing completion: cf service-access -b**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -11344,7 +12695,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -11357,6 +12708,13 @@
 
 @test 'Testing completion: cf service-access -e **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -11387,7 +12745,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -11400,6 +12758,13 @@
 
 @test 'Testing completion: cf service-access -e**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'marketplace'
 
@@ -11430,7 +12795,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service      ${reset_color}plans              description           broker"
         assert ${lines[2]} same_as "${fg[yellow]}service-01   ${reset_color}plan-01, plan-02   Provides service 01   service-broker-01"
@@ -11443,6 +12808,13 @@
 
 @test 'Testing completion: cf service-access -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11471,7 +12843,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11485,6 +12857,13 @@
 
 @test 'Testing completion: cf service-access -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11513,7 +12892,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11527,6 +12906,13 @@
 
 @test 'Testing completion: cf delete-org **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11555,7 +12941,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11569,6 +12955,13 @@
 
 @test 'Testing completion: cf org **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11597,7 +12990,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11611,6 +13004,13 @@
 
 @test 'Testing completion: cf org-users **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11639,7 +13039,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11653,6 +13053,13 @@
 
 @test 'Testing completion: cf rename-org **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11681,7 +13088,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11695,6 +13102,13 @@
 
 @test 'Testing completion: cf reset-org-default-isolation-segment **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11723,7 +13137,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11737,6 +13151,13 @@
 
 @test 'Testing completion: cf create-domain **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11765,7 +13186,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11779,6 +13200,13 @@
 
 @test 'Testing completion: cf disable-org-isolation **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11807,7 +13235,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11821,6 +13249,13 @@
 
 @test 'Testing completion: cf disable-org-isolation org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'isolation-segments'
 
@@ -11849,7 +13284,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                   ${reset_color}orgs"
         assert ${lines[2]} same_as "${fg[yellow]}shared                 ${reset_color}"
@@ -11862,6 +13297,13 @@
 
 @test 'Testing completion: cf enable-org-isolation **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11890,7 +13332,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11904,6 +13346,13 @@
 
 @test 'Testing completion: cf enable-org-isolation org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'isolation-segments'
 
@@ -11932,7 +13381,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                   ${reset_color}orgs"
         assert ${lines[2]} same_as "${fg[yellow]}shared                 ${reset_color}"
@@ -11945,6 +13394,13 @@
 
 @test 'Testing completion: cf set-org-role user-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -11973,7 +13429,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -11987,6 +13443,13 @@
 
 @test 'Testing completion: cf unset-org-role user-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12015,7 +13478,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12029,6 +13492,13 @@
 
 @test 'Testing completion: cf set-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12057,7 +13527,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12071,6 +13541,13 @@
 
 @test 'Testing completion: cf set-quota org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'quotas'
 
@@ -12100,7 +13577,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}total memory   instance memory   routes   service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}10gb    ${reset_color}10G            unlimited         4000     unlimited           allowed      unlimited       0"
@@ -12114,6 +13591,13 @@
 
 @test 'Testing completion: cf set-space-role user-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12142,7 +13626,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12156,6 +13640,13 @@
 
 @test 'Testing completion: cf set-space-role user-01 org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -12164,7 +13655,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -12231,7 +13722,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -12289,7 +13780,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -12303,6 +13794,13 @@
 
 @test 'Testing completion: cf unset-space-role user-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12331,7 +13829,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12345,6 +13843,13 @@
 
 @test 'Testing completion: cf unset-space-role user-01 org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -12353,7 +13858,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -12420,7 +13925,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -12478,7 +13983,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -12492,6 +13997,13 @@
 
 @test 'Testing completion: cf share-private-domain **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12520,7 +14032,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12534,6 +14046,13 @@
 
 @test 'Testing completion: cf share-private-domain org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -12563,7 +14082,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -12579,6 +14098,13 @@
 
 @test 'Testing completion: cf unshare-private-domain **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12607,7 +14133,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12621,6 +14147,13 @@
 
 @test 'Testing completion: cf unshare-private-domain org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -12650,7 +14183,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -12666,6 +14199,13 @@
 
 @test 'Testing completion: cf space-users **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12694,7 +14234,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12708,6 +14248,13 @@
 
 @test 'Testing completion: cf space-users org-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -12716,7 +14263,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -12783,7 +14330,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -12841,7 +14388,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -12855,6 +14402,13 @@
 
 @test 'Testing completion: cf t -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -12883,7 +14437,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -12897,6 +14451,13 @@
 
 @test 'Testing completion: cf t -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -12905,7 +14466,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -12972,7 +14533,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -13030,7 +14591,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13044,6 +14605,13 @@
 
 @test 'Testing completion: cf t -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -13072,7 +14640,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13086,6 +14654,13 @@
 
 @test 'Testing completion: cf t -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -13114,7 +14689,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -13128,6 +14703,13 @@
 
 @test 'Testing completion: cf t -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -13136,7 +14718,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -13203,7 +14785,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -13261,7 +14843,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13275,6 +14857,13 @@
 
 @test 'Testing completion: cf t -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -13303,7 +14892,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13317,6 +14906,13 @@
 
 @test 'Testing completion: cf target -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -13345,7 +14941,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -13359,6 +14955,13 @@
 
 @test 'Testing completion: cf target -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -13367,7 +14970,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -13434,7 +15037,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -13492,7 +15095,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13506,6 +15109,13 @@
 
 @test 'Testing completion: cf target -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -13534,7 +15144,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13548,6 +15158,13 @@
 
 @test 'Testing completion: cf target -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -13576,7 +15193,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -13590,6 +15207,13 @@
 
 @test 'Testing completion: cf target -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -13598,7 +15222,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -13665,7 +15289,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -13723,7 +15347,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13737,6 +15361,13 @@
 
 @test 'Testing completion: cf target -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -13765,7 +15396,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -13779,6 +15410,13 @@
 
 @test 'Testing completion: cf uninstall-plugin **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'plugins'
 
@@ -13811,7 +15449,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}plugin            ${reset_color}version   command name     command help"
         assert ${lines[2]} same_as "${fg[yellow]}FirehosePlugin    ${reset_color}0.13.0    app-nozzle       Displays messages from the firehose for a given app"
@@ -13827,6 +15465,13 @@
 
 @test 'Testing completion: cf delete-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'quotas'
 
@@ -13856,7 +15501,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}total memory   instance memory   routes   service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}10gb    ${reset_color}10G            unlimited         4000     unlimited           allowed      unlimited       0"
@@ -13870,6 +15515,13 @@
 
 @test 'Testing completion: cf quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'quotas'
 
@@ -13899,7 +15551,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}total memory   instance memory   routes   service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}10gb    ${reset_color}10G            unlimited         4000     unlimited           allowed      unlimited       0"
@@ -13913,6 +15565,13 @@
 
 @test 'Testing completion: cf update-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'quotas'
 
@@ -13942,7 +15601,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}total memory   instance memory   routes   service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}10gb    ${reset_color}10G            unlimited         4000     unlimited           allowed      unlimited       0"
@@ -13956,6 +15615,13 @@
 
 @test 'Testing completion: cf create-shared-domain --router-group=**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'router-groups'
 
@@ -13982,7 +15648,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}name                   ${reset_color}type"
         assert ${lines[2]} same_as "${fg[yellow]}default-router-group   ${reset_color}tcp"
@@ -13994,6 +15660,13 @@
 
 @test 'Testing completion: cf create-shared-domain --router-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'router-groups'
 
@@ -14020,7 +15693,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 2
         assert ${lines[1]} same_as "${fg[yellow]}name                   ${reset_color}type"
         assert ${lines[2]} same_as "${fg[yellow]}default-router-group   ${reset_color}tcp"
@@ -14032,6 +15705,13 @@
 
 @test 'Testing completion: cf bind-running-security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'running-security-groups'
 
@@ -14057,7 +15737,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 1
         assert ${lines[1]} same_as "${fg[yellow]}default_security_group${reset_color}"
     }
@@ -14068,6 +15748,13 @@
 
 @test 'Testing completion: cf unbind-running-security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'running-security-groups'
 
@@ -14093,7 +15780,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 1
         assert ${lines[1]} same_as "${fg[yellow]}default_security_group${reset_color}"
     }
@@ -14104,6 +15791,13 @@
 
 @test 'Testing completion: cf delete-security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'security-groups'
 
@@ -14133,7 +15827,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}name                     organization   space   lifecycle"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}default_security_group   <all>          <all>   running"
@@ -14147,6 +15841,13 @@
 
 @test 'Testing completion: cf security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'security-groups'
 
@@ -14176,7 +15877,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}name                     organization   space   lifecycle"
         assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}default_security_group   <all>          <all>   running"
@@ -14190,6 +15891,13 @@
 
 @test 'Testing completion: cf delete-service-broker **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -14217,7 +15925,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -14230,6 +15938,13 @@
 
 @test 'Testing completion: cf rename-service-broker **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -14257,7 +15972,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -14270,6 +15985,13 @@
 
 @test 'Testing completion: cf update-service-broker **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'service-brokers'
 
@@ -14297,7 +16019,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name                ${reset_color}url"
         assert ${lines[2]} same_as "${fg[yellow]}service-broker-01   ${reset_color}https://service-broker-01.example.com"
@@ -14310,6 +16032,13 @@
 
 @test 'Testing completion: cf delete-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14340,7 +16069,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14356,6 +16085,13 @@
 
 @test 'Testing completion: cf ds **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14386,7 +16122,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14402,6 +16138,13 @@
 
 @test 'Testing completion: cf purge-service-instance **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14432,7 +16175,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14448,6 +16191,13 @@
 
 @test 'Testing completion: cf rename-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14478,7 +16228,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14494,6 +16244,13 @@
 
 @test 'Testing completion: cf service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14524,7 +16281,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14540,6 +16297,13 @@
 
 @test 'Testing completion: cf service-keys **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14570,7 +16334,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14586,6 +16350,13 @@
 
 @test 'Testing completion: cf sk **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14616,7 +16387,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14632,6 +16403,13 @@
 
 @test 'Testing completion: cf create-service-key **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14662,7 +16440,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14678,6 +16456,13 @@
 
 @test 'Testing completion: cf csk **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14708,7 +16493,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14724,6 +16509,13 @@
 
 @test 'Testing completion: cf delete-service-key **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14754,7 +16546,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14770,6 +16562,13 @@
 
 @test 'Testing completion: cf delete-service-key service-instance-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'service-keys'
         assert $2 same_as 'service-instance-01'
@@ -14799,7 +16598,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}"
@@ -14813,6 +16612,13 @@
 
 @test 'Testing completion: cf dsk **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14843,7 +16649,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14859,6 +16665,13 @@
 
 @test 'Testing completion: cf dsk service-instance-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'service-keys'
         assert $2 same_as 'service-instance-01'
@@ -14888,7 +16701,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}"
@@ -14902,6 +16715,13 @@
 
 @test 'Testing completion: cf service-key **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -14932,7 +16752,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -14948,6 +16768,13 @@
 
 @test 'Testing completion: cf service-key service-instance-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'service-keys'
         assert $2 same_as 'service-instance-01'
@@ -14977,7 +16804,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}key-01${reset_color}"
@@ -14991,6 +16818,13 @@
 
 @test 'Testing completion: cf share-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -15021,7 +16855,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -15037,6 +16871,13 @@
 
 @test 'Testing completion: cf share-service -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -15065,7 +16906,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -15079,6 +16920,13 @@
 
 @test 'Testing completion: cf share-service -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -15087,7 +16935,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -15154,7 +17002,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -15212,7 +17060,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15226,6 +17074,13 @@
 
 @test 'Testing completion: cf share-service -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -15254,7 +17109,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15268,6 +17123,13 @@
 
 @test 'Testing completion: cf share-service -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -15296,7 +17158,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -15310,6 +17172,13 @@
 
 @test 'Testing completion: cf share-service -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -15318,7 +17187,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -15385,7 +17254,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -15443,7 +17312,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15457,6 +17326,13 @@
 
 @test 'Testing completion: cf share-service -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -15485,7 +17361,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15499,6 +17375,13 @@
 
 @test 'Testing completion: cf unshare-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -15529,7 +17412,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -15545,6 +17428,13 @@
 
 @test 'Testing completion: cf unshare-service -o **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -15573,7 +17463,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -15587,6 +17477,13 @@
 
 @test 'Testing completion: cf unshare-service -o org-01 -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -15595,7 +17492,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -15662,7 +17559,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -15720,7 +17617,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15734,6 +17631,13 @@
 
 @test 'Testing completion: cf unshare-service -s **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -15762,7 +17666,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15776,6 +17680,13 @@
 
 @test 'Testing completion: cf unshare-service -o**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'orgs'
 
@@ -15804,7 +17715,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
@@ -15818,6 +17729,13 @@
 
 @test 'Testing completion: cf unshare-service -oorg-01 -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 3
         assert $1 same_as 'org'
         assert $2 same_as '--guid'
@@ -15826,7 +17744,7 @@
         echo '00000000-0000-0000-0000-000000000000'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
@@ -15893,7 +17811,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
@@ -15951,7 +17869,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -15965,6 +17883,13 @@
 
 @test 'Testing completion: cf unshare-service -s**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -15993,7 +17918,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16007,6 +17932,13 @@
 
 @test 'Testing completion: cf update-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -16037,7 +17969,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -16053,6 +17985,13 @@
 
 @test 'Testing completion: cf update-service service-instance-01 -p **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/service_instances?q=name:service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -16103,7 +18042,7 @@
         }'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/services/00000000-0000-0000-0000-000000000000'
@@ -16141,7 +18080,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -16172,7 +18111,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -16185,6 +18124,13 @@
 
 @test 'Testing completion: cf update-service service-instance-01 -p**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/service_instances?q=name:service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -16235,7 +18181,7 @@
         }'
     }
 
-    cf_mock_2() {
+    cf_mock_3() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/services/00000000-0000-0000-0000-000000000000'
@@ -16273,7 +18219,7 @@
         }'
     }
 
-    cf_mock_3() {
+    cf_mock_4() {
         assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
@@ -16304,7 +18250,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 3
+        assert cf mock_times 4
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}service ${reset_color}plan   description       free or paid"
         assert ${lines[2]} same_as "${fg[yellow]}plan-01 ${reset_color}       A plan 01         free"
@@ -16317,6 +18263,13 @@
 
 @test 'Testing completion: cf delete-space-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'space-quotas'
 
@@ -16345,7 +18298,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name       ${reset_color}total memory   instance memory   routes      service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}quota-01   ${reset_color}1G             512M              50          unlimited           allowed      unlimited       50"
@@ -16358,6 +18311,13 @@
 
 @test 'Testing completion: cf space-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'space-quotas'
 
@@ -16386,7 +18346,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name       ${reset_color}total memory   instance memory   routes      service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}quota-01   ${reset_color}1G             512M              50          unlimited           allowed      unlimited       50"
@@ -16399,6 +18359,13 @@
 
 @test 'Testing completion: cf update-space-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'space-quotas'
 
@@ -16427,7 +18394,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name       ${reset_color}total memory   instance memory   routes      service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}quota-01   ${reset_color}1G             512M              50          unlimited           allowed      unlimited       50"
@@ -16440,6 +18407,13 @@
 
 @test 'Testing completion: cf allow-space-ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16468,7 +18442,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16482,6 +18456,13 @@
 
 @test 'Testing completion: cf disallow-space-ssh **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16510,7 +18491,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16524,6 +18505,13 @@
 
 @test 'Testing completion: cf rename-space **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16552,7 +18540,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16566,6 +18554,13 @@
 
 @test 'Testing completion: cf reset-space-isolation-segment **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16594,7 +18589,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16608,6 +18603,13 @@
 
 @test 'Testing completion: cf space **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16636,7 +18638,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16650,6 +18652,13 @@
 
 @test 'Testing completion: cf space-ssh-allowed **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16678,7 +18687,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16692,6 +18701,13 @@
 
 @test 'Testing completion: cf create-route **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16720,7 +18736,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16734,6 +18750,13 @@
 
 @test 'Testing completion: cf create-route space-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'domains'
 
@@ -16763,7 +18786,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                      ${reset_color}status   type   details"
         assert ${lines[2]} same_as "${fg[yellow]}example.com               ${reset_color}shared          "
@@ -16779,6 +18802,13 @@
 
 @test 'Testing completion: cf set-space-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16807,7 +18837,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16821,6 +18851,13 @@
 
 @test 'Testing completion: cf set-space-quota space-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'space-quotas'
 
@@ -16849,7 +18886,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name       ${reset_color}total memory   instance memory   routes      service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}quota-01   ${reset_color}1G             512M              50          unlimited           allowed      unlimited       50"
@@ -16862,6 +18899,13 @@
 
 @test 'Testing completion: cf unset-space-quota **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'spaces'
 
@@ -16890,7 +18934,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
         assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
@@ -16904,6 +18948,13 @@
 
 @test 'Testing completion: cf unset-space-quota space-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'space-quotas'
 
@@ -16932,7 +18983,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name       ${reset_color}total memory   instance memory   routes      service instances   paid plans   app instances   route ports"
         assert ${lines[2]} same_as "${fg[yellow]}quota-01   ${reset_color}1G             512M              50          unlimited           allowed      unlimited       50"
@@ -16945,6 +18996,13 @@
 
 @test 'Testing completion: cf stack **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'stacks'
 
@@ -16973,7 +19031,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}name          ${reset_color}description"
         assert ${lines[2]} same_as "${fg[yellow]}windows2016   ${reset_color}Microsoft Windows 2016"
@@ -16986,6 +19044,13 @@
 
 @test 'Testing completion: cf bind-staging-security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'staging-security-groups'
 
@@ -17011,7 +19076,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 1
         assert ${lines[1]} same_as "${fg[yellow]}default_security_group${reset_color}"
     }
@@ -17022,6 +19087,13 @@
 
 @test 'Testing completion: cf unbind-staging-security-group **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'staging-security-groups'
 
@@ -17047,7 +19119,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 1
         assert ${lines[1]} same_as "${fg[yellow]}default_security_group${reset_color}"
     }
@@ -17058,6 +19130,13 @@
 
 @test 'Testing completion: cf terminate-task **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'apps'
 
@@ -17087,7 +19166,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 4
         assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   instances   memory   disk   urls"
         assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           3/3         1G       1G     app-01.example.com"
@@ -17101,6 +19180,13 @@
 
 @test 'Testing completion: cf terminate-task app-01 **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'tasks'
         assert $2 same_as 'app-01'
@@ -17130,7 +19216,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as "${fg[yellow]}id   ${reset_color}name       state       start time                      command"
         assert ${lines[2]} same_as "${fg[yellow]}2    ${reset_color}ffffffff   FAILED      Sat, 01 Jan 2021 00:00:00 UTC   echo foo; sleep 100; echo bar"
@@ -17143,6 +19229,13 @@
 
 @test 'Testing completion: cf update-user-provided-service **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 1
         assert $1 same_as 'services'
 
@@ -17173,7 +19266,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -17189,6 +19282,13 @@
 
 @test 'Testing completion: cf update-user-provided-service user-provided-service-instance-01 -p **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/user_provided_service_instances?q=name:user-provided-service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -17243,7 +19343,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as '{"key-01":"value-01"}'
         assert ${lines[2]} same_as '{"key-02":"value-02"}'
@@ -17256,6 +19356,13 @@
 
 @test 'Testing completion: cf update-user-provided-service user-provided-service-instance-01 -p**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/user_provided_service_instances?q=name:user-provided-service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -17310,7 +19417,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as '{"key-01":"value-01"}'
         assert ${lines[2]} same_as '{"key-02":"value-02"}'
@@ -17380,6 +19487,13 @@
 @test 'Testing completion: cf uups **' {
     cf_mock_1() {
         assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
         assert $1 same_as 'services'
 
         echo 'Getting services in org org-01 / space space-01 as user-01...'
@@ -17409,7 +19523,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 6
         assert ${lines[1]} same_as "${fg[yellow]}name                                ${reset_color}service         plan      bound apps       last operation     broker              upgrade available"
         assert ${lines[2]} same_as "${fg[yellow]}service-instance-01                 ${reset_color}service-01      plan-01   app-01           create succeeded   service-broker-01   "
@@ -17425,6 +19539,13 @@
 
 @test 'Testing completion: cf uups user-provided-service-instance-01 -p **' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/user_provided_service_instances?q=name:user-provided-service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -17479,7 +19600,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as '{"key-01":"value-01"}'
         assert ${lines[2]} same_as '{"key-02":"value-02"}'
@@ -17492,6 +19613,13 @@
 
 @test 'Testing completion: cf uups user-provided-service-instance-01 -p**' {
     cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 6.53.0+8e2b70a4a.2020-10-01'
+    }
+
+    cf_mock_2() {
         assert $# equals 2
         assert $1 same_as 'curl'
         assert $2 same_as '/v2/user_provided_service_instances?q=name:user-provided-service-instance-01&q=organization_guid:00000000-0000-0000-0000-000000000000&q=space_guid:00000000-0000-0000-0000-000000000000'
@@ -17546,7 +19674,7 @@
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert cf mock_times 1
+        assert cf mock_times 2
         assert ${#lines} equals 3
         assert ${lines[1]} same_as '{"key-01":"value-01"}'
         assert ${lines[2]} same_as '{"key-02":"value-02"}'


### PR DESCRIPTION
This PR adds version detection for `cf **<TAB>` as part of supporting the newer version of cf CLI (#174).