### PR TITLE
Fix global short option `-n`, `-E`, and `-e` after subcommand to be properly parsed

### DIFF
--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -302,6 +302,6 @@ _fzf_complete_parse_global_options_and_subcommand() {
     done
 
     if [[ -n $parsing_subcommand ]]; then
-        echo ${(q)command_arguments}
+        echo - ${(q)command_arguments}
     fi
 }


### PR DESCRIPTION
```zsh
echo -n seitai get # => seitai get
echo - -n seitai get # => -n seitai get
```