### PR TITLE
Add basic support for cf CLI v7/v8

### DIFF
--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -1212,7 +1212,7 @@ _fzf_complete_cf() {
         fi
     fi
 
-    if [[ $subcommand = (delete-service|ds|purge-service-instance|rename-service|service|service-keys|sk) ]]; then
+    if [[ $subcommand = (delete-service|ds|purge-service-instance|rename-service|service|service-keys|sk|upgrade-service) ]]; then
         resource=services
         _fzf_complete_cf-resources '' "$@"
         return

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -377,6 +377,28 @@ _fzf_complete_cf() {
         fi
     fi
 
+    if [[ $subcommand = (revision|rollback) ]]; then
+        cf_options_argument_required+=(
+            --version
+        )
+
+        _fzf_complete_cf_parse_completing_option
+
+        local app
+        if ! app=$(_fzf_complete_parse_argument 2 2 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
+            resource=apps
+            _fzf_complete_cf-resources '' "$@"
+            return
+        fi
+
+        if [[ -n $app ]] && [[ $completing_option = --version ]]; then
+            resource=revisions
+            cf_arguments+=("$app")
+            _fzf_complete_cf-resources '' "$@"
+            return
+        fi
+    fi
+
     if [[ $subcommand = (rt|run-task) ]]; then
         cf_options_argument_required+=(
             -k

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -275,7 +275,7 @@ _fzf_complete_cf() {
 
         if [[ $completing_option = (-e|--offering) ]]; then
             resource=marketplace
-            if [[ -n $service_broker ]]; then
+            if [[ $cf_version != 6 ]] && [[ -n $service_broker ]]; then
                 cf_arguments+=(-b "$service_broker")
             fi
             _fzf_complete_cf-resources '' "$@"
@@ -991,11 +991,11 @@ _fzf_complete_cf() {
                 cf_arguments+=(-s "$service")
             else
                 cf_arguments+=(-e "$service")
-            fi
 
-            local service_broker
-            if service_broker=$(_fzf_complete_parse_option_arguments '-b' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
-                cf_arguments+=(-b "$service_broker")
+                local service_broker
+                if service_broker=$(_fzf_complete_parse_option_arguments '-b' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
+                    cf_arguments+=(-b "$service_broker")
+                fi
             fi
 
             _fzf_complete_cf-resources '' "$@"
@@ -1037,11 +1037,11 @@ _fzf_complete_cf() {
                 cf_arguments+=(-s "$service")
             else
                 cf_arguments+=(-e "$service")
-            fi
 
-            local service_broker
-            if service_broker=$(_fzf_complete_parse_option_arguments '-b' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
-                cf_arguments+=(-b "$service_broker")
+                local service_broker
+                if service_broker=$(_fzf_complete_parse_option_arguments '-b' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
+                    cf_arguments+=(-b "$service_broker")
+                fi
             fi
 
             _fzf_complete_cf-resources '' "$@"

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -932,13 +932,13 @@ _fzf_complete_cf() {
     fi
 
     if [[ $subcommand = (m|marketplace) ]]; then
-        local service_offering=-e
+        local service_offering_option=-e
         if [[ $cf_version = 6 ]]; then
-            service_offering=-s
+            service_offering_option=-s
         fi
 
         cf_options_argument_required+=(
-            $service_offering
+            $service_offering_option
         )
 
         if [[ $cf_version != 6 ]]; then
@@ -949,7 +949,7 @@ _fzf_complete_cf() {
 
         _fzf_complete_cf_parse_completing_option
 
-        if [[ $completing_option = $service_offering ]]; then
+        if [[ $completing_option = $service_offering_option ]]; then
             resource=marketplace
             _fzf_complete_cf-resources '' "$@"
             return

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -1441,7 +1441,11 @@ _fzf_complete_cf-resources_post() {
             awk '{ print $1 }'
         fi
     elif [[ $resource = network-policies ]]; then
-        awk '{ print $1, "--destination-app=" $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
+        if [[ $cf_version = 6 ]]; then
+            awk '{ print $1, "--destination-app=" $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
+        else
+            awk '{ print $1, $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
+        fi
     elif [[ $resource = routes ]]; then
         awk '
             # space + domain + port + type

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -1448,42 +1448,42 @@ _fzf_complete_cf-resources_post() {
         fi
     elif [[ $resource = routes ]]; then
         awk '
-            # space + domain + port + type
-            # space + domain + port + type + apps
-            # space + domain + port + type + service
-            # space + domain + port + type + apps + service
+            # space + domain + port + type/protocol
+            # space + domain + port + type/protocol + apps
+            # space + domain + port + type/protocol + service
+            # space + domain + port + type/protocol + apps + service
             $3 ~ /^[0-9]+$/ {
                 print $2, "--port=" $3
             }
 
-            # space + host + domain
-            # space + host + domain + apps
-            # space + host + domain + service
-            # space + host + domain + apps + serivce
+            # space + host + domain + (protocol)
+            # space + host + domain + (protocol) + apps
+            # space + host + domain + (protocol) + service
+            # space + host + domain + (protocol) + apps + serivce
             NF >= 3 && $2 !~ /\./ && $3 !~ /^[0-9]+$/ && $4 !~ /\// {
                 print $3, "--hostname=" $2
             }
 
-            # space + host + domain + path
-            # space + host + domain + path + apps
-            # space + host + domain + path + service
-            # space + host + domain + path + apps + service
+            # space + host + domain + path + (protocol)
+            # space + host + domain + path + (protocol) + apps
+            # space + host + domain + path + (protocol) + service
+            # space + host + domain + path + (protocol) + apps + service
             NF >= 4 && $2 !~ /\./ && $3 !~ /^[0-9]+$/ && $4 ~ /\// {
                 print $3, "--hostname=" $2, "--path=" $4
             }
 
-            # space + domain + path
-            # space + domain + path + apps
-            # space + domain + path + service
-            # space + domain + path + apps + serivce
+            # space + domain + path + (protocol)
+            # space + domain + path + (protocol) + apps
+            # space + domain + path + (protocol) + service
+            # space + domain + path + (protocol) + apps + serivce
             NF >= 3 && $2 ~ /\./ && $3 ~ /\// {
                 print $2, "--path=" $3
             }
 
-            # space + domain
-            # space + domain + apps
-            # space + domain + service
-            # space + domain + apps + service
+            # space + domain + (protocol)
+            # space + domain + (protocol) + apps
+            # space + domain + (protocol) + service
+            # space + domain + (protocol) + apps + service
             NF >= 2 && $2 ~ /\./ && $3 !~ /\// && $3 !~ /^[0-9]+$/ {
                 print $2
             }

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -25,7 +25,7 @@ _fzf_complete_cf() {
         return
     fi
 
-    if [[ $subcommand = (app|cancel-deployment|d|delete|disable-ssh|e|enable-ssh|env|events|get-health-check|logs|packages|rename|sp|ssh-enabled|st|start|stop|tasks|v3-delete|v3-droplets|v3-env|v3-get-health-check|v3-packages|v3-restart|v3-start|v3-stop) ]]; then
+    if [[ $subcommand = (app|cancel-deployment|d|delete|disable-ssh|droplets|e|enable-ssh|env|events|get-health-check|logs|packages|rename|sp|ssh-enabled|st|start|stop|tasks|v3-delete|v3-droplets|v3-env|v3-get-health-check|v3-packages|v3-restart|v3-start|v3-stop) ]]; then
         resource=apps
         _fzf_complete_cf-resources '' "$@"
         return

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -1591,8 +1591,9 @@ _fzf_complete_cf-resources() {
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         "$cf" "$resource" "${cf_arguments[@]}" 2> /dev/null |
-            awk '
-                NR > 1 && !/^$|^TIP:|^OK$/
+            awk -v resource=$resource '
+                resource == "marketplace" { gsub(/^   /, "") }
+                NR > 1 && !/^$|^TIP:|^broker: |^OK$/
                 /^$/ && count++ { exit }
             ' |
             if [[ $resource = routes ]]; then

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -316,6 +316,7 @@ _fzf_complete_cf() {
 
         if [[ $completing_option = (-b|--buildpack) ]]; then
             resource=buildpacks
+            resource_column=2
             _fzf_complete_cf-resources '' "$@"
             return
         fi
@@ -627,7 +628,6 @@ _fzf_complete_cf() {
         local position
         if ! position=$(_fzf_complete_parse_argument 2 4 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
             resource=buildpacks
-            resource_column=2
             _fzf_complete_cf-resources '' "$@"
             return
         fi
@@ -649,6 +649,7 @@ _fzf_complete_cf() {
         local buildpack
         if ! buildpack=$(_fzf_complete_parse_argument 2 2 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
             resource=buildpacks
+            resource_column=2
             _fzf_complete_cf-resources '' "$@"
             return
         fi
@@ -682,6 +683,7 @@ _fzf_complete_cf() {
         local buildpack
         if ! buildpack=$(_fzf_complete_parse_argument 2 2 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
             resource=buildpacks
+            resource_column=2
             _fzf_complete_cf-resources '' "$@"
             return
         fi
@@ -694,7 +696,6 @@ _fzf_complete_cf() {
 
         if [[ $completing_option = (-i|--position) ]]; then
             resource=buildpacks
-            resource_column=2
             _fzf_complete_cf-resources '' "$@"
             return
         fi
@@ -1482,7 +1483,21 @@ _fzf_complete_cf-resources() {
 }
 
 _fzf_complete_cf-resources_post() {
-    if [[ $resource = marketplace ]]; then
+    if [[ $resource = buildpacks ]]; then
+        if [[ $resource_column = 1 ]]; then
+            if [[ $cf_version != 6 ]]; then
+                awk '{ print $1 }'
+            else
+                awk '{ print $2 }'
+            fi
+        elif [[ $resource_column = 2 ]]; then
+            if [[ $cf_version != 6 ]]; then
+                awk '{ print $2, "--stack=" $3 }'
+            else
+                awk '{ print $1, "-s", $6 }'
+            fi
+        fi
+    elif [[ $resource = marketplace ]]; then
         if [[ -n ${cf_options_argument_required[(r)-b]} ]]; then
             if [[ -n $completing_option ]]; then
                 awk '{ print $1, "-b", $NF }'
@@ -1493,10 +1508,10 @@ _fzf_complete_cf-resources_post() {
             awk '{ print $1 }'
         fi
     elif [[ $resource = network-policies ]]; then
-        if [[ $cf_version = 6 ]]; then
-            awk '{ print $1, "--destination-app=" $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
-        else
+        if [[ $cf_version != 6 ]]; then
             awk '{ print $1, $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
+        else
+            awk '{ print $1, "--destination-app=" $2, "--protocol=" $3, "--port=" $4, "-o", $6, "-s", $5 }'
         fi
     elif [[ $resource = routes ]]; then
         awk '

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -802,7 +802,7 @@ _fzf_complete_cf() {
         fi
     fi
 
-    if [[ $subcommand = delete-route ]]; then
+    if [[ $subcommand = (delete-route|ro|route) ]]; then
         cf_options_argument_required+=(
             --hostname
             -n

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -151,8 +151,8 @@ _fzf_complete_cf() {
 
         local target_app
         if ! target_app=$(_fzf_complete_parse_argument 2 3 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
-            local org_name=$(_fzf_complete_parse_option_arguments '-o' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}")
-            local space_name=$(_fzf_complete_parse_option_arguments '-s' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}")
+            local org_name=$(_fzf_complete_parse_option_arguments '-o' '--organization' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}")
+            local space_name=$(_fzf_complete_parse_option_arguments '-s' '--space' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}")
 
             if [[ -n $space_name ]]; then
                 _fzf_complete_cf-apps-by-org-space '' "$org_name" "$space_name" "$@"
@@ -173,7 +173,7 @@ _fzf_complete_cf() {
         if [[ $completing_option = (-s|--space) ]]; then
             local org_name
 
-            if org_name=$(_fzf_complete_parse_option_arguments '-o' '' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
+            if org_name=$(_fzf_complete_parse_option_arguments '-o' '--organization' "${(F)cf_options_argument_required}" 'argument' "${arguments[@]}"); then
                 _fzf_complete_cf-spaces-by-org '' "$org_name" "$@"
                 return
             fi

--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -25,7 +25,7 @@ _fzf_complete_cf() {
         return
     fi
 
-    if [[ $subcommand = (app|cancel-deployment|d|delete|disable-ssh|e|enable-ssh|env|events|get-health-check|logs|packages|rename|restage|restart|rg|rs|sp|ssh-enabled|st|start|stop|tasks|v3-delete|v3-droplets|v3-env|v3-get-health-check|v3-packages|v3-restart|v3-start|v3-stop) ]]; then
+    if [[ $subcommand = (app|cancel-deployment|d|delete|disable-ssh|e|enable-ssh|env|events|get-health-check|logs|packages|rename|sp|ssh-enabled|st|start|stop|tasks|v3-delete|v3-droplets|v3-env|v3-get-health-check|v3-packages|v3-restart|v3-start|v3-stop) ]]; then
         resource=apps
         _fzf_complete_cf-resources '' "$@"
         return
@@ -334,6 +334,23 @@ _fzf_complete_cf() {
 
         _fzf_path_completion "$prefix" "$@"
         return
+    fi
+
+    if [[ $subcommand = (restage|restart|rg|rs) ]]; then
+        if [[ $cf_version != 6 ]]; then
+            cf_options_argument_required+=(
+                --strategy
+            )
+
+            _fzf_complete_cf_parse_completing_option
+        fi
+
+        local app
+        if ! app=$(_fzf_complete_parse_argument 2 2 "${(F)cf_options_argument_required}" "${arguments[@]}") && [[ -z $completing_option ]]; then
+            resource=apps
+            _fzf_complete_cf-resources '' "$@"
+            return
+        fi
     fi
 
     if [[ $subcommand = (restart-app-instance|v3-restart-app-instance) ]]; then

--- a/src/completers/cf7.zsh
+++ b/src/completers/cf7.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+autoload -U colors
+colors
+
+_fzf_complete_cf7() {
+    _fzf_complete_cf "$@"
+}

--- a/src/completers/cf8.zsh
+++ b/src/completers/cf8.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+autoload -U colors
+colors
+
+_fzf_complete_cf8() {
+    _fzf_complete_cf "$@"
+}

--- a/tests/cf.zunit
+++ b/tests/cf.zunit
@@ -9514,7 +9514,7 @@
         assert ${lines[3]} same_as "${fg[yellow]}go_buildpack       ${reset_color}2          true      true     go-buildpack-cflinuxfs3-v1.9.34.zip       cflinuxfs3"
         assert ${lines[4]} same_as "${fg[yellow]}java_buildpack     ${reset_color}3          true      true     java-buildpack-v4.40.zip                  cflinuxfs3"
         assert ${lines[5]} same_as "${fg[yellow]}nodejs_buildpack   ${reset_color}4          true      true     nodejs-buildpack-cflinuxfs3-v1.7.57.zip   cflinuxfs3"
-        assert $resource_column same_as 2
+        assert $resource_column same_as 1
     }
 
     prefix=
@@ -10103,7 +10103,7 @@
         assert ${lines[3]} same_as "${fg[yellow]}go_buildpack       ${reset_color}2          true      true     go-buildpack-cflinuxfs3-v1.9.34.zip       cflinuxfs3"
         assert ${lines[4]} same_as "${fg[yellow]}java_buildpack     ${reset_color}3          true      true     java-buildpack-v4.40.zip                  cflinuxfs3"
         assert ${lines[5]} same_as "${fg[yellow]}nodejs_buildpack   ${reset_color}4          true      true     nodejs-buildpack-cflinuxfs3-v1.7.57.zip   cflinuxfs3"
-        assert $resource_column same_as 2
+        assert $resource_column same_as 1
     }
 
     prefix=
@@ -10155,7 +10155,7 @@
         assert ${lines[3]} same_as "${fg[yellow]}go_buildpack       ${reset_color}2          true      true     go-buildpack-cflinuxfs3-v1.9.34.zip       cflinuxfs3"
         assert ${lines[4]} same_as "${fg[yellow]}java_buildpack     ${reset_color}3          true      true     java-buildpack-v4.40.zip                  cflinuxfs3"
         assert ${lines[5]} same_as "${fg[yellow]}nodejs_buildpack   ${reset_color}4          true      true     nodejs-buildpack-cflinuxfs3-v1.7.57.zip   cflinuxfs3"
-        assert $resource_column same_as 2
+        assert $resource_column same_as 1
     }
 
     prefix=-i
@@ -20367,25 +20367,55 @@
 
 @test 'Testing post: a resource' {
     input=(
-        'binary_buildpack   1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3'
+        'app-01   started           3/3         1G       1G     app-01.example.com'
     )
 
-    resource=buildpacks
+    resource=apps
     resource_column=1
     run _fzf_complete_cf-resources_post <<< ${(F)input}
 
     assert $state equals 0
     assert ${#lines} equals 1
-    assert ${lines[1]} same_as 'binary_buildpack'
+    assert ${lines[1]} same_as 'app-01'
 }
 
 @test 'Testing post: a resource with resource column' {
     input=(
+        'app-01   started           3/3         1G       1G     app-01.example.com'
+    )
+
+    resource=apps
+    resource_column=6
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'app-01.example.com'
+}
+
+@test 'Testing post: a buildpack name and stack' {
+    input=(
         'binary_buildpack   1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3'
     )
 
+    cf_version=6
     resource=buildpacks
     resource_column=2
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'binary_buildpack -s cflinuxfs3'
+}
+
+@test 'Testing post: a buildpack position' {
+    input=(
+        'binary_buildpack   1          true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip   cflinuxfs3'
+    )
+
+    cf_version=6
+    resource=buildpacks
+    resource_column=1
     run _fzf_complete_cf-resources_post <<< ${(F)input}
 
     assert $state equals 0

--- a/tests/cf.zunit
+++ b/tests/cf.zunit
@@ -11505,12 +11505,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -11557,12 +11555,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -11803,12 +11799,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -11855,12 +11849,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12243,12 +12235,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12295,12 +12285,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12347,12 +12335,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12399,12 +12385,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12793,12 +12777,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12845,12 +12827,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12897,12 +12877,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'
@@ -12949,12 +12927,10 @@
     }
 
     cf_mock_2() {
-        assert $# equals 5
+        assert $# equals 3
         assert $1 same_as 'marketplace'
         assert $2 same_as '-s'
         assert $3 same_as 'service-01'
-        assert $4 same_as '-b'
-        assert $5 same_as 'service-broker-01'
 
         echo 'Getting service plan information for service service-01 as user-01...'
         echo 'OK'

--- a/tests/cf.zunit
+++ b/tests/cf.zunit
@@ -20440,6 +20440,7 @@
         'app-01   app-02        tcp        8080        space-01            org-01'
     )
 
+    cf_version=6
     resource=network-policies
     run _fzf_complete_cf-resources_post <<< ${(F)input}
 

--- a/tests/cf7.zunit
+++ b/tests/cf7.zunit
@@ -1,0 +1,3247 @@
+#!/usr/bin/env zunit
+
+@setup {
+    load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock cf
+    mock _fzf_complete_cf_unknown-subcommand
+    mock __fzf_extract_command
+
+    CF_HOME=tests/_support/cf
+}
+
+@teardown {
+    (unmock cf)
+    (unmock _fzf_complete_cf_app)
+    (unmock _fzf_complete_cf_unknown-subcommand)
+    (unmock __fzf_extract_command)
+}
+
+@test 'Testing completion: cf7 cancel-deployment **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'apps'
+
+        echo 'Getting apps in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name     requested state   processes   routes'
+        echo 'app-01   started           web:3/3     app-01.example.com'
+        echo 'app-02   started           web:2/2     app-02.example.com'
+        echo 'app-03   stopped           web:0/1     app-03.example.com'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf cancel-deployment '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf cancel-deployment '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   processes   routes"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           web:3/3     app-01.example.com"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02   ${reset_color}started           web:2/2     app-02.example.com"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03   ${reset_color}stopped           web:0/1     app-03.example.com"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf cancel-deployment '
+}
+
+@test 'Testing completion: cf7 packages **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'apps'
+
+        echo 'Getting apps in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name     requested state   processes   routes'
+        echo 'app-01   started           web:3/3     app-01.example.com'
+        echo 'app-02   started           web:2/2     app-02.example.com'
+        echo 'app-03   stopped           web:0/1     app-03.example.com'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf packages '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf packages '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   processes   routes"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           web:3/3     app-01.example.com"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02   ${reset_color}started           web:2/2     app-02.example.com"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03   ${reset_color}stopped           web:0/1     app-03.example.com"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf packages '
+}
+
+@test 'Testing completion: cf7 add-network-policy **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'apps'
+
+        echo 'Getting apps in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name     requested state   processes   routes'
+        echo 'app-01   started           web:3/3     app-01.example.com'
+        echo 'app-02   started           web:2/2     app-02.example.com'
+        echo 'app-03   stopped           web:0/1     app-03.example.com'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   processes   routes"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           web:3/3     app-01.example.com"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02   ${reset_color}started           web:2/2     app-02.example.com"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03   ${reset_color}stopped           web:0/1     app-03.example.com"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy '
+}
+
+@test 'Testing completion: cf7 add-network-policy app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'apps'
+
+        echo 'Getting apps in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name     requested state   processes   routes'
+        echo 'app-01   started           web:3/3     app-01.example.com'
+        echo 'app-02   started           web:2/2     app-02.example.com'
+        echo 'app-03   stopped           web:0/1     app-03.example.com'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   processes   routes"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           web:3/3     app-01.example.com"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02   ${reset_color}started           web:2/2     app-02.example.com"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03   ${reset_color}stopped           web:0/1     app-03.example.com"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy app-01 '
+}
+
+@test 'Testing completion: cf7 add-network-policy -o org-01 -s space-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
+
+        echo '{
+           "total_results": 1,
+           "total_pages": 1,
+           "prev_url": null,
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-01",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 1024,
+                    "instances": 3,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
+                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
+                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
+                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-02",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 512,
+                    "instances": 2,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
+                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
+                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
+                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_5() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-03",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 256,
+                    "instances": 1,
+                    "disk_quota": 1024,
+                    "state": "STOPPED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
+                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
+                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
+                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -o org-01 -s space-01 app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -o org-01 -s space-01 app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 5
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy -o org-01 -s space-01 app-01 '
+}
+
+@test 'Testing completion: cf7 add-network-policy -s space-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'space'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'space-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-01",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 1024,
+                    "instances": 3,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
+                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
+                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
+                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-02",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 512,
+                    "instances": 2,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
+                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
+                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
+                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-03",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 256,
+                    "instances": 1,
+                    "disk_quota": 1024,
+                    "state": "STOPPED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
+                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
+                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
+                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -s space-01 app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -s space-01 app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy -s space-01 app-01 '
+}
+
+@test 'Testing completion: cf7 add-network-policy -o **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'orgs'
+
+        echo 'Getting orgs as user-01...'
+        echo ''
+        echo 'name'
+        echo 'org-01'
+        echo 'org-02'
+        echo 'org-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -o '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -o '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy -o '
+}
+
+@test 'Testing completion: cf7 add-network-policy -o org-01 -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-02",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
+                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
+                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
+                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
+                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
+                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
+                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
+                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
+                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
+                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-03",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
+                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
+                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
+                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
+                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
+                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
+                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
+                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
+                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
+                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -o org-01 -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -o org-01 -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy -o org-01 -s '
+}
+
+@test 'Testing completion: cf7 add-network-policy -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'spaces'
+
+        echo 'Getting spaces in org org-01 as user-01...'
+        echo ''
+        echo 'name'
+        echo 'space-01'
+        echo 'space-02'
+        echo 'space-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf add-network-policy -s '
+}
+
+@test 'Testing completion: cf7 add-network-policy -o**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'orgs'
+
+        echo 'Getting orgs as user-01...'
+        echo ''
+        echo 'name'
+        echo 'org-01'
+        echo 'org-02'
+        echo 'org-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -o'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
+    }
+
+    prefix=-o
+    _fzf_complete_cf 'cf add-network-policy '
+}
+
+@test 'Testing completion: cf7 add-network-policy -oorg-01 -s**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-02",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
+                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
+                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
+                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
+                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
+                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
+                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
+                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
+                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
+                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-03",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
+                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
+                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
+                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
+                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
+                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
+                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
+                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
+                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
+                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy -oorg-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -oorg-01 -s'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=-s
+    _fzf_complete_cf 'cf add-network-policy -oorg-01 '
+}
+
+@test 'Testing completion: cf7 add-network-policy -s**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'spaces'
+
+        echo 'Getting spaces in org org-01 as user-01...'
+        echo ''
+        echo 'name'
+        echo 'space-01'
+        echo 'space-02'
+        echo 'space-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf add-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf add-network-policy -s'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=-s
+    _fzf_complete_cf 'cf add-network-policy '
+}
+
+@test 'Testing completion: cf7 remove-network-policy **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'network-policies'
+
+        echo 'Listing network policies in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'source   destination   protocol   ports       destination space   destination org'
+        echo 'app-01   app-02        tcp        8080        space-01            org-01'
+        echo 'app-03   app-04        tcp        8090-8100   space-01            org-01'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}source   ${reset_color}destination   protocol   ports       destination space   destination org"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}app-02        tcp        8080        space-01            org-01"
+        assert ${lines[3]} same_as "${fg[yellow]}app-03   ${reset_color}app-04        tcp        8090-8100   space-01            org-01"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy '
+}
+
+@test 'Testing completion: cf7 remove-network-policy app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'apps'
+
+        echo 'Getting apps in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name     requested state   processes   routes'
+        echo 'app-01   started           web:3/3     app-01.example.com'
+        echo 'app-02   started           web:2/2     app-02.example.com'
+        echo 'app-03   stopped           web:0/1     app-03.example.com'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name     ${reset_color}requested state   processes   routes"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01   ${reset_color}started           web:3/3     app-01.example.com"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02   ${reset_color}started           web:2/2     app-02.example.com"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03   ${reset_color}stopped           web:0/1     app-03.example.com"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy app-01 '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -o org-01 -s space-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces?q=organization_guid:00000000-0000-0000-0000-000000000000&q=name:space-01'
+
+        echo '{
+           "total_results": 1,
+           "total_pages": 1,
+           "prev_url": null,
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-01",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 1024,
+                    "instances": 3,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
+                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
+                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
+                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-02",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 512,
+                    "instances": 2,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
+                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
+                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
+                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_5() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-03",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 256,
+                    "instances": 1,
+                    "disk_quota": 1024,
+                    "state": "STOPPED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
+                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
+                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
+                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -o org-01 -s space-01 app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -o org-01 -s space-01 app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 5
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy -o org-01 -s space-01 app-01 '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -s space-01 app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'space'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'space-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/apps/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-01",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 1024,
+                    "instances": 3,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/00000000-0000-0000-0000-000000000000/routes",
+                    "events_url": "/v2/apps/00000000-0000-0000-0000-000000000000/events",
+                    "service_bindings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/service_bindings",
+                    "route_mappings_url": "/v2/apps/00000000-0000-0000-0000-000000000000/route_mappings"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/apps/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-02",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 512,
+                    "instances": 2,
+                    "disk_quota": 1024,
+                    "state": "STARTED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/11111111-1111-1111-1111-111111111111/routes",
+                    "events_url": "/v2/apps/11111111-1111-1111-1111-111111111111/events",
+                    "service_bindings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/service_bindings",
+                    "route_mappings_url": "/v2/apps/11111111-1111-1111-1111-111111111111/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/apps/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "app-03",
+                    "production": false,
+                    "space_guid": "00000000-0000-0000-0000-000000000000",
+                    "stack_guid": "00000000-0000-0000-0000-000000000000",
+                    "buildpack": null,
+                    "detected_buildpack": null,
+                    "environment_json": null,
+                    "memory": 256,
+                    "instances": 1,
+                    "disk_quota": 1024,
+                    "state": "STOPPED",
+                    "version": "00000000-0000-0000-0000-000000000000",
+                    "command": null,
+                    "console": false,
+                    "debug": null,
+                    "staging_task_id": null,
+                    "package_state": "PENDING",
+                    "health_check_type": "port",
+                    "health_check_timeout": null,
+                    "staging_failed_reason": null,
+                    "staging_failed_description": null,
+                    "diego": false,
+                    "docker_image": null,
+                    "docker_credentials": {
+                      "username": null,
+                      "password": null
+                    },
+                    "package_updated_at": "2021-01-01T00:00:00Z",
+                    "detected_start_command": "",
+                    "enable_ssh": true,
+                    "ports": null,
+                    "space_url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "stack_url": "/v2/stacks/00000000-0000-0000-0000-000000000000",
+                    "routes_url": "/v2/apps/22222222-2222-2222-2222-222222222222/routes",
+                    "events_url": "/v2/apps/22222222-2222-2222-2222-222222222222/events",
+                    "service_bindings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/service_bindings",
+                    "route_mappings_url": "/v2/apps/22222222-2222-2222-2222-222222222222/route_mappings"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -s space-01 app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -s space-01 app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name  ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}app-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}app-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}app-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy -s space-01 app-01 '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -o **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'orgs'
+
+        echo 'Getting orgs as user-01...'
+        echo ''
+        echo 'name'
+        echo 'org-01'
+        echo 'org-02'
+        echo 'org-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -o '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -o '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy -o '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -o org-01 -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-02",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
+                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
+                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
+                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
+                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
+                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
+                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
+                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
+                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
+                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-03",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
+                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
+                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
+                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
+                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
+                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
+                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
+                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
+                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
+                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -o org-01 -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -o org-01 -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy -o org-01 -s '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -s **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'spaces'
+
+        echo 'Getting spaces in org org-01 as user-01...'
+        echo ''
+        echo 'name'
+        echo 'space-01'
+        echo 'space-02'
+        echo 'space-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -s '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -s '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf remove-network-policy -s '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -o**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'orgs'
+
+        echo 'Getting orgs as user-01...'
+        echo ''
+        echo 'name'
+        echo 'org-01'
+        echo 'org-02'
+        echo 'org-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -o'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}org-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}org-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}org-03${reset_color}"
+    }
+
+    prefix=-o
+    _fzf_complete_cf 'cf remove-network-policy '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -oorg-01 -s**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 3
+        assert $1 same_as 'org'
+        assert $2 same_as '--guid'
+        assert $3 same_as 'org-01'
+
+        echo '00000000-0000-0000-0000-000000000000'
+    }
+
+    cf_mock_3() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": null,
+           "next_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2",
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "00000000-0000-0000-0000-000000000000",
+                    "url": "/v2/spaces/00000000-0000-0000-0000-000000000000",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-01",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/developers",
+                    "managers_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/managers",
+                    "auditors_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/auditors",
+                    "apps_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/apps",
+                    "routes_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/routes",
+                    "domains_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/domains",
+                    "service_instances_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/service_instances",
+                    "app_events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/app_events",
+                    "events_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/events",
+                    "security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/00000000-0000-0000-0000-000000000000/staging_security_groups"
+                 }
+              },
+              {
+                 "metadata": {
+                    "guid": "11111111-1111-1111-1111-111111111111",
+                    "url": "/v2/spaces/11111111-1111-1111-1111-111111111111",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-02",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/developers",
+                    "managers_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/managers",
+                    "auditors_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/auditors",
+                    "apps_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/apps",
+                    "routes_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/routes",
+                    "domains_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/domains",
+                    "service_instances_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/service_instances",
+                    "app_events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/app_events",
+                    "events_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/events",
+                    "security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/11111111-1111-1111-1111-111111111111/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    cf_mock_4() {
+        assert $# equals 2
+        assert $1 same_as 'curl'
+        assert $2 same_as '/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=2'
+
+        echo '{
+           "total_results": 3,
+           "total_pages": 2,
+           "prev_url": "/v2/organizations/00000000-0000-0000-0000-000000000000/spaces?results-per-page=100&page=1",
+           "next_url": null,
+           "resources": [
+              {
+                 "metadata": {
+                    "guid": "22222222-2222-2222-2222-222222222222",
+                    "url": "/v2/spaces/22222222-2222-2222-2222-222222222222",
+                    "created_at": "2021-01-01T00:00:00Z",
+                    "updated_at": "2021-01-01T00:00:00Z"
+                 },
+                 "entity": {
+                    "name": "space-03",
+                    "organization_guid": "00000000-0000-0000-0000-000000000000",
+                    "space_quota_definition_guid": null,
+                    "allow_ssh": true,
+                    "organization_url": "/v2/organizations/00000000-0000-0000-0000-000000000000",
+                    "developers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/developers",
+                    "managers_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/managers",
+                    "auditors_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/auditors",
+                    "apps_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/apps",
+                    "routes_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/routes",
+                    "domains_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/domains",
+                    "service_instances_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/service_instances",
+                    "app_events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/app_events",
+                    "events_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/events",
+                    "security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/security_groups",
+                    "staging_security_groups_url": "/v2/spaces/22222222-2222-2222-2222-222222222222/staging_security_groups"
+                 }
+              }
+           ]
+        }'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy -oorg-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -oorg-01 -s'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 4
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name    ${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=-s
+    _fzf_complete_cf 'cf remove-network-policy -oorg-01 '
+}
+
+@test 'Testing completion: cf7 remove-network-policy -s**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 1
+        assert $1 same_as 'spaces'
+
+        echo 'Getting spaces in org org-01 as user-01...'
+        echo ''
+        echo 'name'
+        echo 'space-01'
+        echo 'space-02'
+        echo 'space-03'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf remove-network-policy '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf remove-network-policy -s'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}name${reset_color}"
+        assert ${lines[2]} same_as "${fg[yellow]}space-01${reset_color}"
+        assert ${lines[3]} same_as "${fg[yellow]}space-02${reset_color}"
+        assert ${lines[4]} same_as "${fg[yellow]}space-03${reset_color}"
+    }
+
+    prefix=-s
+    _fzf_complete_cf 'cf remove-network-policy '
+}
+
+@test 'Testing completion: cf7 create-service -b service-broker-01 service-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf create-service -b service-broker-01 service-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf create-service -b service-broker-01 service-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf create-service -b service-broker-01 service-01 '
+}
+
+@test 'Testing completion: cf7 create-service -bservice-broker-01 service-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf create-service -bservice-broker-01 service-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf create-service -bservice-broker-01 service-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf create-service -bservice-broker-01 service-01 '
+}
+
+@test 'Testing completion: cf7 create-service -bservice-broker-01 service-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf create-service -bservice-broker-01 service-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf create-service -bservice-broker-01 service-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf create-service -bservice-broker-01 service-01 '
+}
+
+@test 'Testing completion: cf7 cs -b service-broker-01 service-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf cs -b service-broker-01 service-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf cs -b service-broker-01 service-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf cs -b service-broker-01 service-01 '
+}
+
+@test 'Testing completion: cf7 cs -bservice-broker-01 service-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf cs -bservice-broker-01 service-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf cs -bservice-broker-01 service-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf cs -bservice-broker-01 service-01 '
+}
+
+@test 'Testing completion: cf7 disable-service-access service-01 -b service-broker-01 -p **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf disable-service-access service-01 -b service-broker-01 -p '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf disable-service-access service-01 -b service-broker-01 -p '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf disable-service-access service-01 -b service-broker-01 -p '
+}
+
+@test 'Testing completion: cf7 disable-service-access service-01 -b service-broker-01 -p**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf disable-service-access service-01 -b service-broker-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf disable-service-access service-01 -b service-broker-01 -p'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=-p
+    _fzf_complete_cf 'cf disable-service-access service-01 -b service-broker-01 '
+}
+
+@test 'Testing completion: cf7 disable-service-access service-01 -bservice-broker-01 -p **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf disable-service-access service-01 -bservice-broker-01 -p '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf disable-service-access service-01 -bservice-broker-01 -p '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf disable-service-access service-01 -bservice-broker-01 -p '
+}
+
+@test 'Testing completion: cf7 enable-service-access service-01 -b service-broker-01 -p **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf enable-service-access service-01 -b service-broker-01 -p '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf enable-service-access service-01 -b service-broker-01 -p '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf enable-service-access service-01 -b service-broker-01 -p '
+}
+
+@test 'Testing completion: cf7 enable-service-access service-01 -b service-broker-01 -p**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf enable-service-access service-01 -b service-broker-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf enable-service-access service-01 -b service-broker-01 -p'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=-p
+    _fzf_complete_cf 'cf enable-service-access service-01 -b service-broker-01 '
+}
+
+@test 'Testing completion: cf7 enable-service-access service-01 -bservice-broker-01 -p **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf enable-service-access service-01 -bservice-broker-01 -p '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf enable-service-access service-01 -bservice-broker-01 -p '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf enable-service-access service-01 -bservice-broker-01 -p '
+}
+
+@test 'Testing completion: cf7 enable-service-access service-01 -bservice-broker-01 -p**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf enable-service-access service-01 -bservice-broker-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf enable-service-access service-01 -bservice-broker-01 -p'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=-p
+    _fzf_complete_cf 'cf enable-service-access service-01 -bservice-broker-01 '
+}
+
+@test 'Testing completion: cf7 disable-service-access service-01 -bservice-broker-01 -p**' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 5
+        assert $1 same_as 'marketplace'
+        assert $2 same_as '-e'
+        assert $3 same_as 'service-01'
+        assert $4 same_as '-b'
+        assert $5 same_as 'service-broker-01'
+
+        echo 'Getting service plan information for service offering service-01 from service broker service-broker-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'broker: service-broker-01'
+        echo '   plan      description   free or paid   costs              available'
+        echo '   plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+        echo '   plan-02   A plan 02     free           USD 0.00/MONTHLY   yes'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf disable-service-access service-01 -bservice-broker-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf disable-service-access service-01 -bservice-broker-01 -p'
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}plan      ${reset_color}description   free or paid   costs              available"
+        assert ${lines[2]} same_as "${fg[yellow]}plan-01   ${reset_color}A plan 01     free           USD 0.00/MONTHLY   yes"
+        assert ${lines[3]} same_as "${fg[yellow]}plan-02   ${reset_color}A plan 02     free           USD 0.00/MONTHLY   yes"
+    }
+
+    prefix=-p
+    _fzf_complete_cf 'cf disable-service-access service-01 -bservice-broker-01 '
+}
+
+@test 'Testing completion: cf7 restart-app-instance app-01 **' {
+    cf_mock_1() {
+        assert $# equals 1
+        assert $1 same_as '--version'
+
+        echo 'cf version 7.4.0+e55633fed.2021-11-15'
+    }
+
+    cf_mock_2() {
+        assert $# equals 2
+        assert $1 same_as 'app'
+        assert $2 same_as 'app-01'
+
+        echo 'Showing health and status for app app-01 in org org-01 / space space-01 as user-01...'
+        echo ''
+        echo 'name:              app-01'
+        echo 'requested state:   started'
+        echo 'routes:            app-01.example.com'
+        echo 'last uploaded:     Sat 01 Jan 09:00:00 JST 2021'
+        echo 'stack:             cflinuxfs3'
+        echo 'buildpacks:'
+        echo '	name           version   detect output   buildpack name'
+        echo '	go_buildpack   1.9.34    go              go'
+        echo ''
+        echo 'type:           web'
+        echo 'sidecars:       '
+        echo 'instances:      3/3'
+        echo 'memory usage:   1024M'
+        echo '     state     since                  cpu    memory         disk           details'
+        echo '#0   running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   '
+        echo '#1   running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   '
+        echo '#2   running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   '
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'cf restart-app-instance app-01 '
+
+        echo 'cf'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'cf restart-app-instance app-01 '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert cf mock_times 2
+        assert ${#lines} equals 4
+        assert ${lines[1]} same_as "${fg[yellow]}     ${reset_color}state     since                  cpu    memory         disk           details"
+        assert ${lines[2]} same_as "${fg[yellow]}#0   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
+        assert ${lines[3]} same_as "${fg[yellow]}#1   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
+        assert ${lines[4]} same_as "${fg[yellow]}#2   ${reset_color}running   2021-01-01T00:00:00Z   0.5%   100.0M of 1G   100.0M of 1G   "
+    }
+
+    prefix=
+    _fzf_complete_cf 'cf restart-app-instance app-01 '
+}
+
+@test 'Testing post: a buildpack name and stack' {
+    input=(
+        '1          binary_buildpack   cflinuxfs3   true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip'
+    )
+
+    cf_version=7
+    resource=buildpacks
+    resource_column=2
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'binary_buildpack --stack=cflinuxfs3'
+}
+
+@test 'Testing post: a buildpack position' {
+    input=(
+        '1          binary_buildpack   cflinuxfs3   true      true     binary-buildpack-cflinuxfs3-v1.0.39.zip'
+    )
+
+    cf_version=7
+    resource=buildpacks
+    resource_column=1
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as '1'
+}
+
+@test 'Testing post: a network policy' {
+    input=(
+        'app-01   app-02        tcp        8080        space-01            org-01'
+    )
+
+    cf_version=7
+    resource=network-policies
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'app-01 app-02 --protocol=tcp --port=8080 -o org-01 -s space-01'
+}
+
+@test 'Testing post: an HTTP route bound to an app' {
+    input=(
+        'space-01   app       example.com                              http   app-01'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=app'
+}
+
+@test 'Testing post: an HTTP route bound to apps' {
+    input=(
+        'space-01   app       example.com                              http   app-01, app-02, app-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=app'
+}
+
+@test 'Testing post: an HTTP path route bound to an app' {
+    input=(
+        'space-01   app       example.com                      /sub    http   app-02'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=app --path=/sub'
+}
+
+@test 'Testing post: an HTTP path route bound to apps' {
+    input=(
+        'space-01   app       example.com                      /sub    http   app-02, app-03, app-04'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=app --path=/sub'
+}
+
+@test 'Testing post: an HTTP route' {
+    input=(
+        'space-01   app       unbound.example.com                      http'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'unbound.example.com --hostname=app'
+}
+
+@test 'Testing post: an HTTP path route' {
+    input=(
+        'space-01   app       unbound.example.com              /sub    http'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'unbound.example.com --hostname=app --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain route bound to an app' {
+    input=(
+        'space-01             example.com                              http   app-01'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com'
+}
+
+@test 'Testing post: an HTTP domain route bound to apps' {
+    input=(
+        'space-01             example.com                              http   app-01, app-02, app-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com'
+}
+
+@test 'Testing post: an HTTP domain path route bound to an app' {
+    input=(
+        'space-01             example.com                      /sub    http   app-02'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain path route bound to apps' {
+    input=(
+        'space-01             example.com                      /sub    http   app-02, app-03, app-04'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain route' {
+    input=(
+        'space-01             unbound.example.com                      http'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'unbound.example.com'
+}
+
+@test 'Testing post: an HTTP domain path route' {
+    input=(
+        'space-01             unbound.example.com              /sub    http'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'unbound.example.com --path=/sub'
+}
+
+@test 'Testing post: a TCP route bound to an app' {
+    input=(
+        'space-01             tcp.example.com           1024           tcp    app-01'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'tcp.example.com --port=1024'
+}
+
+@test 'Testing post: a TCP route bound to apps' {
+    input=(
+        'space-01             tcp.example.com           1024           tcp    app-01, app-02, app-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'tcp.example.com --port=1024'
+}
+
+@test 'Testing post: a TCP route' {
+    input=(
+        'space-01             tcp.unbound.example.com   1024           tcp'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'tcp.unbound.example.com --port=1024'
+}

--- a/tests/cf8.zunit
+++ b/tests/cf8.zunit
@@ -1,0 +1,162 @@
+#!/usr/bin/env zunit
+
+@setup {
+    load ../fzf-zsh-completions.plugin.zsh
+    load _helpers/mock.zsh
+    load _helpers/assertions.zsh
+    mock cf
+    mock _fzf_complete_cf_unknown-subcommand
+    mock __fzf_extract_command
+
+    CF_HOME=tests/_support/cf
+}
+
+@teardown {
+    (unmock cf)
+    (unmock _fzf_complete_cf_app)
+    (unmock _fzf_complete_cf_unknown-subcommand)
+    (unmock __fzf_extract_command)
+}
+
+@test 'Testing post: an HTTP route bound to an app and service' {
+    input=(
+        'space-01   service   example.com                             http   http1          app-03                   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=service'
+}
+
+@test 'Testing post: an HTTP route bound to apps and service' {
+    input=(
+        'space-01   service   example.com                             http   http1          app-03, app-04, app-05   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=service'
+}
+
+@test 'Testing post: an HTTP path route bound to an app and service' {
+    input=(
+        'space-01   service   example.com                      /sub   http   http1, http2   app-04                   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=service --path=/sub'
+}
+
+@test 'Testing post: an HTTP path route bound to apps and service' {
+    input=(
+        'space-01   service   example.com                      /sub   http   http1, http2   app-04, app-05, app-06   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --hostname=service --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain route bound to an app and service' {
+    input=(
+        'space-01             example.com                             http   http2          app-03                   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com'
+}
+
+@test 'Testing post: an HTTP domain route bound to apps and service' {
+    input=(
+        'space-01             example.com                             http   http2          app-03, app-04, app-05   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com'
+}
+
+@test 'Testing post: an HTTP domain path route bound to an app and service' {
+    input=(
+        'space-01             example.com                      /sub   http   http2          app-04                   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain path route bound to apps and service' {
+    input=(
+        'space-01             example.com                      /sub   http   http2          app-04, app-05, app-06   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'example.com --path=/sub'
+}
+
+@test 'Testing post: an HTTP domain path route bound to a service' {
+    input=(
+        'space-01             unbound.example.com              /sub   http   http2                                   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'unbound.example.com --path=/sub'
+}
+
+@test 'Testing post: a TCP route bound to apps and service' {
+    input=(
+        'space-01             tcp.example.com           1025          tcp                   app-03, app-04, app-05   service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'tcp.example.com --port=1025'
+}
+
+@test 'Testing post: a TCP route bound to a service' {
+    input=(
+        'space-01             tcp.unbound.example.com   1025          tcp                                            service-instance-03'
+    )
+
+    resource=routes
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'tcp.unbound.example.com --port=1025'
+}


### PR DESCRIPTION
Closes #174 

## TODO

- [x] Implement backward incompatible command changes between cf CLI v6 and later
- [x] Implement backward incompatible output changes between cf CLI v6 and later
  - [x] Processes
    - [x] cf restart-app-instance APP_NAME **\<TAB\>
  - [x] Service Plans
    - [x] cf create-service SERVICE_NAME **\<TAB\>
- [x] Add newly added options
- [x] Add newly added resources
  - [x] Labels
- [x] Add newly added subcommands
- [x] Testing

## Not To Do

Will be supported in a future version...

- [ ] Add newly added resources
  - [ ] Processes
    - [ ] cf restart-app-instance APP_NAME --process=**\<TAB\>
    - [ ] cf run-task APP_NAME --process=**\<TAB\>
    - [ ] cf scale APP_NAME --process=**\<TAB\>
    - [ ] cf set-health-check APP_NAME --process=**\<TAB\>
    - [ ] cf ssh APP_NAME --process=**\<TAB\>
- [ ] Use of CAPI V3