### PR TITLE
Fix a bug where global options were not inherited when subcommand was missing

### DIFF
--- a/src/completers/kubectl.zsh
+++ b/src/completers/kubectl.zsh
@@ -130,17 +130,18 @@ _fzf_complete_kubectl() {
         --warnings-as-errors
     )
 
-    options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_parse_global_options_and_subcommand "${(F)kubectl_options_argument_optional}" "${arguments[@]}")"}[@]}")
-    subcommands=("${options_and_subcommand[-1]}")
-    arguments=(
-        "${arguments[1,1][@]}"
-        "${subcommands[1,1][@]}"
-        "${options_and_subcommand[1,-2][@]}"
-        "${arguments[${#options_and_subcommand}+2,-1][@]}"
-    )
+    if options_and_subcommand=("${(Q)${(z)"$(_fzf_complete_parse_global_options_and_subcommand "${(F)kubectl_options_argument_optional}" "${arguments[@]}")"}[@]}"); then
+        subcommands=("${options_and_subcommand[-1]}")
+        arguments=(
+            "${arguments[1,1][@]}"
+            "${subcommands[1,1][@]}"
+            "${options_and_subcommand[1,-2][@]}"
+            "${arguments[${#options_and_subcommand}+2,-1][@]}"
+        )
 
-    if (( $+functions[_fzf_complete_kubectl_${subcommands[1]}] )) && _fzf_complete_kubectl_${subcommands[1]} "$@"; then
-        return
+        if (( $+functions[_fzf_complete_kubectl_${subcommands[1]}] )) && _fzf_complete_kubectl_${subcommands[1]} "$@"; then
+            return
+        fi
     fi
 
     if [[ ${subcommands[1]} = (apply|auth|certificate|config|create|rollout|set) ]]; then

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -301,7 +301,6 @@ _fzf_complete_parse_global_options_and_subcommand() {
         break
     done
 
-    if [[ -n $parsing_subcommand ]]; then
-        echo - ${(q)command_arguments}
-    fi
+    echo - ${(q)command_arguments}
+    [[ -n $parsing_subcommand ]]
 }

--- a/tests/kubectl.zunit
+++ b/tests/kubectl.zunit
@@ -1016,6 +1016,90 @@
     _fzf_complete_kubectl 'kubectl -oyaml get '
 }
 
+@test 'Testing completion: kubectl --context=kubeadm --namespace=**' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--context=kubeadm'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --context=kubeadm '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --context=kubeadm --namespace='
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=--namespace=
+    _fzf_complete_kubectl 'kubectl --context=kubeadm '
+}
+
+@test 'Testing completion: kubectl --context=kubeadm --namespace **' {
+    kubectl_mock_1() {
+        assert $# equals 5
+        assert $1 same_as 'get'
+        assert $2 same_as 'namespaces'
+        assert $3 same_as '-o'
+        assert $4 same_as 'wide'
+        assert $5 same_as '--context=kubeadm'
+
+        echo 'NAME          STATUS   AGE'
+        echo 'default       Active   1d'
+        echo 'kube-system   Active   1d'
+    }
+
+    __fzf_extract_command_mock_1() {
+        assert $# equals 1
+        assert $1 same_as 'kubectl --context=kubeadm --namespace '
+
+        echo 'kubectl'
+    }
+
+    _fzf_complete() {
+        assert $# equals 5
+        assert $1 same_as '--ansi'
+        assert $2 same_as '--tiebreak=index'
+        assert $3 same_as '--header-lines=1'
+        assert $4 same_as '--'
+        assert $5 same_as 'kubectl --context=kubeadm --namespace '
+
+        run cat
+        assert __fzf_extract_command mock_times 1
+        assert kubectl mock_times 1
+        assert ${#lines} equals 3
+        assert ${lines[1]} same_as "${fg[yellow]}NAME          ${reset_color}STATUS   AGE"
+        assert ${lines[2]} same_as "${fg[yellow]}default       ${reset_color}Active   1d"
+        assert ${lines[3]} same_as "${fg[yellow]}kube-system   ${reset_color}Active   1d"
+    }
+
+    prefix=
+    _fzf_complete_kubectl 'kubectl --context=kubeadm --namespace '
+}
+
 @test 'Testing completion: kubectl --context=kubeadm get pods **' {
     kubectl_mock_1() {
         assert $# equals 4


### PR DESCRIPTION
When completing an option for kubectl, it did not previously inherit global options if subcommand is not input:
```
$ kubectl --context=foo --namespace=**<TAB>
          ^^^^^^^^^^^^^
             ignored
```

```
$ kubectl --context=foo get --namespace=**<TAB>
          ^^^^^^^^^^^^^
            inherited
```

This PR fixes the global options parser to always print global options and whether the subcommand is present. The kubectl completer checks its return value and parses subcommand only if the parser detects any subcommand.