### PR TITLE
Move parser for global options and subcommand to core/

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -130,7 +130,7 @@ _fzf_complete_kubectl() {
         --warnings-as-errors
     )
 
-    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_kubectl_parse_global_options_and_subcommand "${(F)kubectl_options_argument_optional}" "${arguments[@]}")"}[@]}")
+    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_parse_global_options_and_subcommand "${(F)kubectl_options_argument_optional}" "${arguments[@]}")"}[@]}")
     subcommands=("${options_and_subcommand[-1]}")
     arguments=(
         "${arguments[1,1][@]}"
@@ -1578,47 +1578,5 @@ _fzf_complete_kubectl_parse_kubectl_arguments() {
 
     if inherit_values=$(_fzf_complete_parse_option_arguments "$shorts" "$longs" "${(F)kubectl_options_argument_required}" 'option argument' "${(Q)${(z)RBUFFER}[@]}"); then
         kubectl_arguments+=("${(Q)${(z)inherit_values}[@]}")
-    fi
-}
-
-_fzf_complete_kubectl_parse_global_options_and_subcommand() {
-    local options_argument_optional=(${(z)1})
-    shift
-
-    local i parsing_argument parsing_subcommand
-    local command_arguments=()
-    local start_index=2
-    local arguments=("$@")
-
-    for i in {$start_index..${#arguments}}; do
-        if [[ -n $parsing_argument ]]; then
-            parsing_argument=
-            command_arguments+=("${arguments[$i]}")
-            continue
-        fi
-
-        if [[ ${arguments[$i]} = -[A-Za-z0-9] ]] || [[ ${arguments[$i]} = --[A-Za-z0-9-](#c1,) ]]; then
-            if [[ ${options_argument_optional[(r)$arguments[$i]]} = ${arguments[$i]} ]]; then
-                parsing_argument=
-            else
-                parsing_argument=1
-            fi
-            command_arguments+=("${arguments[$i]}")
-            continue
-        fi
-
-        if [[ ${arguments[$i]} = -(#c1,2)* ]]; then
-            parsing_argument=
-            command_arguments+=("${arguments[$i]}")
-            continue
-        fi
-
-        parsing_subcommand=1
-        command_arguments+=("${arguments[$i]}")
-        break
-    done
-
-    if [[ -n $parsing_subcommand ]]; then
-        echo ${(q)command_arguments}
     fi
 }

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -263,3 +263,45 @@ _fzf_complete_parse_option_arguments() {
 
     echo - ${(q)result}
 }
+
+_fzf_complete_parse_global_options_and_subcommand() {
+    local options_argument_optional=(${(z)1})
+    shift
+
+    local i parsing_argument parsing_subcommand
+    local command_arguments=()
+    local start_index=2
+    local arguments=("$@")
+
+    for i in {$start_index..${#arguments}}; do
+        if [[ -n $parsing_argument ]]; then
+            parsing_argument=
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        if [[ ${arguments[$i]} = -[A-Za-z0-9] ]] || [[ ${arguments[$i]} = --[A-Za-z0-9-](#c1,) ]]; then
+            if [[ ${options_argument_optional[(r)$arguments[$i]]} = ${arguments[$i]} ]]; then
+                parsing_argument=
+            else
+                parsing_argument=1
+            fi
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        if [[ ${arguments[$i]} = -(#c1,2)* ]]; then
+            parsing_argument=
+            command_arguments+=("${arguments[$i]}")
+            continue
+        fi
+
+        parsing_subcommand=1
+        command_arguments+=("${arguments[$i]}")
+        break
+    done
+
+    if [[ -n $parsing_subcommand ]]; then
+        echo ${(q)command_arguments}
+    fi
+}


### PR DESCRIPTION
This PR moves the parser to core/ which is used in kubectl completions that extracts global options and subcommand from the command string.