### PR TITLE
Fix compatibility issues with old versions of git, jq, mawk, and zsh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,7 @@ body:
   - type: textarea
     attributes:
       label: awk version
-      description: '`awk --version` output'
+      description: '`awk --version` or `awk -W version` output'
       placeholder: 'GNU Awk 5.2.2, API 3.2, PMA Avon 8-g1, (GNU MPFR 4.2.0-p9, GNU MP 6.2.1)'
       render: shell
     validations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,54 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            timeout: 10
           - os: macos-latest
-            timeout: 30
+          - os: ubuntu-latest
+            awk: gawk
+          - os: ubuntu-latest
+            awk: mawk
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           submodules: true
       - name: Install Zsh
-        if: startsWith(matrix.os, 'ubuntu')
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get update
           sudo apt-get install -y zsh
+      - name: Switch awk variant
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.awk }}
+        run: |
+          sudo update-alternatives --set awk /usr/bin/${{ matrix.awk }}
+      - name: Show versions
+        run: |
+          echo ::group::zsh
+          zsh --version
+          echo ::endgroup::
+
+          echo ::group::jq
+          jq --version
+          echo ::endgroup::
+
+          echo ::group::awk
+          awk --version 2> /dev/null || awk -W version
+          echo ::endgroup::
+
+          echo ::group::git
+          git --version
+          echo ::endgroup::
+
+          echo ::group::node
+          node --version
+          echo ::endgroup::
+
+          echo ::group::yarn
+          yarn --version
+          echo ::endgroup::
+
+          echo ::group::php
+          php --version
+          echo ::endgroup::
       - name: Run unit tests
         run: |
