### PR TITLE
fix(make): exclude makefile variable from completion and handle multiple targets in a rule

### DIFF
--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -13,5 +13,5 @@ _fzf_complete_make-target() {
     # 2. multiple targets on a line `bigoutput   littleoutput  median : `
     # 3. proper exclude variable assigment `var := `
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i=1; i<=length(arr); i++) print arr[i] }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile 2> /dev/null | uniq | awk -F ':' '{ n = split($1, arr, " "); for (i=1; i<=n; i++) print arr[i] }')
 }

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -9,5 +9,5 @@ _fzf_complete_make-target() {
     local fzf_options=$1
     shift
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^[a-zA-Z_-]+:.*?$$' Makefile 2> /dev/null | uniq | awk -F ':' '{ print $1 }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -P '^[a-zA-Z_-]+:(?!=).*?$$' Makefile 2> /dev/null | uniq | awk -F ':' '{ print $1 }')
 }

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -13,5 +13,5 @@ _fzf_complete_make-target() {
     # 2. multiple targets on a line `bigoutput   littleoutput  median : `
     # 3. proper exclude variable assigment `var := `
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile | 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i in arr) print arr[i] }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i in arr) print arr[i] }')
 }

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -8,6 +8,10 @@ _fzf_complete_make() {
 _fzf_complete_make-target() {
     local fzf_options=$1
     shift
+    # handles target matching
+    # 1. single target like `single_target:`
+    # 2. multiple targets on a line `bigoutput   littleoutput  median : `
+    # 3. proper exclude variable assigment `var := `
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -P '^[a-zA-Z_-]+:(?!=).*?$$' Makefile 2> /dev/null | uniq | awk -F ':' '{ print $1 }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile | 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i in arr) print arr[i] }')
 }

--- a/src/completers/make.zsh
+++ b/src/completers/make.zsh
@@ -13,5 +13,5 @@ _fzf_complete_make-target() {
     # 2. multiple targets on a line `bigoutput   littleoutput  median : `
     # 3. proper exclude variable assigment `var := `
 
-    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i in arr) print arr[i] }')
+    _fzf_complete --ansi --tiebreak=index ${(Q)${(Z+n+)fzf_options}} -- "$@" < <(grep -E '^(([a-zA-Z_-]+)\s*?)*:([^=]|$).*?$' Makefile 2> /dev/null | uniq | awk -F ':' '{ split($1, arr, " "); for (i=1; i<=length(arr); i++) print arr[i] }')
 }

--- a/tests/_support/make/Makefile
+++ b/tests/_support/make/Makefile
@@ -2,3 +2,6 @@ aoi:
 	echo 'Yeah, Akane-chang is very cute'
 akane:
 	echo 'Yeah, Aoi-chang is very cute'
+sayuri chitori :
+	echo Yeah, $@-chang is very cute
+chika := 'chika-chang is very cute'

--- a/tests/make.zunit
+++ b/tests/make.zunit
@@ -25,8 +25,8 @@
         assert ${#lines} equals 4
         assert ${lines[1]} same_as 'aoi'
         assert ${lines[2]} same_as 'akane'
-        assert ${lines[3]} same_as 'chitori'
-        assert ${lines[4]} same_as 'sayuri'
+        assert ${lines[3]} same_as 'sayuri'
+        assert ${lines[4]} same_as 'chitori'
     }
 
     prefix=
@@ -45,8 +45,8 @@
         assert ${#lines} equals 4
         assert ${lines[1]} same_as 'aoi'
         assert ${lines[2]} same_as 'akane'
-        assert ${lines[3]} same_as 'chitori'
-        assert ${lines[4]} same_as 'sayuri'
+        assert ${lines[3]} same_as 'sayuri'
+        assert ${lines[4]} same_as 'chitori'
     }
 
     prefix=

--- a/tests/make.zunit
+++ b/tests/make.zunit
@@ -22,9 +22,11 @@
         assert $4 same_as 'make '
 
         run cat
-        assert ${#lines} equals 2
+        assert ${#lines} equals 4
         assert ${lines[1]} same_as 'aoi'
         assert ${lines[2]} same_as 'akane'
+        assert ${lines[3]} same_as 'chitori'
+        assert ${lines[4]} same_as 'sayuri'
     }
 
     prefix=
@@ -40,9 +42,11 @@
         assert $4 same_as 'make '
 
         run cat
-        assert ${#lines} equals 2
+        assert ${#lines} equals 4
         assert ${lines[1]} same_as 'aoi'
         assert ${lines[2]} same_as 'akane'
+        assert ${lines[3]} same_as 'chitori'
+        assert ${lines[4]} same_as 'sayuri'
     }
 
     prefix=


### PR DESCRIPTION
https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html

Makefile variables can be defined as

```makefile
red:=$(shell echo -e "\033[0;31m")
```

this change uses negative lookahead to exclude `:=` patterns

also added support for multi-target case

https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html

```makefile
bigoutput littleoutput : text.g
        generate text.g -$(subst output,,$@) > $@
```