### PR TITLE
Fix kubectl set image TYPE NAME ** being expanded to a container name

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -1058,6 +1058,8 @@ _fzf_complete_kubectl-containers() {
 }
 
 _fzf_complete_kubectl-containers_post() {
+    setopt local_options no_ksh_arrays
+
     if [[ ${subcommands[1]} = set ]] && [[ ${subcommands[2]} = image ]]; then
         awk '{ printf "%s=%s", $1, $2 }'
         return


### PR DESCRIPTION
Since the fzf calls `ksh_arrays` before calling `*_post`, `set` and `image` are assigned to `subcommands[0]` and `subcommands[1]` respectively in `_fzf_complete_kubectl-containers_post`. The fix is to call `no_ksh_arrays` before referencing them.