-          tests/test.zsh --tap --time-limit ${{ matrix.timeout }} tests/*.zunit
+          tests/test.zsh --tap --time-limit=30 tests/*.zunit

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ sequence that defaults to `**`.
 The following dependencies are optional unless those completions are desired:
 - [docker][] CLI >= 17.03.0 (for `docker` completions)
 - [git][] >= 2.7.1 (for `git` completions)
-- [node][] >= 5.0.0 (for `node` completions)
-- [php][] >= 5.2.3 (for `php` completions)
+- [node][] >= 5.0.0 (for `npm` completions)
+- [php][] >= 5.2.3 (for `composer` completions)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following dependencies are optional unless those completions are desired:
 - [docker][] CLI >= 17.03.0 (for `docker` completions)
 - [git][] >= 2.7.1 (for `git` completions)
 - [node][] >= 5.0.0 (for `npm` completions)
-- [php][] >= 5.2.3 (for `composer` completions)
+- [php][] >= 5.2.0 (for `composer` completions)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ sequence that defaults to `**`.
 
 ## Prerequisites
 
-- [fzf][]
-- [Zsh][] >= 5.3
-- [jq][]
+- [fzf][] >= 0.21.1
+- [Zsh][] >= 5.1
+- [jq][] >= 1.5
+- awk
+
+The following dependencies are optional unless those completions are desired:
+- [docker][] CLI >= 17.03.0 (for `docker` completions)
+- [git][] >= 2.7.1 (for `git` completions)
+- [node][] >= 5.0.0 (for `node` completions)
+- [php][] >= 5.2.3 (for `php` completions)
 
 ## Installation
 
@@ -126,3 +133,7 @@ tests/test.zsh
 [Zsh]:             https://www.zsh.org/
 [fzf-preview.zsh]: https://github.com/yuki-ycino/fzf-preview.zsh
 [jq]:              https://github.com/stedolan/jq
+[docker]:          https://github.com/docker/cli
+[git]:             https://github.com/git/git
+[node]:            https://github.com/nodejs/node
+[php]:             https://github.com/php/php-src

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -778,7 +778,7 @@ _fzf_complete_git-files_tree_and_index_post() {
     local input=$(cat)
 
     for filename in ${(0)input}; do
-        echo ${${(q+)filename}//\\n/\\\\n}
+        echo ${${(q-)filename}//$'\n'/\'\$\'\\\\n\'\'}
     done
 }
 
@@ -820,7 +820,7 @@ _fzf_complete_git-status-files_post() {
     local input=$(cat)
 
     for filename in ${(0)input}; do
-        echo ${${(q+)filename:3}//\\n/\\\\n}
+        echo ${${(q-)filename:3}//$'\n'/\'\$\'\\\\n\'\'}
     done
 }
 
@@ -897,7 +897,7 @@ _fzf_complete_git-show-files_post() {
     local input=$(cat)
 
     for filename in ${(0)input}; do
-        echo ${${(q+)filename}//\\n/\\\\n}
+        echo ${${(q-)filename}//$'\n'/\'\$\'\\\\n\'\'}
     done
 }
 

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -791,7 +791,7 @@ _fzf_complete_git-status-files() {
     _fzf_complete --ansi --read0 --print0 ${(Q)${(Z+n+)fzf_options}} -- "$@" < <({
         local previous_status
         local filename
-        local files=$(git status --porcelain=v1 -z ${(Z+n+)git_options} 2> /dev/null)
+        local files=$(git status --porcelain -z ${(Z+n+)git_options} 2> /dev/null)
         local cdup=$(git rev-parse --show-cdup 2> /dev/null)
 
         for filename in ${(0)files}; do

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -644,8 +644,8 @@ _fzf_complete_git-commits() {
     shift
 
     _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option$prefix_ref" < <({
-        git for-each-ref refs/heads refs/remotes --format='%(refname:lstrip=2) branch %(contents:subject)' 2> /dev/null
-        git for-each-ref refs/tags --format='%(refname:lstrip=2) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
+        git for-each-ref refs/heads refs/remotes --format='%(refname:strip=2) branch %(contents:subject)' 2> /dev/null
+        git for-each-ref refs/tags --format='%(refname:strip=2) tag %(contents:subject)' --sort=-version:refname 2> /dev/null
         git log --format='%h commit %s' 2> /dev/null
     } | _fzf_complete_tabularize ${fg[yellow]} ${fg[green]})
 }

--- a/src/completers/git.zsh
+++ b/src/completers/git.zsh
@@ -716,7 +716,7 @@ _fzf_complete_git-files_tree() {
         local git_prefix=$(git rev-parse --show-prefix 2> /dev/null)
         cd $(git rev-parse --show-toplevel 2> /dev/null)
 
-        local files=$(git ls-files --deduplicate -z ${(Z+n+)git_options} 2> /dev/null)
+        local files=$(git ls-files -z ${(Z+n+)git_options} 2> /dev/null)
         files=(${(0)files})
         local paths=($cdup${^files})
 
@@ -762,7 +762,7 @@ _fzf_complete_git-files_tree_and_index() {
         cd $(git rev-parse --show-toplevel 2> /dev/null)
 
         local files=()
-        local ls_files=$(git ls-files --deduplicate -z ${(Z+n+)git_ls_files_options} 2> /dev/null)
+        local ls_files=$(git ls-files -z ${(Z+n+)git_ls_files_options} 2> /dev/null)
         local ls_tree=$(git ls-tree --name-only --full-tree -r -z ${(Z+n+)git_ls_tree_options} ${treeish:-HEAD} 2> /dev/null)
         files+=(${(0)ls_files})
         files+=(${(0)ls_tree})

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -1250,7 +1250,7 @@ _fzf_complete_kubectl-annotations_post() {
             echo
         fi
 
-        echo -n ${item%=*}=${${(q+)item#*=}//\\n/\\\\n}
+        echo -n ${item%=*}=${${(q-)item#*=}//$'\n'/\'\$\'\\\\n\'\'}
         first=
     done
 }

--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -1304,7 +1304,7 @@ _fzf_complete_kubectl-selectors() {
                 echo KEY VALUE
             fi
 
-            kubectl get "${resource:-all}" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
+            kubectl get "${resource:-all}" "${kubectl_arguments[@]}" -o jsonpath='{range .items[*]}{.metadata.labels}{"\n"}{end}' |
                 if [[ $prefix_option = *! ]]; then
                     jq --slurp -r 'map(to_entries[]) | group_by(.key) | map("\(first | .key) \(map(.value) | unique | join(", "))")[]'
                 elif [[ $prefix_option = *= ]] && [[ -n $selector ]]; then
@@ -1452,7 +1452,7 @@ _fzf_complete_kubectl-field-selectors() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUE
-            kubectl get "${resource:-all}" "${kubectl_arguments[@]}" -o jsonpath='{.items[*]}' |
+            kubectl get "${resource:-all}" "${kubectl_arguments[@]}" -o jsonpath='{range .items[*]}{@}{"\n"}{end}' |
                 jq --slurp -r --arg labels "$labels" '
                     [[($labels | split(" ")), .] | combinations] |
                         map(
@@ -1501,7 +1501,7 @@ _fzf_complete_kubectl-label-columns() {
     _fzf_complete --ansi --tiebreak=index --header-lines=1 ${(Q)${(Z+n+)fzf_options}} -- "$@$prefix_option" < <(
         _fzf_complete_tabularize $fg[yellow] < <({
             echo KEY VALUES
-            kubectl get "$resource" "${kubectl_arguments[@]}" -o jsonpath='{.items[*].metadata.labels}' |
+            kubectl get "$resource" "${kubectl_arguments[@]}" -o jsonpath='{range .items[*]}{.metadata.labels}{"\n"}{end}' |
                 jq --slurp -r 'map(to_entries[]) | group_by(.key) | map("\(first | .key) \(map(.value) | unique | join(", "))")[]'
         } 2> /dev/null)
     )

--- a/src/core/formatter.zsh
+++ b/src/core/formatter.zsh
@@ -14,11 +14,11 @@ _fzf_complete_tabularize() {
         -v colors_args=${(pj: :)@} \
         -v reset=$reset_color '
         BEGIN {
-            split(colors_args, colors, " ")
+            colors_len = split(colors_args, colors, " ")
         }
         {
             str = $0
-            for (i = 1; i <= length(colors); ++i) {
+            for (i = 1; i <= colors_len; ++i) {
                 field_max[i] = length($i) > field_max[i] ? length($i) : field_max[i]
                 fields[NR, i] = $i
                 pos = index(str, FS)
@@ -30,7 +30,7 @@ _fzf_complete_tabularize() {
         }
         END {
             for (i = 1; i <= NR; ++i) {
-                for (j = 1; j <= length(colors); ++j) {
+                for (j = 1; j <= colors_len; ++j) {
                     printf "%s%s%-" field_max[j] "s%s", (j > 1 ? "  " : ""), colors[j], fields[i, j], reset
                 }
                 if ((i, j) in fields) {
@@ -52,23 +52,24 @@ _fzf_complete_colorize() {
         -v colors_args=${(pj: :)@} \
         -v reset=$reset_color '
         BEGIN {
-            split(colors_args, colors, " ")
+            colors_len = split(colors_args, colors, " ")
             header = 1
         }
         header {
             delete fields
-            fields[1] = 1
+            fields_len = 0
+            fields[++fields_len] = 1
             header = 0
 
             for (i = 2; i <= length($0); ++i) {
                 if (substr($0, i - 1, 1) == " " && substr($0, i, 1) != " ") {
-                    fields[length(fields) + 1] = i
+                    fields[++fields_len] = i
                 }
             }
         }
         {
             total = 0
-            for (i = 1; i<= length(colors); ++i) {
+            for (i = 1; i <= colors_len; ++i) {
                 width = fields[i + 1] - fields[i] < 0 ? length($0) : fields[i + 1] - fields[i]
                 total += width
                 printf "%s%s%s", colors[i], substr($0, fields[i], width), reset

--- a/tests/_helpers/mock.zsh
+++ b/tests/_helpers/mock.zsh
@@ -1,4 +1,4 @@
-typeset -g mock_dir=${funcsourcetrace[1]:P:h:h}/_support/mock
+typeset -g mock_dir=${funcsourcetrace[1]:a:h:h}/_support/mock
 
 mock() {
     local target=$1

--- a/tests/git.zunit
+++ b/tests/git.zunit
@@ -8151,9 +8151,9 @@
     assert ${lines[1]} same_as 'file1'
     assert ${lines[2]} same_as 'directory1/file2'
     assert ${lines[3]} same_as "' file3 containing space '"
-    assert ${lines[4]} same_as "\$'file4\\ncontaining\\nnewlines'"
+    assert ${lines[4]} same_as "'file4'$'\\n''containing'$'\\n''newlines'"
     assert ${lines[5]} same_as "' file5 containing space '"
-    assert ${lines[6]} same_as "\$'directory2/file6\\ncontaining\\nnewlines'"
+    assert ${lines[6]} same_as "'directory2/file6'$'\\n''containing'$'\\n''newlines'"
 }
 
 @test 'Testing post: git repositories' {
@@ -8202,9 +8202,9 @@
     assert ${lines[1]} same_as 'file1'
     assert ${lines[2]} same_as 'directory1/file2'
     assert ${lines[3]} same_as "' file3 containing space '"
-    assert ${lines[4]} same_as "\$'file4\\ncontaining\\nnewlines'"
+    assert ${lines[4]} same_as "'file4'$'\\n''containing'$'\\n''newlines'"
     assert ${lines[5]} same_as "' file5 containing space '"
-    assert ${lines[6]} same_as "\$'directory2/file6\\ncontaining\\nnewlines'"
+    assert ${lines[6]} same_as "'directory2/file6'$'\\n''containing'$'\\n''newlines'"
 }
 
 @test 'Testing post: git files in tree and index' {
@@ -8225,9 +8225,9 @@
     assert ${lines[1]} same_as 'file1'
     assert ${lines[2]} same_as 'directory1/file2'
     assert ${lines[3]} same_as "' file3 containing space '"
-    assert ${lines[4]} same_as "\$'file4\\ncontaining\\nnewlines'"
+    assert ${lines[4]} same_as "'file4'$'\\n''containing'$'\\n''newlines'"
     assert ${lines[5]} same_as "' file5 containing space '"
-    assert ${lines[6]} same_as "\$'directory2/file6\\ncontaining\\nnewlines'"
+    assert ${lines[6]} same_as "'directory2/file6'$'\\n''containing'$'\\n''newlines'"
 }
 
 @test 'Testing post: git notes' {

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -1027,13 +1027,13 @@
         assert $2 same_as 'all'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1076,13 +1076,13 @@
         assert $2 same_as 'all'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1125,13 +1125,13 @@
         assert $2 same_as 'all'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1174,13 +1174,13 @@
         assert $2 same_as 'all'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1223,13 +1223,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1272,13 +1272,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1321,13 +1321,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1370,13 +1370,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1419,13 +1419,13 @@
         assert $2 same_as 'deployments.apps,replicasets.apps,replicationcontrollers,statefulsets.apps'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1468,13 +1468,13 @@
         assert $2 same_as 'deployments.apps,replicasets.apps,replicationcontrollers,statefulsets.apps'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1517,13 +1517,13 @@
         assert $2 same_as 'deployments.apps,replicasets.apps,replicationcontrollers,statefulsets.apps'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1566,13 +1566,13 @@
         assert $2 same_as 'deployments.apps,replicasets.apps,replicationcontrollers,statefulsets.apps'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1901,13 +1901,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1950,13 +1950,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -1999,13 +1999,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -2048,13 +2048,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -2459,13 +2459,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -2508,13 +2508,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -2557,13 +2557,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -2606,13 +2606,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -3795,13 +3795,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -3844,13 +3844,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -3893,13 +3893,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -3942,13 +3942,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9460,11 +9460,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9507,11 +9507,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9554,11 +9554,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9601,11 +9601,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9688,11 +9688,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9735,11 +9735,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9782,11 +9782,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9829,11 +9829,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9916,11 +9916,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -9963,11 +9963,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10010,11 +10010,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10057,11 +10057,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10670,13 +10670,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10719,13 +10719,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10768,13 +10768,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -10817,13 +10817,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -11230,13 +11230,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -11279,13 +11279,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -11328,13 +11328,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -11377,13 +11377,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12056,13 +12056,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12105,13 +12105,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12156,13 +12156,13 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12249,12 +12249,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12297,12 +12297,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12345,12 +12345,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12390,12 +12390,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12435,12 +12435,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12481,12 +12481,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12527,12 +12527,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12573,12 +12573,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12619,12 +12619,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12665,12 +12665,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12710,13 +12710,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12759,13 +12759,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12810,13 +12810,13 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12903,12 +12903,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12951,12 +12951,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -12999,12 +12999,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13044,12 +13044,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13089,12 +13089,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13135,12 +13135,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13181,12 +13181,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13227,12 +13227,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13273,12 +13273,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13319,12 +13319,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13364,13 +13364,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13413,13 +13413,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13464,13 +13464,13 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
         echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13557,12 +13557,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13605,12 +13605,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13653,12 +13653,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13698,12 +13698,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13743,12 +13743,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13789,12 +13789,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13835,12 +13835,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13881,12 +13881,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13927,12 +13927,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -13973,12 +13973,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14018,13 +14018,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14067,13 +14067,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14118,13 +14118,13 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
         echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14211,12 +14211,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14259,12 +14259,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14307,12 +14307,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14352,12 +14352,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14397,12 +14397,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14443,12 +14443,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14489,12 +14489,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14535,12 +14535,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14581,12 +14581,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14627,12 +14627,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--selector=tier=control-plane,component'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14779,13 +14779,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14826,12 +14826,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14871,12 +14871,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14915,13 +14915,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -14962,12 +14962,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15007,12 +15007,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15051,13 +15051,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15098,12 +15098,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15143,12 +15143,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15187,13 +15187,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15234,12 +15234,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15279,12 +15279,12 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--label-columns=tier'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $6 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15533,14 +15533,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15604,14 +15604,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15677,14 +15677,14 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15749,14 +15749,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15821,14 +15821,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15871,14 +15871,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15921,14 +15921,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -15971,14 +15971,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16021,14 +16021,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16071,14 +16071,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16121,13 +16121,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16188,13 +16188,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16255,13 +16255,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16303,13 +16303,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16351,13 +16351,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16399,13 +16399,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16447,13 +16447,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16495,13 +16495,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16542,14 +16542,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16613,14 +16613,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--namespace=kube-system'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16686,14 +16686,14 @@
         assert $3 same_as '--namespace'
         assert $4 same_as ''
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16758,14 +16758,14 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*]}'
+        assert $5 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16830,14 +16830,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16880,14 +16880,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16930,14 +16930,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -16980,14 +16980,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17030,14 +17030,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17080,14 +17080,14 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector='
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-0000000000-00000","namespace":"default"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.1","podIPs":[{"ip":"10.0.0.1"},{"ip":"fd00::1"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17130,13 +17130,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17197,13 +17197,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17264,13 +17264,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17312,13 +17312,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17360,13 +17360,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17408,13 +17408,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17456,13 +17456,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17504,13 +17504,13 @@
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '--field-selector=metadata.namespace=kube-system'
         assert $5 same_as '-o'
-        assert $6 same_as 'jsonpath={.items[*]}'
+        assert $6 same_as 'jsonpath={range .items[*]}{@}{"\\n"}{end}'
 
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
-        echo -n '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"etcd-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.2","podIPs":[{"ip":"10.0.0.2"},{"ip":"fd00::2"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-apiserver-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.3","podIPs":[{"ip":"10.0.0.3"},{"ip":"fd00::3"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-controller-manager-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.4","podIPs":[{"ip":"10.0.0.4"},{"ip":"fd00::4"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-proxy-00000","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.5","podIPs":[{"ip":"10.0.0.5"},{"ip":"fd00::5"}]}}'
+        echo '{"apiVersion":"v1","kind":"Pod","metadata":{"name":"kube-scheduler-minikube","namespace":"kube-system"},"spec":{"nodeName":"minikube","restartPolicy":"Always","schedulerName":"default-scheduler","serviceAccountName":"default"},"status":{"phase":"Running","podIP":"10.0.0.6","podIPs":[{"ip":"10.0.0.6"},{"ip":"fd00::6"}]}}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17906,13 +17906,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -17955,13 +17955,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18004,13 +18004,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18053,13 +18053,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18104,7 +18104,7 @@
         assert $4 same_as '-o'
         assert $5 same_as 'jsonpath={.metadata.labels}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18393,7 +18393,7 @@
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.metadata.labels}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18437,7 +18437,7 @@
         assert $6 same_as '-o'
         assert $7 same_as 'jsonpath={.metadata.labels}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18480,7 +18480,7 @@
         assert $5 same_as '-o'
         assert $6 same_as 'jsonpath={.metadata.labels}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18524,7 +18524,7 @@
         assert $6 same_as '-o'
         assert $7 same_as 'jsonpath={.metadata.labels}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18718,13 +18718,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18767,13 +18767,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18816,13 +18816,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -18865,13 +18865,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22215,13 +22215,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22264,13 +22264,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22313,13 +22313,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22362,13 +22362,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22769,13 +22769,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22818,13 +22818,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22867,13 +22867,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -22916,13 +22916,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -23652,13 +23652,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -23701,13 +23701,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -23750,13 +23750,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -23799,13 +23799,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24206,13 +24206,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24255,13 +24255,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24304,13 +24304,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24353,13 +24353,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24634,11 +24634,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24681,11 +24681,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24728,11 +24728,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24775,11 +24775,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24862,11 +24862,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24909,11 +24909,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -24956,11 +24956,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25003,11 +25003,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25159,11 +25159,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25206,11 +25206,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25253,11 +25253,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25300,11 +25300,11 @@
         assert $2 same_as 'nodes'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
-        echo -n '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node01","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node02","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
+        echo '{"kubernetes.io/arch":"amd64","kubernetes.io/hostname":"node03","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25397,13 +25397,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25446,13 +25446,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25495,13 +25495,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {
@@ -25544,13 +25544,13 @@
         assert $2 same_as 'pods'
         assert $3 same_as '--all-namespaces'
         assert $4 same_as '-o'
-        assert $5 same_as 'jsonpath={.items[*].metadata.labels}'
+        assert $5 same_as 'jsonpath={range .items[*]}{.metadata.labels}{"\\n"}{end}'
 
-        echo -n '{"component":"etcd","tier":"control-plane"}'
-        echo -n '{"component":"kube-apiserver","tier":"control-plane"}'
-        echo -n '{"component":"kube-controller-manager","tier":"control-plane"}'
-        echo -n '{"k8s-app":"kube-proxy"}'
-        echo -n '{"component":"kube-scheduler","tier":"control-plane"}'
+        echo '{"component":"etcd","tier":"control-plane"}'
+        echo '{"component":"kube-apiserver","tier":"control-plane"}'
+        echo '{"component":"kube-controller-manager","tier":"control-plane"}'
+        echo '{"k8s-app":"kube-proxy"}'
+        echo '{"component":"kube-scheduler","tier":"control-plane"}'
     }
 
     __fzf_extract_command_mock_1() {

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -26107,7 +26107,7 @@
     assert $state equals 0
     assert ${#lines} equals 2
     assert ${lines[1]} same_as "cni.projectcalico.org/podIP=10.0.0.1/32"
-    assert ${lines[2]} same_as "note=\$'line\\nbreaks'"
+    assert ${lines[2]} same_as "note='line'$'\\n''breaks'"
 }
 
 @test 'Testing post: a label name' {


### PR DESCRIPTION
This PR closes #234 by making some modifications to support older versions of git, jq, mawk, and zsh.

| Dependency | Minimum Version | Reason |
|:---|:---|:---|
| fzf | 0.21.1 | `_fzf_complete` correctly iterates through args from this version |
| zsh | 5.1 | The builtins like `local` handle assignments to an array from this version |
| jq | 1.5 | regexp support was added in this version |
| awk | - | - |
| docker | - | - |
| git | 2.7.1 | `git for-each-ref --format` accepts `%(refname:strip=<N>)` from this version |
| node | 5.0.0 | `fs.readFile*()` accepts a file descriptor from this version |
| php | 5.2.0 | `json_decode()` was added in this version |

Tested with zsh 5.1 on Debian 10 "buster":

```
$ docker run --rm -it -v .:/fzf-zsh-completions zshusers/zsh:5.1
f9241ad9f890# apt-get -y update && \
    apt-get -y install git jq ncurses-bin nodejs npm php && \
    npm install -g yarn
f9241ad9f890# cd /fzf-zsh-completions
f9241ad9f890# tests/test.zsh --tap tests/*.zunit
f9241ad9f890# echo $?
0
```

```
f9241ad9f890# zsh --version                                             
zsh 5.1 (x86_64-unknown-linux-gnu) 

f9241ad9f890# awk -W version 2>&1 | head -n 1
mawk 1.3.3 Nov 1996, Copyright (C) Michael D. Brennan

f9241ad9f890# jq --version
jq-1.5-1-a5b5cbe

f9241ad9f890# git --version
git version 2.20.1

f9241ad9f890# php --version | head -n 1
PHP 7.3.31-1~deb10u4 (cli) (built: Jun 19 2023 19:10:11) ( NTS )

f9241ad9f890# node --version
v10.24.0

f9241ad9f890# yarn --version
1.22.19
```