### PR TITLE
Fix a bug where service plans being incorrectly handled

### DIFF
--- a/src/completers/cf.zsh
+++ b/src/completers/cf.zsh
@@ -1620,7 +1620,7 @@ _fzf_complete_cf-resources_post() {
             fi
         fi
     elif [[ $resource = marketplace ]]; then
-        if [[ -n ${cf_options_argument_required[(r)-b]} ]]; then
+        if [[ -z ${cf_arguments[(r)-s|-e]} ]] && [[ -n ${cf_options_argument_required[(r)-b]} ]]; then
             if [[ -n $completing_option ]]; then
                 awk '{ print $1, "-b", $NF }'
             else

--- a/tests/cf.zunit
+++ b/tests/cf.zunit
@@ -20441,6 +20441,21 @@
     assert ${lines[1]} same_as 'service-01 -b service-broker-01'
 }
 
+@test 'Testing post: a service plan' {
+    input=(
+        'plan-01   A plan 01     free'
+    )
+
+    cf_options_argument_required=(-b -o -p)
+    cf_arguments=(-s service-01)
+    resource=marketplace
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'plan-01'
+}
+
 @test 'Testing post: a network policy' {
     input=(
         'app-01   app-02        tcp        8080        space-01            org-01'
@@ -20907,7 +20922,7 @@
     assert ${lines[1]} same_as 'key-01'
 }
 
-@test 'Testing post: a service plan' {
+@test 'Testing post: a service plan by service instance' {
     input=(
         'plan-01        A plan 01         free'
     )

--- a/tests/cf7.zunit
+++ b/tests/cf7.zunit
@@ -3037,6 +3037,21 @@
     assert ${lines[1]} same_as '1'
 }
 
+@test 'Testing post: a service plan' {
+    input=(
+        'plan-01   A plan 01     free           USD 0.00/MONTHLY   yes'
+    )
+
+    cf_options_argument_required=(-b -o -p)
+    cf_arguments=(-e service-01)
+    resource=marketplace
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'plan-01'
+}
+
 @test 'Testing post: a network policy' {
     input=(
         'app-01   app-02        tcp        8080        space-01            org-01'

--- a/tests/cf8.zunit
+++ b/tests/cf8.zunit
@@ -18,6 +18,21 @@
     (unmock __fzf_extract_command)
 }
 
+@test 'Testing post: a service plan' {
+    input=(
+        'plan-01   A plan 01     free           USD 0.00/MONTHLY'
+    )
+
+    cf_options_argument_required=(-b -o -p)
+    cf_arguments=(-e service-01)
+    resource=marketplace
+    run _fzf_complete_cf-resources_post <<< ${(F)input}
+
+    assert $state equals 0
+    assert ${#lines} equals 1
+    assert ${lines[1]} same_as 'plan-01'
+}
+
 @test 'Testing post: an HTTP route bound to an app and service' {
     input=(
         'space-01   service   example.com                             http   http1          app-03                   service-instance-03'


### PR DESCRIPTION
Context: `cf create-service SERVICE_NAME **<TAB>` results in the completed result inserted with `-b` flag.