### PR TITLE
Show files with git status as the result of `git reset HEAD **`

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -413,6 +413,11 @@ _fzf_complete_git() {
                 return
             fi
 
+            if _fzf_complete_git_is_head "${treeish:-HEAD}"; then
+                _fzf_complete_git-status-files 'staged' '--untracked-files=no' "--multi $_fzf_complete_preview_git_diff_cached $FZF_DEFAULT_OPTS" "$@"
+                return
+            fi
+
             _fzf_complete_git-files_tree_and_index '' '' '--multi' "$@"
             return
         fi
@@ -879,4 +884,11 @@ _fzf_complete_git_parse_completing_option() {
         fi
         prefix=${prefix#$prefix_option}
     fi
+}
+
+_fzf_complete_git_is_head() {
+    local head_commit=$(git rev-parse HEAD 2> /dev/null)
+    local target=$(git rev-parse "$1" 2> /dev/null)
+
+    [[ $head_commit = $target ]]
 }

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -1089,7 +1089,8 @@
 
 @test 'Testing completion: git reset -- **' {
     echo >> newfile
-    run git add newfile
+    echo >> file1
+    run git add newfile file1
 
     __fzf_extract_command_mock_1() {
         assert $# equals 1
@@ -1099,27 +1100,67 @@
     }
 
     _fzf_complete() {
-        assert $# equals 6
+        assert $# equals 9
         assert $1 same_as '--ansi'
         assert $2 same_as '--read0'
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset -- '
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git reset -- '
 
         run cat
         assert __fzf_extract_command mock_times 1
         assert ${#lines} equals 1
 
         actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as 'directory1/file2'
-        assert ${actual1[2]} same_as 'file1'
-        assert ${actual1[3]} same_as 'newfile'
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as "$fg[green]M$reset_color $reset_color file1"
+        assert ${actual1[2]} same_as "$fg[green]A$reset_color $reset_color newfile"
     }
 
     prefix=
     _fzf_complete_git 'git reset -- '
+}
+
+@test 'Testing completion: git reset @ -- **' {
+    echo >> newfile
+    echo >> file1
+    run git add newfile file1
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'git reset @ -- '
+
+        echo 'git'
+    }
+
+    _fzf_complete() {
+        assert $# equals 9
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--read0'
+        assert $3 same_as '--print0'
+        assert $4 same_as '--multi'
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git reset @ -- '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert ${#lines} equals 1
+
+        actual1=(${(0)lines[1]})
+        assert ${#actual1} equals 2
+        assert ${actual1[1]} same_as "$fg[green]M$reset_color $reset_color file1"
+        assert ${actual1[2]} same_as "$fg[green]A$reset_color $reset_color newfile"
+    }
+
+    prefix=
+    _fzf_complete_git 'git reset @ -- '
 }
 
 @test 'Testing completion: git reset another-branch -- **' {
@@ -1249,6 +1290,7 @@
     echo >> directory2/$'file4\ncontaining\nnewlines'
     echo >> ' file5 containing space '
     echo >> directory2/$'file6\ncontaining\nnewlines'
+    run git add .
 
     cd directory1
 
@@ -1260,23 +1302,27 @@
     }
 
     _fzf_complete() {
-        assert $# equals 6
+        assert $# equals 9
         assert $1 same_as '--ansi'
         assert $2 same_as '--read0'
         assert $3 same_as '--print0'
         assert $4 same_as '--multi'
-        assert $5 same_as '--'
-        assert $6 same_as 'git reset -- '
+        assert $5 same_as '--preview-window=right:70%:wrap'
+        assert $6 matches '--preview=*'
+        assert $7 same_as '--reverse'
+        assert $8 same_as '--'
+        assert $9 same_as 'git reset -- '
 
         run cat
         assert __fzf_extract_command mock_times 1
-        assert ${#lines} equals 3
+        assert ${#lines} equals 5
 
         actual1=(${(0)lines[1]})
-        assert ${#actual1} equals 3
-        assert ${actual1[1]} same_as '../ file3 containing space '
-        assert ${actual1[2]} same_as '../directory1/file2'
-        assert ${actual1[3]} same_as '../directory2/file4'
+        assert ${#actual1} equals 4
+        assert ${actual1[1]} same_as "$fg[green]M$reset_color $reset_color ../ file3 containing space "
+        assert ${actual1[2]} same_as "$fg[green]A$reset_color $reset_color ../ file5 containing space "
+        assert ${actual1[3]} same_as "$fg[green]M$reset_color $reset_color ../directory1/file2"
+        assert ${actual1[4]} same_as "$fg[green]M$reset_color $reset_color ../directory2/file4"
 
         actual2=(${(0)lines[2]})
         assert ${#actual2} equals 1
@@ -1285,7 +1331,7 @@
         actual3=(${(0)lines[3]})
         assert ${#actual3} equals 2
         assert ${actual3[1]} same_as 'newlines'
-        assert ${actual3[2]} same_as '../file1'
+        assert ${actual3[2]} same_as "$fg[green]A$reset_color $reset_color ../directory2/file6"
     }
 
     prefix=


### PR DESCRIPTION
It had shown files both under the working tree and under the index also when an identifier like HEAD is specified so far. This shows files with git status as with the result of `git restore --staged **`.
