### PR TITLE
Enable extended_glob when necessary

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -4,7 +4,7 @@ autoload -U colors
 colors
 
 _fzf_complete_kubectl() {
-    setopt local_options no_aliases
+    setopt local_options extended_glob no_aliases
     local command_pos=$(_fzf_complete_get_command_pos "$@")
     local arguments=("${(Q)${(z)"$(_fzf_complete_trim_env "$command_pos" "$@")"}[@]}")
     local options_and_subcommand=()

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -90,6 +90,7 @@ _fzf_complete_parse_completing_option() {
 }
 
 _fzf_complete_parse_argument() {
+    setopt local_options extended_glob
     local start_index=$1
     local index=$2
     local options_argument_required=(${(z)3})


### PR DESCRIPTION
The `extended_glob` has to be enabled in order to use the glob syntax like `(#c1,2)`.