### PR TITLE
Fix issue where error is shown in fzf v0.56.1 or later

### DIFF
--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,14 +1,8 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_get_command_pos() {
-    local cmd
     local arguments=("${(Q)${(z)@}[@]}")
-
-    if [[ -n $cmd_word ]]; then
-        cmd=$cmd_word
-    else
-        cmd=$(__fzf_extract_command "$@")
-    fi
+    local cmd=${cmd_word-$(__fzf_extract_command "$@")}
 
     echo ${arguments[(i)$cmd]}
 }

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -1,8 +1,15 @@
 #!/usr/bin/env zsh
 
 _fzf_complete_get_command_pos() {
+    local cmd
     local arguments=("${(Q)${(z)@}[@]}")
-    local cmd=$(__fzf_extract_command "$@")
+
+    if [[ "$(which __fzf_extract_command)" == *compstate* ]]; then
+        cmd=$cmd_word
+    else
+        cmd=$(__fzf_extract_command "$@")
+    fi
+
     echo ${arguments[(i)$cmd]}
 }
 

--- a/src/core/parser.zsh
+++ b/src/core/parser.zsh
@@ -4,7 +4,7 @@ _fzf_complete_get_command_pos() {
     local cmd
     local arguments=("${(Q)${(z)@}[@]}")
 
-    if [[ "$(which __fzf_extract_command)" == *compstate* ]]; then
+    if [[ -n $cmd_word ]]; then
         cmd=$cmd_word
     else
         cmd=$(__fzf_extract_command "$@")


### PR DESCRIPTION
After fzf v0.56.1, in all situations, shown completions are paths, and the following error is displayed.

```
__fzf_extract_command:3: compstate: assignment to invalid subscript range
```

`_fzf_extract_command` has been rewritten and is no longer directly called, which is the cause of this issue. This PR replaces it with the global `$cmd_word` according to the change of fzf.

ref: https://github.com/junegunn/fzf/commit/57c08d925f050bb955028992a6435c4341e1056a
