### PR TITLE
Fix issue where command after confirming or cancelling completion is incorrect

### DIFF
--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -1,23 +1,24 @@
+alias ktest="kubectl --kubeconfig ~/.kube/config"
+
 _fzf_complete_enable_aliases() {
-    local expr name value completer arguments
+    local expr name value completer
     local completers=("${@[@]:t:r}")
 
-    local IFS=$'\n'
-    for expr in $(alias); do
-        name=${expr%%=*}
-        value=(${(Q)${(z)${(Q)${(z)expr##*=}}}})
+    for name expr in ${(kv)aliases[@]}; do
+        value=(${(Q)${(z)expr}})
         completer=${completers[(r)$value[1]]}
-        arguments=${(e@)value[2,-1]}
 
         if [[ -n $completer ]]; then
             source -- "${@[(r)*completers/$completer.zsh]}"
+            echo $name
+            echo ${aliases[$name]}
             eval "
                 _fzf_complete_$name() {
-                    LBUFFER=\"\${LBUFFER/$name/$completer $arguments}\"
+                    LBUFFER=\"\${LBUFFER/$name/\${aliases[$name]}}\"
                     () {
                         $functions[_fzf_complete_$completer]
-                    } \"\${@/$name/$completer $arguments}\"
-                    LBUFFER=\"\${LBUFFER/$completer ${(qq)arguments//\//\\/}/$name}\"
+                    } \"\${@/$name/\${aliases[$name]}}\"
+                    LBUFFER=\"\${LBUFFER/\${aliases[$name]}/$name}\"
                 }
             "
         fi

--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -7,7 +7,7 @@ _fzf_complete_enable_aliases() {
         name=${expr%%=*}
         value=(${(Q)${(z)${(Q)${(z)expr##*=}}}})
         completer=${completers[(r)$value[1]]}
-        arguments=${(@)value[2,-1]}
+        arguments=${(e@)value[2,-1]}
 
         if [[ -n $completer ]]; then
             source -- "${@[(r)*completers/$completer.zsh]}"
@@ -17,7 +17,7 @@ _fzf_complete_enable_aliases() {
                     () {
                         $functions[_fzf_complete_$completer]
                     } \"\${@/$name/$completer $arguments}\"
-                    LBUFFER=\"\${LBUFFER/$completer ${arguments//\//\\/}/$name}\"
+                    LBUFFER=\"\${LBUFFER/$completer ${(qq)arguments//\//\\/}/$name}\"
                 }
             "
         fi

--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -1,5 +1,3 @@
-alias ktest="kubectl --kubeconfig ~/.kube/config"
-
 _fzf_complete_enable_aliases() {
     local expr name value completer
     local completers=("${@[@]:t:r}")

--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -17,7 +17,7 @@ _fzf_complete_enable_aliases() {
                     () {
                         $functions[_fzf_complete_$completer]
                     } \"\${@/$name/$completer $arguments}\"
-                    LBUFFER=\"\${LBUFFER/$completer $arguments/$name}\"
+                    LBUFFER=\"\${LBUFFER/$completer ${arguments//\//\\/}/$name}\"
                 }
             "
         fi

--- a/src/core/aliases.zsh
+++ b/src/core/aliases.zsh
@@ -8,8 +8,6 @@ _fzf_complete_enable_aliases() {
 
         if [[ -n $completer ]]; then
             source -- "${@[(r)*completers/$completer.zsh]}"
-            echo $name
-            echo ${aliases[$name]}
             eval "
                 _fzf_complete_$name() {
                     LBUFFER=\"\${LBUFFER/$name/\${aliases[$name]}}\"


### PR DESCRIPTION
This PR fixes an issue (https://github.com/chitoku-k/fzf-zsh-completions/issues/230#issuecomment-1588855797) where the command after confirming or cancelling a completion is incorrect when the alias includes a path. This is caused by interpreting `/` in `pattern` of `${name/pattern/repl}` as a delimiter between `pattern` and `repl`, so it is resolved by escaping `/`.