### PR TITLE
Fix git completions showed invalid HEAD

### DIFF
--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -644,8 +644,8 @@ _fzf_complete_git-commits() {
     shift
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <({
-        git for-each-ref refs/heads refs/remotes --format='%(refname:short) branch %(contents:subject)' 2> /dev/null
-        git for-each-ref refs/tags --format='%(refname:short) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
+        git for-each-ref refs/heads refs/remotes --format='%(refname:lstrip=2) branch %(contents:subject)' 2> /dev/null
+        git for-each-ref refs/tags --format='%(refname:lstrip=2) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
     } | _fzf_complete_tabularize ${fg[yellow]} ${fg[green]})
 }


### PR DESCRIPTION
When completing refs, `git checkout **<TAB>` showed an invalid entry (`origin`) as in:
```
>
  188/188 ──────────────────────────────────────────────────────
> master         branch  Support `git checkout -B **` (#225)
  origin         branch  Support `git checkout -B **` (#225)
  origin/master  branch  Support `git checkout -B **` (#225)
  fc46b2f        commit  Fix git completions showed invalid HEAD
```
instead of the following (`origin/HEAD`):
```
>
  188/188 ──────────────────────────────────────────────────────
> master         branch  Support `git checkout -B **` (#225)
  origin/HEAD    branch  Support `git checkout -B **` (#225)
  origin/master  branch  Support `git checkout -B **` (#225)
  fc46b2f        commit  Fix git completions showed invalid HEAD
```
