### PR TITLE
Run unit tests on Ubuntu 16.04 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   - push
 
 jobs:
-  build:
+  test:
     name: Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,33 +31,50 @@ jobs:
           sudo update-alternatives --set awk /usr/bin/${{ matrix.awk }}
       - name: Show versions
         run: |
-          echo ::group::zsh
-          zsh --version
-          echo ::endgroup::
-
-          echo ::group::jq
-          jq --version
-          echo ::endgroup::
-
-          echo ::group::awk
-          awk --version 2> /dev/null || awk -W version
-          echo ::endgroup::
-
-          echo ::group::git
-          git --version
-          echo ::endgroup::
-
-          echo ::group::node
-          node --version
-          echo ::endgroup::
-
-          echo ::group::yarn
-          yarn --version
-          echo ::endgroup::
-
-          echo ::group::php
-          php --version
-          echo ::endgroup::
+          tests/versions.zsh
       - name: Run unit tests
         run: |
-          tests/test.zsh --tap --time-limit=30 tests/*.zunit
+          tests/test.zsh --tap --time-limit 30 tests/*.zunit
+  test-container:
+    name: Unit Tests (Container)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ubuntu-16.04
+            awk: gawk
+          - image: ubuntu-16.04
+            awk: mawk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          context: tests/_dockerfiles/${{ matrix.image }}
+          load: true
+          build-args: |
+            AWK=${{ matrix.awk }}
+      - name: Show versions
+        run: |
+          docker run \
+            --rm \
+            --env=GITHUB_ACTIONS \
+            --mount=type=bind,source=$(pwd),destination=/fzf-zsh-completions \
+            --workdir=/fzf-zsh-completions \
+            '${{ steps.build.outputs.imageid }}' \
+            tests/versions.zsh
+      - name: Run unit tests
+        run: |
+          docker run \
+            --rm \
+            --mount=type=bind,source=$(pwd),destination=/fzf-zsh-completions \
+            --workdir=/fzf-zsh-completions \
+            '${{ steps.build.outputs.imageid }}' \
+            tests/test.zsh --tap --time-limit 30 tests/*.zunit

--- a/tests/_dockerfiles/ubuntu-16.04/Dockerfile
+++ b/tests/_dockerfiles/ubuntu-16.04/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:16.04
+ARG AWK
+ARG NODE_VERSION=16
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
+    apt-get -y install \
+        --no-install-recommends \
+        ca-certificates \
+        curl \
+        gawk \
+        git \
+        jq \
+        php \
+        zsh && \
+    update-alternatives --set awk "/usr/bin/$AWK" && \
+    curl -fsSL "https://deb.nodesource.com/setup_$NODE_VERSION.x" | bash - && \
+    curl -fsSL 'https://dl.yarnpkg.com/debian/pubkey.gpg' | gpg --dearmor > /usr/share/keyrings/yarnkey.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main' > /etc/apt/sources.list.d/yarn.list && \
+    apt-get -y update && \
+    apt-get -y install \
+        --no-install-recommends \
+        nodejs \
+        yarn && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/tests/versions.zsh
+++ b/tests/versions.zsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+
+group() {
+    local name=$1
+    shift
+
+    [[ $GITHUB_ACTIONS = true ]] && echo ::group::$name || echo "=== $name ==="
+
+    cat -- "$@"
+
+    [[ $GITHUB_ACTIONS = true ]] && echo ::endgroup:: || echo
+}
+
+group zsh <(zsh --version)
+group jq <(jq --version)
+group awk <(awk --version 2> /dev/null || awk -W version)
+group git <(git --version)
+group node <(node --version)
+group yarn <(yarn --version)
+group php <(php --version)


### PR DESCRIPTION
This is a follow up for #235 in an attempt to prevent any future breakage from happening. This PR creates a container image that currently contains the following packages:

| Package | Version |
|:---|:---|
| zsh | 5.1.1-1ubuntu2.3 |
| jq | 1.5+dfsg-1ubuntu0.1 |
| mawk | 1.3.3-17ubuntu2 |
| gawk | 1:4.1.3+dfsg-0.1 |
| git | 1:2.7.4-0ubuntu1.10 |
| nodejs | 16.19.1-deb-1nodesource1 |
| yarn | 1.22.19-1 |
| php7.0 | 7.0.33-0ubuntu0.16.04.16 |

> **Note**  
> The latest nodejs from xenial is 4.2.6~dfsg-1ubuntu4.2, which is not supported. In order to run yarn 1.22.19, Node.js has to be at least v6.x.